### PR TITLE
feat(test-performance): optimize 10x unit test execution time

### DIFF
--- a/quantmind/config/storage.py
+++ b/quantmind/config/storage.py
@@ -12,6 +12,10 @@ class BaseStorageConfig(BaseModel):
         default=Path("./data"), description="Base storage directory"
     )
 
+    download_timeout: int = Field(
+        default=30, description="Timeout in seconds for downloading files"
+    )
+
 
 class LocalStorageConfig(BaseStorageConfig):
     """Configuration for local file-based storage."""

--- a/quantmind/storage/base.py
+++ b/quantmind/storage/base.py
@@ -164,19 +164,29 @@ class BaseStorage(ABC):
                     f"Failed to download PDF for {paper.get_primary_id()}: {e}"
                 )
 
-    def _download_file_content(self, url: str) -> Optional[bytes]:
+    def _download_file_content(
+        self, url: str, timeout: Optional[int] = None
+    ) -> Optional[bytes]:
         """Download file content from URL.
 
         Args:
             url: URL to download from
+            timeout: Timeout in seconds (uses config if None)
 
         Returns:
             File content as bytes or None if failed
         """
+        # Use config timeout if not provided
+        if timeout is None:
+            timeout = getattr(self, "config", None)
+            timeout = (
+                getattr(timeout, "download_timeout", 30) if timeout else 30
+            )
+
         try:
             import requests
 
-            response = requests.get(url, timeout=30)
+            response = requests.get(url, timeout=timeout)
             response.raise_for_status()
             return response.content
         except Exception:

--- a/scripts/unittest.sh
+++ b/scripts/unittest.sh
@@ -3,6 +3,10 @@
 # If the input is all, run all tests.
 if [ "$1" == "all" ]; then
     pytest tests
+elif [ "$1" == "report" ]; then
+    # Show the 20 slowest tests to identify performance bottlenecks.
+    # Also reports the total execution time of the test suite.
+    time pytest --durations=20 tests
 elif [ -n "$1" ]; then
     # If the input file exists, test the input file.
     pytest $1

--- a/tests/config/test_embedding.py
+++ b/tests/config/test_embedding.py
@@ -31,7 +31,7 @@ class TestEmbeddingConfig(unittest.TestCase):
             user="test_user_123",
             dimensions=512,
             encoding_format="base64",
-            timeout=30,
+            timeout=1,
             api_key="test-key",
             api_base="https://api.example.com",
             api_version="2023-05-15",
@@ -42,7 +42,7 @@ class TestEmbeddingConfig(unittest.TestCase):
         self.assertEqual(config.user, "test_user_123")
         self.assertEqual(config.dimensions, 512)
         self.assertEqual(config.encoding_format, "base64")
-        self.assertEqual(config.timeout, 30)
+        self.assertEqual(config.timeout, 1)
         self.assertEqual(config.api_key, "test-key")
         self.assertEqual(config.api_base, "https://api.example.com")
         self.assertEqual(config.api_version, "2023-05-15")
@@ -126,7 +126,7 @@ class TestEmbeddingConfig(unittest.TestCase):
             user="test_user",
             dimensions=512,
             encoding_format="base64",
-            timeout=30,
+            timeout=1,
             api_key="test-key",
             api_base="https://api.example.com",
             api_version="2023-05-15",
@@ -171,24 +171,24 @@ class TestEmbeddingConfig(unittest.TestCase):
         """Test creating configuration variants."""
         base_config = EmbeddingConfig(
             model="text-embedding-ada-002",
-            timeout=60,
+            timeout=1,
             api_key="base-key",
         )
 
         # Create variant with overrides
         variant = base_config.create_variant(
-            timeout=30,
+            timeout=1,
             api_key="variant-key",
             user="test_user",
         )
 
         # Original config should be unchanged
-        self.assertEqual(base_config.timeout, 60)
+        self.assertEqual(base_config.timeout, 1)
         self.assertEqual(base_config.api_key, "base-key")
         self.assertIsNone(base_config.user)
 
         # Variant should have new values
-        self.assertEqual(variant.timeout, 30)
+        self.assertEqual(variant.timeout, 1)
         self.assertEqual(variant.api_key, "variant-key")
         self.assertEqual(variant.user, "test_user")
         self.assertEqual(variant.model, "text-embedding-ada-002")  # Unchanged
@@ -197,7 +197,7 @@ class TestEmbeddingConfig(unittest.TestCase):
         """Test creating variant with no overrides."""
         base_config = EmbeddingConfig(
             model="text-embedding-ada-002",
-            timeout=60,
+            timeout=1,
         )
 
         variant = base_config.create_variant()
@@ -245,11 +245,11 @@ class TestEmbeddingConfig(unittest.TestCase):
         config = EmbeddingConfig(timeout=1)
         self.assertEqual(config.timeout, 1)
 
-        config = EmbeddingConfig(timeout=600)
-        self.assertEqual(config.timeout, 600)
+        config = EmbeddingConfig(timeout=1)
+        self.assertEqual(config.timeout, 1)
 
-        config = EmbeddingConfig(timeout=3600)
-        self.assertEqual(config.timeout, 3600)
+        config = EmbeddingConfig(timeout=1)
+        self.assertEqual(config.timeout, 1)
 
         # Zero and negative timeouts should be allowed (validation handled by API)
         config = EmbeddingConfig(timeout=0)

--- a/tests/llm/test_embedding_block.py
+++ b/tests/llm/test_embedding_block.py
@@ -16,7 +16,8 @@ class TestEmbeddingBlock(unittest.TestCase):
         self.config = EmbeddingConfig(
             model="text-embedding-ada-002",
             api_key="test-key",
-            timeout=30,
+            timeout=1,
+            retry_delay=0.01,
         )
 
     @patch("quantmind.llm.embedding.LITELLM_AVAILABLE", True)
@@ -28,7 +29,7 @@ class TestEmbeddingBlock(unittest.TestCase):
         self.assertEqual(block.config, self.config)
         mock_litellm.set_verbose = False
         self.assertEqual(mock_litellm.num_retries, 3)
-        self.assertEqual(mock_litellm.request_timeout, 30)
+        self.assertEqual(mock_litellm.request_timeout, 1)
 
     @patch("quantmind.llm.embedding.LITELLM_AVAILABLE", False)
     def test_init_litellm_unavailable(self):
@@ -163,7 +164,7 @@ class TestEmbeddingBlock(unittest.TestCase):
 
         self.assertEqual(result, mock_response)
         self.assertEqual(mock_embedding.call_count, 2)
-        mock_sleep.assert_called_once_with(1.0)
+        mock_sleep.assert_called_once_with(0.01)
 
     @patch("quantmind.llm.embedding.LITELLM_AVAILABLE", True)
     @patch("quantmind.llm.embedding.litellm")
@@ -271,7 +272,7 @@ class TestEmbeddingBlock(unittest.TestCase):
 
         self.assertEqual(info["model"], "text-embedding-ada-002")
         self.assertEqual(info["provider"], "openai")
-        self.assertEqual(info["timeout"], 30)
+        self.assertEqual(info["timeout"], 1)
         self.assertEqual(info["retry_attempts"], 3)
 
     @patch("quantmind.llm.embedding.LITELLM_AVAILABLE", True)
@@ -281,14 +282,14 @@ class TestEmbeddingBlock(unittest.TestCase):
         block = EmbeddingBlock(self.config)
 
         # Check initial config
-        self.assertEqual(block.config.timeout, 30)
+        self.assertEqual(block.config.timeout, 1)
         self.assertEqual(block.config.api_key, "test-key")
 
         # Update config
-        block.update_config(timeout=60, api_key="new-key")
+        block.update_config(timeout=2, api_key="new-key")
 
         # Check updated config
-        self.assertEqual(block.config.timeout, 60)
+        self.assertEqual(block.config.timeout, 2)
         self.assertEqual(block.config.api_key, "new-key")
         # Other values should remain unchanged
         self.assertEqual(block.config.model, "text-embedding-ada-002")
@@ -300,14 +301,14 @@ class TestEmbeddingBlock(unittest.TestCase):
         block = EmbeddingBlock(self.config)
 
         # Check initial config
-        self.assertEqual(block.config.timeout, 30)
+        self.assertEqual(block.config.timeout, 1)
 
         # Use temporary config
-        with block.temporary_config(timeout=60):
-            self.assertEqual(block.config.timeout, 60)
+        with block.temporary_config(timeout=2):
+            self.assertEqual(block.config.timeout, 2)
 
         # Check config is restored
-        self.assertEqual(block.config.timeout, 30)
+        self.assertEqual(block.config.timeout, 1)
 
     @patch("quantmind.llm.embedding.LITELLM_AVAILABLE", True)
     @patch("quantmind.llm.embedding.litellm")
@@ -353,8 +354,8 @@ class TestEmbeddingBlock(unittest.TestCase):
         config = EmbeddingConfig(
             model="text-embedding-ada-002",
             api_key="test-key",
-            timeout=30,
-            retry_delay=0.1,
+            timeout=1,
+            retry_delay=0.01,
         )
 
         mock_response = Mock()

--- a/tests/llm/test_llm_block.py
+++ b/tests/llm/test_llm_block.py
@@ -14,7 +14,12 @@ class TestLLMBlock(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.config = LLMConfig(
-            model="gpt-4o", temperature=0.7, max_tokens=1000, api_key="test-key"
+            model="gpt-4o",
+            temperature=0.7,
+            max_tokens=1000,
+            api_key="test-key",
+            timeout=1,
+            retry_delay=0.01,
         )
 
     @patch("quantmind.llm.block.LITELLM_AVAILABLE", True)
@@ -26,7 +31,7 @@ class TestLLMBlock(unittest.TestCase):
         self.assertEqual(block.config, self.config)
         mock_litellm.set_verbose = False
         self.assertEqual(mock_litellm.num_retries, 3)
-        self.assertEqual(mock_litellm.request_timeout, 60)
+        self.assertEqual(mock_litellm.request_timeout, 1)
 
     @patch("quantmind.llm.block.LITELLM_AVAILABLE", False)
     def test_init_litellm_unavailable(self):
@@ -210,7 +215,7 @@ class TestLLMBlock(unittest.TestCase):
 
         self.assertEqual(result, mock_response)
         self.assertEqual(mock_completion.call_count, 2)
-        mock_sleep.assert_called_once_with(1.0)
+        mock_sleep.assert_called_once_with(0.01)
 
     @patch("quantmind.llm.block.LITELLM_AVAILABLE", True)
     @patch("quantmind.llm.block.litellm")
@@ -263,7 +268,7 @@ class TestLLMBlock(unittest.TestCase):
             "provider": "openai",
             "temperature": 0.7,
             "max_tokens": 1000,
-            "timeout": 60,
+            "timeout": 1,
             "retry_attempts": 3,
         }
 


### PR DESCRIPTION
## Description

#55 

### Overview

This PR significantly reduces the execution time of the unit test suite to improve developer workflow. The optimizations focus on lowering API timeouts within test configurations and adding tools to monitor test performance.

### Key Changes

-   **Reduced Test Timeouts**: Default timeouts in test configurations for LLM, Embedding, and Storage operations have been lowered from 30-60 seconds to 1 second. This accelerates tests that verify timeout and retry logic without waiting for actual network latency.
-   **Configurable Download Timeout**: A `download_timeout` parameter has been added to the storage configuration, making file download timeouts explicitly configurable.
-   **Test Performance Reporting**: A new `report` option has been added to the `scripts/unittest.sh` script. It runs `pytest --durations=20` to help identify the slowest tests and potential performance bottlenecks in the future.

### Implementation Notes

The primary strategy was to adjust test-specific configurations to use aggressive timeouts. This allows the test suite to validate error-handling paths (like `TimeoutError`) almost instantly, rather than waiting for the full duration. Network requests in storage tests are now also mocked to prevent I/O delays and ensure test reliability.

### Performance Gains

> [!IMPORTANT]
> This optimization reduces the total test suite execution time by approximately **90%** (from ~28.5 seconds to ~2.8 seconds), resulting in a **~10x faster** feedback loop for developers.

<details>
<summary><strong>Before Optimization (~28.5s)</strong></summary>

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================== slowest 20 durations ===============================================
3.02s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_generate_embeddings_failure
3.01s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_test_connection_failure
3.01s call     tests/llm/test_llm_block.py::TestLLMBlock::test_test_connection_failure
3.01s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_generate_embedding_failure
3.01s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_batch_embed_failure
3.01s call     tests/llm/test_llm_block.py::TestLLMBlock::test_generate_text_failure
3.01s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_get_embedding_dimension_failure
1.43s call     tests/parsers/test_llama_parser.py::TestLlamaParser::test_parse_paper_parsing_error
1.13s call     tests/storage/test_local_storage.py::TestEnhancedStorageWithIndexing::test_process_knowledge_paper_with_pdf_url
1.00s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_batch_embed_success
0.02s call     tests/config/test_settings.py::TestSetting::test_load_config_yaml_file
0.01s call     tests/storage/test_local_storage.py::TestEnhancedStorageWithIndexing::test_raw_file_indexing

(8 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================== 227 passed, 19 warnings in 28.09s ========================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

real    0m28.554s
user    0m1.911s
sys     0m0.327s
```
</details>

<details>
<summary><strong>After Optimization (~2.8s)</strong></summary>

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================== slowest 20 durations ===============================================
0.04s call     tests/llm/test_llm_block.py::TestLLMBlock::test_generate_text_failure
0.04s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_get_embedding_dimension_failure
0.04s call     tests/llm/test_llm_block.py::TestLLMBlock::test_test_connection_failure
0.04s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_batch_embed_failure
0.04s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_generate_embedding_failure
0.04s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_test_connection_failure
0.04s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_generate_embeddings_failure
0.01s call     tests/llm/test_embedding_block.py::TestEmbeddingBlock::test_batch_embed_success
0.01s call     tests/config/test_settings.py::TestSetting::test_load_config_yaml_file

(11 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================== 227 passed, 19 warnings in 2.47s =========================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

real    0m2.822s
user    0m1.685s
sys     0m0.198s
```
</details>

## Checklist

Please feel free to remove inapplicable items for your PR.

- [x] The PR title starts with `$CATEGORY(xx): xxx` (such as `feat(tool): xxx`, `fix(source): xxx`, `docs(README): xxx`)
- [x] Related issue is referred in this PR
- [x] The markdown and latex are rendered correctly.
- [x] The code in PR is well-documented.
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR.
