### PR TITLE
feat: knowledge data standard + configs/ skeleton (PR3 of OpenAI Agents SDK migration)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,24 +29,26 @@ quantmind/
 Key principle: QuantMind does NOT rebuild Agent runtime, lifecycle hooks, tracing,
 multi-agent handoff, or tool framework. Those come from `openai-agents`.
 
-## Current Repository State (transitional, after PR #70 / #72)
+## Current Repository State (transitional, after PR #70 / #73 / PR3)
 
-Surviving modules — these still work but will be replaced or migrated in PR3-PR6:
+| Module | Status | Notes |
+|--------|--------|-------|
+| `quantmind/knowledge/` | landed (PR3) | output schemas: `KnowledgeItem` + `Paper` / `News` / `Earnings` |
+| `quantmind/configs/` | landed (PR3) | `BaseFlowCfg` / `BaseInput` + per-flow cfg + discriminated-union input types |
+| `quantmind/utils/logger.py` | permanent | only general-purpose utility |
+| `quantmind/flow/` | transitional | replaced by `flows/` in PR5 |
+| `quantmind/parsers/` | transitional | replaced by `preprocess/format/` in PR4 |
+| `quantmind/sources/` | transitional | replaced by `preprocess/fetch/` in PR4 |
+| `quantmind/config/` | transitional | superseded by `quantmind/configs/` (PR3); deletion when consumers (`flow/`, `llm/`) migrate in PR5 |
+| `quantmind/llm/` | transitional | deleted in PR5 (use SDK + `openai` directly) |
+| `quantmind/models/{content,paper,analysis}.py` | transitional | superseded by `quantmind/knowledge/` (PR3); deletion when consumers (`parsers/`, `sources/`, `flow/`) migrate in PR4-PR5 |
+| `quantmind/utils/tmp.py` | transitional | deleted in PR3-4 alongside the templating refactor |
 
-| Module | Status | Replacement |
-|--------|--------|-------------|
-| `quantmind/flow/` | active | `flows/` in PR5 |
-| `quantmind/parsers/` | active | `preprocess/format/` in PR4 |
-| `quantmind/sources/` | active | `preprocess/fetch/` in PR4 |
-| `quantmind/config/` | active | `configs/` in PR3 |
-| `quantmind/llm/` | active | deleted in PR5 (use SDK + `openai` directly) |
-| `quantmind/models/{content,paper,analysis}.py` | active | move to `knowledge/` in PR3 |
-| `quantmind/utils/logger.py` | active | permanent |
-| `quantmind/utils/tmp.py` | active | deleted in PR3-4 alongside the templating refactor |
-
-These transitional modules are excluded from `basedpyright` (see `pyproject.toml`)
-to keep the harness green during migration; new modules (`knowledge/`, `configs/`,
-`preprocess/`, `flows/`, `mind/`, `magic.py`) are auto-included at standard mode.
+Transitional modules are excluded from `basedpyright` (see `pyproject.toml`)
+to keep the harness green during migration. New modules (`knowledge/`,
+`configs/`, `preprocess/`, `flows/`, `mind/`, `magic.py`) are auto-included
+at standard mode and gated by additional `import-linter` contracts so they
+cannot accidentally pull in a transitional module.
 
 ## Development Commands
 
@@ -156,9 +158,9 @@ issue instead.
 | PR | Focus |
 |----|-------|
 | #70 (merged) | Clean removal of self-built agent runtime |
-| #72 (this PR) | Golden Harness — `scripts/verify.sh` with ruff + basedpyright + import-linter + pytest --cov, plus matching CI |
-| PR3 | `knowledge/` + `configs/` skeleton |
-| PR4 | `preprocess/` (fetch + format two layers) |
-| PR5 | `flows/` + `paper_flow` + `batch_run` + `magic.py`; drop old `flow/` `llm/` |
+| #73 (merged) | Golden Harness — `scripts/verify.sh` with ruff + basedpyright + import-linter + pytest --cov, plus matching CI |
+| PR3 (this PR) | `knowledge/` + `configs/` skeleton — output schemas + flow cfgs + discriminated-union inputs; `openai-agents>=0.14` introduced as a hard dep for `BaseFlowCfg.model_settings` |
+| PR4 | `preprocess/` (fetch + format two layers); migrate `parsers/` + `sources/`; delete `quantmind/models/{content,paper,analysis}.py` |
+| PR5 | `flows/` + `paper_flow` + `batch_run` + `magic.py`; delete `quantmind/flow/`, `quantmind/llm/`, `quantmind/config/` |
 | PR6 | `mind/memory/filesystem` MVP + trajectory archive |
 | PR7+ | Second flow (news/earnings) / observability cookbook / longer-term modules |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ multi-agent handoff, or tool framework. Those come from `openai-agents`.
 
 | Module | Status | Notes |
 |--------|--------|-------|
-| `quantmind/knowledge/` | landed (PR3) | output schemas: `KnowledgeItem` + `Paper` / `News` / `Earnings` |
+| `quantmind/knowledge/` | landed (PR3) | data standard with three shapes: `FlattenKnowledge` (`News` / `Earnings` / `PaperKnowledgeCard`), `TreeKnowledge` (`Paper`), `GraphKnowledge` (placeholder); shared base = `BaseKnowledge` with typed `SourceRef` / `ExtractionRef` provenance + `embedding_text()` contract |
 | `quantmind/configs/` | landed (PR3) | `BaseFlowCfg` / `BaseInput` + per-flow cfg + discriminated-union input types |
 | `quantmind/utils/logger.py` | permanent | only general-purpose utility |
 | `quantmind/flow/` | transitional | replaced by `flows/` in PR5 |
@@ -109,8 +109,14 @@ issue instead.
 
 ## Conventions When Editing
 
-- **Schemas**: Pydantic, `extra="forbid"`, `frozen=True`. All `KnowledgeItem`
+- **Schemas**: Pydantic, `extra="forbid"`, `frozen=True`. All `BaseKnowledge`
   subclasses must require `as_of: datetime` (financial time-sensitivity is mandatory)
+  and provide a typed `source: SourceRef` (no bare strings). Subclasses MUST
+  override `embedding_text()` so the store layer knows what to embed.
+- **Knowledge shapes**: pick one of `FlattenKnowledge` (atomic card),
+  `TreeKnowledge` (hierarchical artifact), or wait for `GraphKnowledge`
+  (placeholder). Whole-document objects are `TreeKnowledge` even when a
+  flatten card exists alongside (e.g. `Paper` vs `PaperKnowledgeCard`).
 - **Configs**: Extend `BaseFlowCfg` (lands in PR2); never use `Dict[str, Any]` in
   init signatures
 - **Tools**: SDK's `@function_tool` decorator; do NOT subclass anything
@@ -159,7 +165,7 @@ issue instead.
 |----|-------|
 | #70 (merged) | Clean removal of self-built agent runtime |
 | #73 (merged) | Golden Harness — `scripts/verify.sh` with ruff + basedpyright + import-linter + pytest --cov, plus matching CI |
-| PR3 (this PR) | `knowledge/` + `configs/` skeleton — output schemas + flow cfgs + discriminated-union inputs; `openai-agents>=0.14` introduced as a hard dep for `BaseFlowCfg.model_settings` |
+| PR3 (this PR) | `knowledge/` data standard (Flatten / Tree / Graph shapes) + `configs/` skeleton; `openai-agents>=0.14` introduced for `BaseFlowCfg.model_settings`. Storage layer (`mind/store/` + SQLite + `sqlite-vec`) lands separately. |
 | PR4 | `preprocess/` (fetch + format two layers); migrate `parsers/` + `sources/`; delete `quantmind/models/{content,paper,analysis}.py` |
 | PR5 | `flows/` + `paper_flow` + `batch_run` + `magic.py`; delete `quantmind/flow/`, `quantmind/llm/`, `quantmind/config/` |
 | PR6 | `mind/memory/filesystem` MVP + trajectory archive |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pyyaml",
     "numpy>=2.2.4",
     "openai>=1.68.2",
+    "openai-agents>=0.14",
     "pillow>=10.1.0,<11.0.0",
     "llama-cloud-services>=0.6.12",
     "ipykernel>=6.29.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,12 @@ pythonVersion = "3.10"
 typeCheckingMode = "standard"
 reportMissingImports = "error"
 reportMissingTypeStubs = "none"
+# Pydantic v2 discriminated unions tighten a `str` field to `Literal["..."]`
+# in subclasses (e.g. `Paper.item_type: Literal["paper"]`). Python's variance
+# rules say mutable attributes must be invariant, so basedpyright flags this
+# even though Pydantic supports it. We use this idiom throughout knowledge/
+# and configs/, so disable the diagnostic globally.
+reportIncompatibleVariableOverride = "none"
 
 # ----------------------------------------------------------------------------
 # import-linter: architectural boundary contracts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,36 @@ type = "forbidden"
 source_modules = ["quantmind.utils"]
 forbidden_modules = [
     "quantmind.config",
+    "quantmind.configs",
+    "quantmind.flow",
+    "quantmind.knowledge",
+    "quantmind.llm",
+    "quantmind.models",
+    "quantmind.parsers",
+    "quantmind.sources",
+]
+
+[[tool.importlinter.contracts]]
+name = "knowledge is a leaf (no inbound deps from quantmind packages)"
+type = "forbidden"
+source_modules = ["quantmind.knowledge"]
+forbidden_modules = [
+    "quantmind.config",
+    "quantmind.configs",
+    "quantmind.flow",
+    "quantmind.llm",
+    "quantmind.models",
+    "quantmind.parsers",
+    "quantmind.sources",
+    "quantmind.utils",
+]
+
+[[tool.importlinter.contracts]]
+name = "configs only depends on knowledge (transitional modules forbidden)"
+type = "forbidden"
+source_modules = ["quantmind.configs"]
+forbidden_modules = [
+    "quantmind.config",
     "quantmind.flow",
     "quantmind.llm",
     "quantmind.models",

--- a/quantmind/config/registry.py
+++ b/quantmind/config/registry.py
@@ -108,8 +108,16 @@ class FlowConfigRegistry:
 
     def _discover_flows_in_path(self, path: Path) -> None:
         """Discover flows in a specific path."""
-        # Look for flow.py files in subdirectories
-        for flow_file in path.rglob("flow.py"):
+        # Look for flow.py files in subdirectories.
+        # `rglob` on macOS tmpdirs can hit AppTranslocation paths that raise
+        # OSError mid-iteration; swallow scan errors so registry probing never
+        # crashes the caller.
+        try:
+            flow_files = list(path.rglob("flow.py"))
+        except OSError as e:
+            logger.warning(f"Failed to scan {path} for flows: {e}")
+            return
+        for flow_file in flow_files:
             try:
                 self._load_flow_from_file(flow_file)
             except Exception as e:

--- a/quantmind/configs/__init__.py
+++ b/quantmind/configs/__init__.py
@@ -1,0 +1,25 @@
+"""quantmind.configs — flow configuration + input types.
+
+Each flow has a `<Name>FlowCfg` (extends `BaseFlowCfg`) and a `<Name>Input`
+discriminated-union type. All cfg / input classes live here so that:
+
+  - YAML / CLI users see a single import surface,
+  - JSON schemas can be exported uniformly (for IDE autocomplete),
+  - the magic-input resolver (PR5) has one introspection target.
+"""
+
+from quantmind.configs.base import BaseFlowCfg, BaseInput
+from quantmind.configs.earnings import EarningsFlowCfg, EarningsInput
+from quantmind.configs.news import NewsFlowCfg, NewsInput
+from quantmind.configs.paper import PaperFlowCfg, PaperInput
+
+__all__ = [
+    "BaseFlowCfg",
+    "BaseInput",
+    "EarningsFlowCfg",
+    "EarningsInput",
+    "NewsFlowCfg",
+    "NewsInput",
+    "PaperFlowCfg",
+    "PaperInput",
+]

--- a/quantmind/configs/base.py
+++ b/quantmind/configs/base.py
@@ -1,0 +1,49 @@
+"""Base flow-cfg + input types shared across all flows.
+
+`BaseFlowCfg` is the data contract for everything a flow exposes to YAML / CLI
+users. Each `<Name>FlowCfg` subclasses it and adds domain knobs; nothing here
+encodes flow behaviour. `BaseInput` is the parent of every flow's input
+discriminated-union member; subclasses set a `Literal` discriminator field.
+"""
+
+from agents import ModelSettings
+from pydantic import BaseModel, ConfigDict
+
+
+class BaseFlowCfg(BaseModel):
+    """Base configuration shared by all flows."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Model & execution
+    model: str = "gpt-4o"
+    model_settings: ModelSettings | None = None
+    max_turns: int = 10
+    timeout_seconds: float = 300.0
+
+    # Output persistence
+    output_dir: str | None = None
+    overwrite: bool = False
+
+    # Mind / memory (filesystem-backed when set)
+    memory_dir: str | None = None
+
+    # Observability (consumed by flows/_runner in PR5)
+    workflow_name: str | None = None
+    trace_metadata: dict[str, str] | None = None
+    trace_include_sensitive_data: bool = True
+    tracing_disabled: bool = False
+    archive_trajectory: bool = True
+
+    # Cost / budget guardrails (enforced in PR5+)
+    max_total_input_tokens: int | None = None
+    max_total_cost_usd: float | None = None
+
+    # Default guardrails (populated in PR8+)
+    enable_default_guardrails: bool = True
+
+
+class BaseInput(BaseModel):
+    """Parent of every flow's discriminated-union input member."""
+
+    model_config = ConfigDict(extra="forbid")

--- a/quantmind/configs/earnings.py
+++ b/quantmind/configs/earnings.py
@@ -1,0 +1,42 @@
+"""Earnings-flow configuration + input discriminated union."""
+
+from typing import Annotated, Literal, Union
+
+from pydantic import Field
+
+from quantmind.configs.base import BaseFlowCfg, BaseInput
+
+
+class TickerPeriod(BaseInput):
+    """Ticker + reporting period (e.g. ``AAPL`` / ``2026Q1``)."""
+
+    type: Literal["ticker_period"] = "ticker_period"
+    ticker: str
+    period: str  # e.g. "2026Q1"
+
+
+class TranscriptText(BaseInput):
+    """Raw earnings-call transcript pasted inline."""
+
+    type: Literal["transcript"] = "transcript"
+    text: str
+
+
+class HttpUrl(BaseInput):
+    """URL to an earnings release / IR filing."""
+
+    type: Literal["http"] = "http"
+    url: str
+
+
+EarningsInput = Annotated[
+    Union[TickerPeriod, TranscriptText, HttpUrl],
+    Field(discriminator="type"),
+]
+
+
+class EarningsFlowCfg(BaseFlowCfg):
+    """Knobs specific to earnings_flow."""
+
+    detect_surprises: bool = True
+    include_guidance: bool = True

--- a/quantmind/configs/news.py
+++ b/quantmind/configs/news.py
@@ -1,0 +1,41 @@
+"""News-flow configuration + input discriminated union."""
+
+from typing import Annotated, Literal, Union
+
+from pydantic import Field
+
+from quantmind.configs.base import BaseFlowCfg, BaseInput
+
+
+class RssFeed(BaseInput):
+    """RSS/Atom feed URL to be polled for items."""
+
+    type: Literal["rss"] = "rss"
+    url: str
+
+
+class HttpUrl(BaseInput):
+    """Single news article URL."""
+
+    type: Literal["http"] = "http"
+    url: str
+
+
+class Headline(BaseInput):
+    """Inline headline text (no body fetching)."""
+
+    type: Literal["headline"] = "headline"
+    text: str
+
+
+NewsInput = Annotated[
+    Union[RssFeed, HttpUrl, Headline],
+    Field(discriminator="type"),
+]
+
+
+class NewsFlowCfg(BaseFlowCfg):
+    """Knobs specific to news_flow."""
+
+    materiality_threshold: Literal["low", "medium", "high"] = "medium"
+    entities_hint: list[str] = Field(default_factory=list)

--- a/quantmind/configs/paper.py
+++ b/quantmind/configs/paper.py
@@ -1,0 +1,65 @@
+"""Paper-flow configuration + input discriminated union.
+
+`PaperInput` is one of:
+- `ArxivIdentifier`: arxiv id or full URL parsed by preprocess.fetch.arxiv
+- `HttpUrl`: any web URL (PDF or HTML; routed by content-type)
+- `LocalFilePath`: filesystem path to a PDF / HTML / Markdown file
+- `RawText`: an inline string (for tests or LLM-pre-cleaned inputs)
+- `DoiIdentifier`: a DOI to be resolved via preprocess.fetch.doi
+"""
+
+from pathlib import Path
+from typing import Annotated, Literal, Union
+
+from pydantic import Field
+
+from quantmind.configs.base import BaseFlowCfg, BaseInput
+
+
+class ArxivIdentifier(BaseInput):
+    """Arxiv id (e.g. ``2604.12345``) or full arxiv URL."""
+
+    type: Literal["arxiv"] = "arxiv"
+    id: str
+
+
+class HttpUrl(BaseInput):
+    """Any web URL; PDF vs HTML is decided by content-type."""
+
+    type: Literal["http"] = "http"
+    url: str
+
+
+class LocalFilePath(BaseInput):
+    """Filesystem path to a PDF / HTML / Markdown file."""
+
+    type: Literal["local"] = "local"
+    path: Path
+
+
+class RawText(BaseInput):
+    """Inline text input (tests / pre-cleaned content)."""
+
+    type: Literal["text"] = "text"
+    text: str
+
+
+class DoiIdentifier(BaseInput):
+    """A DOI to be resolved by ``preprocess.fetch.doi``."""
+
+    type: Literal["doi"] = "doi"
+    doi: str
+
+
+PaperInput = Annotated[
+    Union[ArxivIdentifier, HttpUrl, LocalFilePath, RawText, DoiIdentifier],
+    Field(discriminator="type"),
+]
+
+
+class PaperFlowCfg(BaseFlowCfg):
+    """Knobs specific to paper_flow."""
+
+    extract_methodology: bool = True
+    extract_limitations: bool = True
+    asset_class_hint: str | None = None

--- a/quantmind/knowledge/__init__.py
+++ b/quantmind/knowledge/__init__.py
@@ -1,0 +1,19 @@
+"""quantmind.knowledge — Pydantic schemas for extracted financial knowledge.
+
+Each subclass of `KnowledgeItem` is a frozen schema designed to be passed as
+`Agent(output_type=...)` to the OpenAI Agents SDK and to round-trip through
+JSON.
+"""
+
+from quantmind.knowledge._base import Citation, KnowledgeItem
+from quantmind.knowledge.earnings import Earnings
+from quantmind.knowledge.news import News
+from quantmind.knowledge.paper import Paper
+
+__all__ = [
+    "Citation",
+    "Earnings",
+    "KnowledgeItem",
+    "News",
+    "Paper",
+]

--- a/quantmind/knowledge/__init__.py
+++ b/quantmind/knowledge/__init__.py
@@ -1,19 +1,44 @@
-"""quantmind.knowledge — Pydantic schemas for extracted financial knowledge.
+"""quantmind.knowledge — data standard for extracted financial knowledge.
 
-Each subclass of `KnowledgeItem` is a frozen schema designed to be passed as
-`Agent(output_type=...)` to the OpenAI Agents SDK and to round-trip through
-JSON.
+The standard defines three shapes that share `BaseKnowledge`:
+
+- `FlattenKnowledge` — atomic cards (`News`, `Earnings`, `PaperKnowledgeCard`).
+- `TreeKnowledge` — hierarchical artifacts (`Paper`).
+- `GraphKnowledge` — cross-item edges (placeholder, not implemented).
+
+Every concrete subclass is frozen Pydantic v2 with ``extra="forbid"``,
+suitable for ``Agent(output_type=...)`` and round-tripping through JSON.
+Subclasses MUST override ``embedding_text()`` so the store layer knows
+what to embed.
 """
 
-from quantmind.knowledge._base import Citation, KnowledgeItem
+from quantmind.knowledge._base import (
+    BaseKnowledge,
+    Citation,
+    ExtractionRef,
+    SourceRef,
+)
+from quantmind.knowledge._flatten import FlattenKnowledge
+from quantmind.knowledge._graph import GraphKnowledge
+from quantmind.knowledge._tree import TreeKnowledge, TreeNode
 from quantmind.knowledge.earnings import Earnings
 from quantmind.knowledge.news import News
-from quantmind.knowledge.paper import Paper
+from quantmind.knowledge.paper import Paper, PaperKnowledgeCard
 
 __all__ = [
+    # Base
+    "BaseKnowledge",
     "Citation",
+    "ExtractionRef",
+    "SourceRef",
+    # Shapes
+    "FlattenKnowledge",
+    "GraphKnowledge",
+    "TreeKnowledge",
+    "TreeNode",
+    # Concrete
     "Earnings",
-    "KnowledgeItem",
     "News",
     "Paper",
+    "PaperKnowledgeCard",
 ]

--- a/quantmind/knowledge/__init__.py
+++ b/quantmind/knowledge/__init__.py
@@ -22,8 +22,10 @@ from quantmind.knowledge._flatten import FlattenKnowledge
 from quantmind.knowledge._graph import GraphKnowledge
 from quantmind.knowledge._tree import TreeKnowledge, TreeNode
 from quantmind.knowledge.earnings import Earnings
+from quantmind.knowledge.factor import Factor
 from quantmind.knowledge.news import News
 from quantmind.knowledge.paper import Paper, PaperKnowledgeCard
+from quantmind.knowledge.thesis import Thesis
 
 __all__ = [
     # Base
@@ -38,7 +40,9 @@ __all__ = [
     "TreeNode",
     # Concrete
     "Earnings",
+    "Factor",
     "News",
     "Paper",
     "PaperKnowledgeCard",
+    "Thesis",
 ]

--- a/quantmind/knowledge/_base.py
+++ b/quantmind/knowledge/_base.py
@@ -1,15 +1,25 @@
-"""Base types for the quantmind.knowledge package.
+"""Base types for the quantmind.knowledge data standard.
 
-`KnowledgeItem` is the frozen Pydantic v2 base every domain schema (Paper,
-News, Earnings, ...) inherits. Subclasses are returned as Agents SDK
-`output_type=`, so they must be both serialisable and strict.
+Three shapes share `BaseKnowledge`:
 
-The `as_of` field is mandatory: financial knowledge is only useful when its
-time-of-validity is explicit.
+- `FlattenKnowledge` — atomic cards (`News`, `Earnings`, `PaperKnowledgeCard`, ...)
+- `TreeKnowledge` — hierarchical artifacts (`Paper`, `EarningsCallTranscript`, ...)
+- `GraphKnowledge` — cross-item edges (placeholder, future PR)
+
+The `as_of` field is mandatory by design: financial knowledge is only useful
+when its time-of-validity is explicit. `source` and `extraction` are typed
+references (not bare strings) so dedup, audit, and re-runs all have stable
+keys.
+
+Subclasses MUST override `embedding_text()` to declare what string the store
+layer should embed for them. The contract is enforced at runtime, not at
+type-check time, because `BaseKnowledge` itself can be referenced as a
+generic return type without forcing every consumer to know about embeddings.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
+from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -23,20 +33,75 @@ class Citation(BaseModel):
     page: int | None = None
     char_offset: int | None = None
     quote: str | None = Field(default=None, max_length=500)
+    # When the citation points into a TreeKnowledge, anchor to a specific node.
+    tree_id: UUID | None = None
+    node_id: UUID | None = None
 
 
-class KnowledgeItem(BaseModel):
-    """Base schema for every quantmind knowledge type."""
+class SourceRef(BaseModel):
+    """Typed provenance reference. Replaces a bare ``source: str``."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    citations: list[Citation] = Field(default_factory=list)
+    kind: Literal[
+        "arxiv", "http", "doi", "local", "rss", "transcript", "manual"
+    ]
+    uri: str | None = None
+    fetched_at: datetime | None = None
+    content_hash: str | None = None  # sha256 of fetched bytes; dedup key.
+
+
+class ExtractionRef(BaseModel):
+    """Records which flow + model produced this knowledge item."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    flow: str
+    model: str
+    run_id: UUID | None = None
+    extracted_at: datetime
+
+
+class BaseKnowledge(BaseModel):
+    """Root of every quantmind knowledge type.
+
+    All three shapes (Flatten / Tree / Graph) share this field set; subclasses
+    add domain-specific payload. Subclasses MUST override `embedding_text()`
+    to declare what string the store layer should embed.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    # Identity
+    id: UUID = Field(default_factory=uuid4)
+    item_type: str
+    schema_version: str = "1.0"
+
+    # Time (financial mandate)
     as_of: datetime = Field(..., description="Information cutoff time.")
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+    # Provenance (no bare strings)
+    source: SourceRef
+    extraction: ExtractionRef | None = None
+
+    # Trust
     confidence: Literal["low", "medium", "high"] = "medium"
 
-    item_type: str
-    source: str | None = None
-    extraction_method: str | None = None
-
+    # Citations & tags
+    citations: list[Citation] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
     disclaimers: list[str] = Field(default_factory=list)
+
+    def embedding_text(self) -> str:
+        """Return the canonical string the store should embed for this item.
+
+        Flatten subclasses: typically ``summary + key attrs``.
+        Tree subclasses: typically ``root.title + root.summary``.
+        Subclasses MUST override.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.embedding_text() must be overridden"
+        )

--- a/quantmind/knowledge/_base.py
+++ b/quantmind/knowledge/_base.py
@@ -17,11 +17,12 @@ type-check time, because `BaseKnowledge` itself can be referenced as a
 generic return type without forcing every consumer to know about embeddings.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import Self
 
 
 class Citation(BaseModel):
@@ -105,3 +106,27 @@ class BaseKnowledge(BaseModel):
         raise NotImplementedError(
             f"{type(self).__name__}.embedding_text() must be overridden"
         )
+
+    # ── Convenience helpers ────────────────────────────────────────────
+    # These are shared by every shape (Flatten / Tree / Graph) because they
+    # operate on `BaseKnowledge` metadata, not domain payload.
+
+    def is_extracted(self) -> bool:
+        """True iff the item came from an LLM flow (vs hand-curated)."""
+        return self.extraction is not None
+
+    def freshness(self, now: datetime | None = None) -> timedelta:
+        """Time elapsed since ``as_of``. Defaults ``now`` to ``utcnow()``."""
+        reference = now if now is not None else datetime.now(timezone.utc)
+        return reference - self.as_of
+
+    def with_tags(self, *new_tags: str) -> Self:
+        """Return a copy with extra tags appended (frozen-friendly).
+
+        Duplicates are skipped so the operation is idempotent.
+        """
+        merged = list(self.tags)
+        for t in new_tags:
+            if t not in merged:
+                merged.append(t)
+        return self.model_copy(update={"tags": merged})

--- a/quantmind/knowledge/_base.py
+++ b/quantmind/knowledge/_base.py
@@ -1,0 +1,42 @@
+"""Base types for the quantmind.knowledge package.
+
+`KnowledgeItem` is the frozen Pydantic v2 base every domain schema (Paper,
+News, Earnings, ...) inherits. Subclasses are returned as Agents SDK
+`output_type=`, so they must be both serialisable and strict.
+
+The `as_of` field is mandatory: financial knowledge is only useful when its
+time-of-validity is explicit.
+"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Citation(BaseModel):
+    """A pointer back to the source span an extracted fact came from."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source_id: str
+    page: int | None = None
+    char_offset: int | None = None
+    quote: str | None = Field(default=None, max_length=500)
+
+
+class KnowledgeItem(BaseModel):
+    """Base schema for every quantmind knowledge type."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    citations: list[Citation] = Field(default_factory=list)
+    as_of: datetime = Field(..., description="Information cutoff time.")
+    confidence: Literal["low", "medium", "high"] = "medium"
+
+    item_type: str
+    source: str | None = None
+    extraction_method: str | None = None
+
+    tags: list[str] = Field(default_factory=list)
+    disclaimers: list[str] = Field(default_factory=list)

--- a/quantmind/knowledge/_flatten.py
+++ b/quantmind/knowledge/_flatten.py
@@ -1,0 +1,22 @@
+"""FlattenKnowledge — atomic-card shape.
+
+A flatten card is semantically indivisible: one source artifact maps to one
+card whose body is the answer (no structure to navigate). Flatten is the
+right shape for `News`, `Earnings`, `Factor`, `Thesis`, and the summary card
+of a paper (`PaperKnowledgeCard`). Whole research papers are NOT flatten —
+they are `TreeKnowledge`.
+
+This file only declares the marker base; concrete subclasses live in
+`paper.py` / `news.py` / `earnings.py` / etc.
+"""
+
+from quantmind.knowledge._base import BaseKnowledge
+
+
+class FlattenKnowledge(BaseKnowledge):
+    """Marker base for flat domain cards.
+
+    Subclasses add a typed payload (e.g. ``summary``, ``methodology``,
+    ``revenue``). They MUST override `embedding_text()` to produce a stable
+    string suitable for the store's vector index.
+    """

--- a/quantmind/knowledge/_graph.py
+++ b/quantmind/knowledge/_graph.py
@@ -1,0 +1,40 @@
+"""GraphKnowledge — cross-item edges (placeholder, NOT implemented).
+
+The graph shape covers relations BETWEEN knowledge items: paper-cites-paper,
+factor-derived-from-factor, news-mentions-ticker. It is distinct from the
+internal hierarchy of a single item (which is `TreeKnowledge`).
+
+This module exists so users can write::
+
+    Knowledge = FlattenKnowledge | TreeKnowledge | GraphKnowledge
+
+honestly today, even though the implementation is deferred. Subclassing is
+blocked at class-creation time so no one accidentally builds against an
+unfinalised contract.
+"""
+
+from typing import Any
+
+from quantmind.knowledge._base import BaseKnowledge
+
+
+class GraphKnowledge(BaseKnowledge):
+    """Reserved for cross-item edges. NOT IMPLEMENTED.
+
+    Future shape (sketched, subject to change):
+
+    - ``nodes: dict[UUID, NodeRef]`` where ``NodeRef = (knowledge_id, knowledge_type)``
+    - ``edges: list[Edge]`` where ``Edge = (from, to, kind, weight, evidence)``
+
+    Use cases under consideration: paper citation graph, factor lineage,
+    news–entity co-occurrence. An issue will be opened when the first
+    concrete need arrives (PR8+).
+    """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        raise NotImplementedError(
+            "GraphKnowledge is a design-intent placeholder; subclassing is "
+            "blocked until the shape is finalised. Open a tracking issue "
+            "before lifting this guard."
+        )

--- a/quantmind/knowledge/_tree.py
+++ b/quantmind/knowledge/_tree.py
@@ -1,0 +1,91 @@
+"""TreeKnowledge — hierarchical-artifact shape.
+
+A tree's structure carries information: nodes derive meaning from their
+position under a parent. `TreeKnowledge` is the right shape for whole
+research papers (sections / subsections), regulatory filings (10-K parts),
+and earnings-call transcripts (intro / Q&A / per-question).
+
+Retrieval over a tree is reasoning-driven (PageIndex-style): an agent reads
+the root summary plus children summaries, picks the most likely branch,
+drills down, and lazy-loads leaf content. Embeddings (when available) act as
+a coarse pre-filter, never as a replacement for that reasoning.
+"""
+
+from collections.abc import Iterator
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from quantmind.knowledge._base import BaseKnowledge, Citation
+
+
+class TreeNode(BaseModel):
+    """A single node in a TreeKnowledge.
+
+    `summary` is mandatory because agents navigate by reading it. `content`
+    is the optional full-text body (typically populated only on leaves to
+    keep the tree small in memory). `children_ids` is an adjacency list; the
+    parent `TreeKnowledge` resolves them via its `nodes` map.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    node_id: UUID = Field(default_factory=uuid4)
+    parent_id: UUID | None = None
+    position: int = 0
+    title: str
+    summary: str
+    content: str | None = None
+    citations: list[Citation] = Field(default_factory=list)
+    children_ids: list[UUID] = Field(default_factory=list)
+
+    def embedding_text(self) -> str:
+        """Default: title + summary. Override per domain if needed."""
+        return f"{self.title}\n{self.summary}"
+
+
+class TreeKnowledge(BaseKnowledge):
+    """Hierarchical knowledge artifact.
+
+    Holds the full set of nodes in a flat ``nodes`` dict for O(1) lookup,
+    plus the ``root_node_id`` pointer. Whether a backend loads all nodes
+    eagerly or lazily is its concern; the schema always represents a
+    complete tree.
+    """
+
+    root_node_id: UUID
+    nodes: dict[UUID, TreeNode]
+
+    def root(self) -> TreeNode:
+        return self.nodes[self.root_node_id]
+
+    def children_of(self, node_id: UUID) -> list[TreeNode]:
+        node = self.nodes[node_id]
+        return [self.nodes[c] for c in node.children_ids]
+
+    def walk_dfs(self) -> Iterator[TreeNode]:
+        """Depth-first traversal starting at the root."""
+        stack: list[UUID] = [self.root_node_id]
+        while stack:
+            node_id = stack.pop()
+            node = self.nodes[node_id]
+            yield node
+            # Reverse so children are visited in declared order.
+            stack.extend(reversed(node.children_ids))
+
+    def find_path(self, node_id: UUID) -> list[TreeNode]:
+        """Root-to-node path. Empty if `node_id` is not in the tree."""
+        if node_id not in self.nodes:
+            return []
+        path: list[TreeNode] = []
+        cursor: UUID | None = node_id
+        while cursor is not None:
+            node = self.nodes[cursor]
+            path.append(node)
+            cursor = node.parent_id
+        path.reverse()
+        return path
+
+    def embedding_text(self) -> str:
+        """Default: root node's embedding text. Override per domain if needed."""
+        return self.root().embedding_text()

--- a/quantmind/knowledge/earnings.py
+++ b/quantmind/knowledge/earnings.py
@@ -4,11 +4,11 @@ from typing import Literal
 
 from pydantic import Field
 
-from quantmind.knowledge._base import KnowledgeItem
+from quantmind.knowledge._flatten import FlattenKnowledge
 
 
-class Earnings(KnowledgeItem):
-    """An earnings-release extraction (one filing -> one Earnings)."""
+class Earnings(FlattenKnowledge):
+    """An earnings-release extraction (one filing -> one Earnings card)."""
 
     item_type: Literal["earnings"] = "earnings"
 
@@ -19,3 +19,7 @@ class Earnings(KnowledgeItem):
     guidance: str | None = None
     surprise_flags: list[str] = Field(default_factory=list)
     transcript_quote: str | None = None
+
+    def embedding_text(self) -> str:
+        guidance = self.guidance or ""
+        return f"{self.ticker} {self.period} earnings\n{guidance}".strip()

--- a/quantmind/knowledge/earnings.py
+++ b/quantmind/knowledge/earnings.py
@@ -1,0 +1,21 @@
+"""Earnings knowledge schema (output of earnings_flow)."""
+
+from typing import Literal
+
+from pydantic import Field
+
+from quantmind.knowledge._base import KnowledgeItem
+
+
+class Earnings(KnowledgeItem):
+    """An earnings-release extraction (one filing -> one Earnings)."""
+
+    item_type: Literal["earnings"] = "earnings"
+
+    ticker: str
+    period: str  # e.g. "2026Q1", "FY2025"
+    revenue: float | None = None
+    eps: float | None = None
+    guidance: str | None = None
+    surprise_flags: list[str] = Field(default_factory=list)
+    transcript_quote: str | None = None

--- a/quantmind/knowledge/factor.py
+++ b/quantmind/knowledge/factor.py
@@ -1,0 +1,23 @@
+"""Factor knowledge schema (stub; full payload lands with factor_flow).
+
+The class exists today so ``from quantmind.knowledge import Factor`` is
+stable across PRs. Concrete factor research fields (universe / period / pnl
+/ ic / turnover) are added when ``factor_flow`` ships.
+"""
+
+from typing import Literal
+
+from quantmind.knowledge._flatten import FlattenKnowledge
+
+
+class Factor(FlattenKnowledge):
+    """A single factor card (stub)."""
+
+    item_type: Literal["factor"] = "factor"
+
+    factor_name: str
+    universe: str | None = None
+
+    def embedding_text(self) -> str:
+        scope = self.universe or "unspecified"
+        return f"factor {self.factor_name} on {scope}"

--- a/quantmind/knowledge/news.py
+++ b/quantmind/knowledge/news.py
@@ -1,0 +1,21 @@
+"""News knowledge schema (output of news_flow)."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import Field
+
+from quantmind.knowledge._base import KnowledgeItem
+
+
+class News(KnowledgeItem):
+    """A news event extraction."""
+
+    item_type: Literal["news"] = "news"
+
+    headline: str
+    event_type: str
+    timestamp: datetime
+    entities: list[str] = Field(default_factory=list)
+    sentiment: Literal["positive", "neutral", "negative"] = "neutral"
+    materiality: Literal["low", "medium", "high"] = "medium"

--- a/quantmind/knowledge/news.py
+++ b/quantmind/knowledge/news.py
@@ -5,11 +5,11 @@ from typing import Literal
 
 from pydantic import Field
 
-from quantmind.knowledge._base import KnowledgeItem
+from quantmind.knowledge._flatten import FlattenKnowledge
 
 
-class News(KnowledgeItem):
-    """A news event extraction."""
+class News(FlattenKnowledge):
+    """A single news event extraction."""
 
     item_type: Literal["news"] = "news"
 
@@ -19,3 +19,7 @@ class News(KnowledgeItem):
     entities: list[str] = Field(default_factory=list)
     sentiment: Literal["positive", "neutral", "negative"] = "neutral"
     materiality: Literal["low", "medium", "high"] = "medium"
+
+    def embedding_text(self) -> str:
+        entities = ", ".join(self.entities)
+        return f"{self.headline}\n{self.event_type}\n{entities}".strip()

--- a/quantmind/knowledge/paper.py
+++ b/quantmind/knowledge/paper.py
@@ -1,0 +1,21 @@
+"""Paper knowledge schema (output of paper_flow)."""
+
+from typing import Literal
+
+from pydantic import Field
+
+from quantmind.knowledge._base import KnowledgeItem
+
+
+class Paper(KnowledgeItem):
+    """A research paper extraction (one paper -> one Paper instance)."""
+
+    item_type: Literal["paper"] = "paper"
+
+    summary: str
+    methodology: str | None = None
+    key_findings: list[str] = Field(default_factory=list)
+    limitations: list[str] = Field(default_factory=list)
+    asset_classes: list[str] = Field(default_factory=list)
+    authors: list[str] = Field(default_factory=list)
+    arxiv_id: str | None = None

--- a/quantmind/knowledge/paper.py
+++ b/quantmind/knowledge/paper.py
@@ -1,21 +1,52 @@
-"""Paper knowledge schema (output of paper_flow)."""
+"""Paper knowledge schemas.
+
+A whole paper is `TreeKnowledge` (sections + subsections); the distilled
+summary card is `PaperKnowledgeCard` (`FlattenKnowledge`). They are separate
+items linked by ``PaperKnowledgeCard.paper_id == Paper.id``.
+
+`paper_flow` (PR5) typically produces a `Paper` first (sectioning + per-node
+summarisation), then a `PaperKnowledgeCard` derived from the root summary.
+"""
 
 from typing import Literal
+from uuid import UUID
 
 from pydantic import Field
 
-from quantmind.knowledge._base import KnowledgeItem
+from quantmind.knowledge._flatten import FlattenKnowledge
+from quantmind.knowledge._tree import TreeKnowledge
 
 
-class Paper(KnowledgeItem):
-    """A research paper extraction (one paper -> one Paper instance)."""
+class Paper(TreeKnowledge):
+    """A research paper as a tree of sections.
+
+    The tree's nodes carry per-section ``summary`` (for navigation) and, on
+    leaves, the section ``content`` (Markdown). Top-level metadata
+    (``arxiv_id``, ``authors``) lives here on the tree itself.
+    """
 
     item_type: Literal["paper"] = "paper"
+    arxiv_id: str | None = None
+    authors: list[str] = Field(default_factory=list)
+    asset_classes: list[str] = Field(default_factory=list)
 
+
+class PaperKnowledgeCard(FlattenKnowledge):
+    """Distilled summary card of a `Paper`.
+
+    The store layer keys this off ``paper_id`` so the card and its tree can
+    be retrieved together. The card is the right shape for tagging,
+    filtering, and dashboard surfaces; deep questions go to the tree.
+    """
+
+    item_type: Literal["paper_card"] = "paper_card"
+
+    paper_id: UUID
     summary: str
     methodology: str | None = None
     key_findings: list[str] = Field(default_factory=list)
     limitations: list[str] = Field(default_factory=list)
     asset_classes: list[str] = Field(default_factory=list)
-    authors: list[str] = Field(default_factory=list)
-    arxiv_id: str | None = None
+
+    def embedding_text(self) -> str:
+        return f"{self.summary}\n{' '.join(self.key_findings)}"

--- a/quantmind/knowledge/thesis.py
+++ b/quantmind/knowledge/thesis.py
@@ -1,0 +1,21 @@
+"""Thesis knowledge schema (stub; full payload lands with thesis_flow).
+
+The class exists today so ``from quantmind.knowledge import Thesis`` is
+stable across PRs. Concrete thesis fields (assumptions / evidence_refs /
+time_horizon) are added when ``thesis_flow`` ships.
+"""
+
+from typing import Literal
+
+from quantmind.knowledge._flatten import FlattenKnowledge
+
+
+class Thesis(FlattenKnowledge):
+    """An investment thesis card (stub)."""
+
+    item_type: Literal["thesis"] = "thesis"
+
+    claim: str
+
+    def embedding_text(self) -> str:
+        return self.claim

--- a/tests/configs/test_base.py
+++ b/tests/configs/test_base.py
@@ -1,0 +1,64 @@
+"""Tests for configs.base."""
+
+import unittest
+
+from agents import ModelSettings
+from pydantic import ValidationError
+
+from quantmind.configs.base import BaseFlowCfg, BaseInput
+
+
+class BaseFlowCfgTests(unittest.TestCase):
+    def test_defaults(self):
+        cfg = BaseFlowCfg()
+        self.assertEqual(cfg.model, "gpt-4o")
+        self.assertEqual(cfg.max_turns, 10)
+        self.assertAlmostEqual(cfg.timeout_seconds, 300.0)
+        self.assertIsNone(cfg.model_settings)
+        self.assertIsNone(cfg.memory_dir)
+        self.assertTrue(cfg.archive_trajectory)
+        self.assertTrue(cfg.enable_default_guardrails)
+        self.assertFalse(cfg.tracing_disabled)
+
+    def test_extra_forbidden(self):
+        with self.assertRaises(ValidationError):
+            BaseFlowCfg(unknown=True)  # type: ignore[call-arg]
+
+    def test_model_settings_accepted(self):
+        ms = ModelSettings(temperature=0.1)
+        cfg = BaseFlowCfg(model_settings=ms)
+        assert cfg.model_settings is not None
+        self.assertEqual(cfg.model_settings.temperature, 0.1)
+
+
+class BaseInputTests(unittest.TestCase):
+    def test_extra_forbidden(self):
+        class _SampleInput(BaseInput):
+            x: int
+
+        with self.assertRaises(ValidationError):
+            _SampleInput(x=1, y=2)  # type: ignore[call-arg]
+
+
+class PackageExportTests(unittest.TestCase):
+    def test_top_level_imports(self):
+        from quantmind.configs import (
+            BaseFlowCfg as BaseFlowCfgExport,
+        )
+        from quantmind.configs import (
+            BaseInput as BaseInputExport,
+        )
+        from quantmind.configs import (
+            EarningsFlowCfg,
+            NewsFlowCfg,
+            PaperFlowCfg,
+        )
+
+        self.assertTrue(issubclass(PaperFlowCfg, BaseFlowCfgExport))
+        self.assertTrue(issubclass(NewsFlowCfg, BaseFlowCfgExport))
+        self.assertTrue(issubclass(EarningsFlowCfg, BaseFlowCfgExport))
+        self.assertEqual(BaseInputExport.__name__, "BaseInput")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/configs/test_earnings.py
+++ b/tests/configs/test_earnings.py
@@ -1,0 +1,56 @@
+"""Tests for configs.earnings."""
+
+import unittest
+
+from pydantic import TypeAdapter, ValidationError
+
+from quantmind.configs.earnings import (
+    EarningsFlowCfg,
+    EarningsInput,
+    HttpUrl,
+    TickerPeriod,
+    TranscriptText,
+)
+
+
+class EarningsFlowCfgTests(unittest.TestCase):
+    def test_defaults(self):
+        cfg = EarningsFlowCfg()
+        self.assertEqual(cfg.model, "gpt-4o")
+        self.assertTrue(cfg.detect_surprises)
+
+
+class EarningsInputTests(unittest.TestCase):
+    def setUp(self):
+        self.adapter = TypeAdapter(EarningsInput)
+
+    def test_ticker_period(self):
+        v = self.adapter.validate_python(
+            {
+                "type": "ticker_period",
+                "ticker": "AAPL",
+                "period": "2026Q1",
+            }
+        )
+        self.assertIsInstance(v, TickerPeriod)
+        self.assertEqual(v.ticker, "AAPL")
+
+    def test_transcript(self):
+        v = self.adapter.validate_python(
+            {"type": "transcript", "text": "Operator: ..."}
+        )
+        self.assertIsInstance(v, TranscriptText)
+
+    def test_http(self):
+        v = self.adapter.validate_python(
+            {"type": "http", "url": "https://ir.example.com/q1.pdf"}
+        )
+        self.assertIsInstance(v, HttpUrl)
+
+    def test_unknown_rejected(self):
+        with self.assertRaises(ValidationError):
+            self.adapter.validate_python({"type": "video", "url": "x"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/configs/test_news.py
+++ b/tests/configs/test_news.py
@@ -1,0 +1,51 @@
+"""Tests for configs.news."""
+
+import unittest
+
+from pydantic import TypeAdapter, ValidationError
+
+from quantmind.configs.news import (
+    Headline,
+    HttpUrl,
+    NewsFlowCfg,
+    NewsInput,
+    RssFeed,
+)
+
+
+class NewsFlowCfgTests(unittest.TestCase):
+    def test_defaults(self):
+        cfg = NewsFlowCfg()
+        self.assertEqual(cfg.model, "gpt-4o")
+        self.assertEqual(cfg.materiality_threshold, "medium")
+
+
+class NewsInputTests(unittest.TestCase):
+    def setUp(self):
+        self.adapter = TypeAdapter(NewsInput)
+
+    def test_rss(self):
+        v = self.adapter.validate_python(
+            {"type": "rss", "url": "https://feeds.example.com/markets"}
+        )
+        self.assertIsInstance(v, RssFeed)
+
+    def test_http(self):
+        v = self.adapter.validate_python(
+            {"type": "http", "url": "https://news.example.com/a"}
+        )
+        self.assertIsInstance(v, HttpUrl)
+
+    def test_headline(self):
+        v = self.adapter.validate_python(
+            {"type": "headline", "text": "Fed holds rates"}
+        )
+        self.assertIsInstance(v, Headline)
+
+    def test_unknown_rejected(self):
+        with self.assertRaises(ValidationError):
+            self.adapter.validate_python({"type": "podcast", "url": "x"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/configs/test_paper.py
+++ b/tests/configs/test_paper.py
@@ -1,0 +1,64 @@
+"""Tests for configs.paper."""
+
+import unittest
+from pathlib import Path
+
+from pydantic import TypeAdapter, ValidationError
+
+from quantmind.configs.paper import (
+    ArxivIdentifier,
+    DoiIdentifier,
+    HttpUrl,
+    LocalFilePath,
+    PaperFlowCfg,
+    PaperInput,
+    RawText,
+)
+
+
+class PaperFlowCfgTests(unittest.TestCase):
+    def test_defaults(self):
+        cfg = PaperFlowCfg()
+        self.assertEqual(cfg.model, "gpt-4o")
+        self.assertTrue(cfg.extract_methodology)
+        self.assertTrue(cfg.extract_limitations)
+        self.assertIsNone(cfg.asset_class_hint)
+
+
+class PaperInputDiscriminatedTests(unittest.TestCase):
+    def setUp(self):
+        self.adapter = TypeAdapter(PaperInput)
+
+    def test_arxiv_round_trip(self):
+        v = self.adapter.validate_python({"type": "arxiv", "id": "2604.12345"})
+        self.assertIsInstance(v, ArxivIdentifier)
+        self.assertEqual(v.id, "2604.12345")
+
+    def test_http(self):
+        v = self.adapter.validate_python(
+            {"type": "http", "url": "https://example.com/p.pdf"}
+        )
+        self.assertIsInstance(v, HttpUrl)
+
+    def test_local(self):
+        v = self.adapter.validate_python(
+            {"type": "local", "path": "/tmp/p.pdf"}
+        )
+        self.assertIsInstance(v, LocalFilePath)
+        self.assertEqual(v.path, Path("/tmp/p.pdf"))
+
+    def test_text(self):
+        v = self.adapter.validate_python({"type": "text", "text": "hello"})
+        self.assertIsInstance(v, RawText)
+
+    def test_doi(self):
+        v = self.adapter.validate_python({"type": "doi", "doi": "10.1000/xyz"})
+        self.assertIsInstance(v, DoiIdentifier)
+
+    def test_unknown_type_rejected(self):
+        with self.assertRaises(ValidationError):
+            self.adapter.validate_python({"type": "ftp", "url": "x"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge/test_base.py
+++ b/tests/knowledge/test_base.py
@@ -1,7 +1,8 @@
 """Tests for knowledge._base — BaseKnowledge data standard."""
 
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 
 from pydantic import ValidationError
 
@@ -33,6 +34,17 @@ class CitationTests(unittest.TestCase):
     def test_quote_max_length(self):
         with self.assertRaises(ValidationError):
             Citation(source_id="x", quote="a" * 501)
+
+    def test_tree_anchor_round_trip(self):
+        tree_id = uuid4()
+        node_id = uuid4()
+        cit = Citation(source_id="paper:abc", tree_id=tree_id, node_id=node_id)
+        self.assertEqual(cit.tree_id, tree_id)
+        self.assertEqual(cit.node_id, node_id)
+        # JSON round-trip preserves UUID anchors.
+        revived = Citation.model_validate_json(cit.model_dump_json())
+        self.assertEqual(revived.tree_id, tree_id)
+        self.assertEqual(revived.node_id, node_id)
 
 
 class SourceRefTests(unittest.TestCase):
@@ -140,6 +152,41 @@ class BaseKnowledgeTests(unittest.TestCase):
         assert item.extraction is not None
         self.assertEqual(item.extraction.flow, "paper_flow")
 
+    def test_is_extracted_false_when_hand_curated(self):
+        item = _ConcreteKnowledge(as_of=_now(), source=_src())
+        self.assertFalse(item.is_extracted())
+
+    def test_is_extracted_true_when_extraction_set(self):
+        ext = ExtractionRef(
+            flow="paper_flow", model="gpt-4o", extracted_at=_now()
+        )
+        item = _ConcreteKnowledge(as_of=_now(), source=_src(), extraction=ext)
+        self.assertTrue(item.is_extracted())
+
+    def test_freshness_with_explicit_now(self):
+        item = _ConcreteKnowledge(as_of=_now(), source=_src())
+        future = _now() + timedelta(days=3)
+        self.assertEqual(item.freshness(future), timedelta(days=3))
+
+    def test_freshness_default_now_is_utc(self):
+        # Just verify it returns a timedelta without raising; default `now`
+        # comes from `datetime.now(timezone.utc)`.
+        item = _ConcreteKnowledge(as_of=_now(), source=_src())
+        self.assertIsInstance(item.freshness(), timedelta)
+
+    def test_with_tags_appends_unique(self):
+        item = _ConcreteKnowledge(as_of=_now(), source=_src(), tags=["macro"])
+        updated = item.with_tags("equities", "macro", "rates")
+        self.assertEqual(updated.tags, ["macro", "equities", "rates"])
+        # Original is frozen and unchanged.
+        self.assertEqual(item.tags, ["macro"])
+
+    def test_with_tags_returns_new_instance(self):
+        item = _ConcreteKnowledge(as_of=_now(), source=_src())
+        updated = item.with_tags("x")
+        self.assertIsNot(item, updated)
+        self.assertEqual(updated.tags, ["x"])
+
 
 class PackageExportTests(unittest.TestCase):
     def test_top_level_imports(self):
@@ -148,12 +195,14 @@ class PackageExportTests(unittest.TestCase):
             Citation,
             Earnings,
             ExtractionRef,
+            Factor,
             FlattenKnowledge,
             GraphKnowledge,
             News,
             Paper,
             PaperKnowledgeCard,
             SourceRef,
+            Thesis,
             TreeKnowledge,
             TreeNode,
         )
@@ -164,6 +213,8 @@ class PackageExportTests(unittest.TestCase):
         self.assertTrue(issubclass(News, FlattenKnowledge))
         self.assertTrue(issubclass(Earnings, FlattenKnowledge))
         self.assertTrue(issubclass(PaperKnowledgeCard, FlattenKnowledge))
+        self.assertTrue(issubclass(Factor, FlattenKnowledge))
+        self.assertTrue(issubclass(Thesis, FlattenKnowledge))
         self.assertTrue(issubclass(Paper, TreeKnowledge))
         # Ensure side-imports are real classes
         self.assertEqual(Citation.__name__, "Citation")

--- a/tests/knowledge/test_base.py
+++ b/tests/knowledge/test_base.py
@@ -1,0 +1,66 @@
+"""Tests for knowledge._base."""
+
+import unittest
+from datetime import datetime, timezone
+
+from pydantic import ValidationError
+
+from quantmind.knowledge._base import Citation, KnowledgeItem
+
+
+class CitationTests(unittest.TestCase):
+    def test_minimal(self):
+        cit = Citation(source_id="arxiv:2604.12345")
+        self.assertEqual(cit.source_id, "arxiv:2604.12345")
+        self.assertIsNone(cit.page)
+        self.assertIsNone(cit.quote)
+
+    def test_quote_max_length(self):
+        with self.assertRaises(ValidationError):
+            Citation(source_id="x", quote="a" * 501)
+
+
+class KnowledgeItemTests(unittest.TestCase):
+    def _now(self) -> datetime:
+        return datetime(2026, 4, 26, tzinfo=timezone.utc)
+
+    def test_as_of_required(self):
+        with self.assertRaises(ValidationError):
+            KnowledgeItem(item_type="generic")  # type: ignore[call-arg]
+
+    def test_default_confidence_is_medium(self):
+        item = KnowledgeItem(item_type="generic", as_of=self._now())
+        self.assertEqual(item.confidence, "medium")
+
+    def test_frozen(self):
+        item = KnowledgeItem(item_type="generic", as_of=self._now())
+        with self.assertRaises(ValidationError):
+            item.tags = ["new"]  # type: ignore[misc]
+
+    def test_extra_forbidden(self):
+        with self.assertRaises(ValidationError):
+            KnowledgeItem(
+                item_type="generic",
+                as_of=self._now(),
+                unexpected_field=1,  # type: ignore[call-arg]
+            )
+
+
+class PackageExportTests(unittest.TestCase):
+    def test_top_level_imports(self):
+        from quantmind.knowledge import (
+            Citation,
+            Earnings,
+            KnowledgeItem,
+            News,
+            Paper,
+        )
+
+        self.assertTrue(issubclass(Paper, KnowledgeItem))
+        self.assertTrue(issubclass(News, KnowledgeItem))
+        self.assertTrue(issubclass(Earnings, KnowledgeItem))
+        self.assertEqual(Citation.__name__, "Citation")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge/test_base.py
+++ b/tests/knowledge/test_base.py
@@ -1,11 +1,24 @@
-"""Tests for knowledge._base."""
+"""Tests for knowledge._base — BaseKnowledge data standard."""
 
 import unittest
 from datetime import datetime, timezone
 
 from pydantic import ValidationError
 
-from quantmind.knowledge._base import Citation, KnowledgeItem
+from quantmind.knowledge._base import (
+    BaseKnowledge,
+    Citation,
+    ExtractionRef,
+    SourceRef,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 26, tzinfo=timezone.utc)
+
+
+def _src() -> SourceRef:
+    return SourceRef(kind="manual")
 
 
 class CitationTests(unittest.TestCase):
@@ -14,52 +27,149 @@ class CitationTests(unittest.TestCase):
         self.assertEqual(cit.source_id, "arxiv:2604.12345")
         self.assertIsNone(cit.page)
         self.assertIsNone(cit.quote)
+        self.assertIsNone(cit.tree_id)
+        self.assertIsNone(cit.node_id)
 
     def test_quote_max_length(self):
         with self.assertRaises(ValidationError):
             Citation(source_id="x", quote="a" * 501)
 
 
-class KnowledgeItemTests(unittest.TestCase):
-    def _now(self) -> datetime:
-        return datetime(2026, 4, 26, tzinfo=timezone.utc)
+class SourceRefTests(unittest.TestCase):
+    def test_minimal(self):
+        s = SourceRef(kind="arxiv", uri="arxiv:2604.12345")
+        self.assertEqual(s.kind, "arxiv")
+        self.assertEqual(s.uri, "arxiv:2604.12345")
+        self.assertIsNone(s.fetched_at)
+        self.assertIsNone(s.content_hash)
 
+    def test_kind_enum_enforced(self):
+        with self.assertRaises(ValidationError):
+            SourceRef(kind="ftp")  # type: ignore[arg-type]
+
+    def test_extra_forbidden(self):
+        with self.assertRaises(ValidationError):
+            SourceRef(kind="manual", garbage=1)  # type: ignore[call-arg]
+
+
+class ExtractionRefTests(unittest.TestCase):
+    def test_minimal(self):
+        e = ExtractionRef(
+            flow="paper_flow", model="gpt-4o", extracted_at=_now()
+        )
+        self.assertEqual(e.flow, "paper_flow")
+        self.assertEqual(e.model, "gpt-4o")
+        self.assertIsNone(e.run_id)
+
+
+class _ConcreteKnowledge(BaseKnowledge):
+    """Test fixture: concrete subclass that overrides embedding_text."""
+
+    item_type: str = "test"  # pyright: ignore[reportIncompatibleVariableOverride]
+    payload: str = ""
+
+    def embedding_text(self) -> str:
+        return self.payload
+
+
+class BaseKnowledgeTests(unittest.TestCase):
     def test_as_of_required(self):
         with self.assertRaises(ValidationError):
-            KnowledgeItem(item_type="generic")  # type: ignore[call-arg]
+            _ConcreteKnowledge(source=_src())  # type: ignore[call-arg]
+
+    def test_source_required(self):
+        with self.assertRaises(ValidationError):
+            _ConcreteKnowledge(as_of=_now())  # type: ignore[call-arg]
+
+    def test_default_id_unique(self):
+        a = _ConcreteKnowledge(as_of=_now(), source=_src())
+        b = _ConcreteKnowledge(as_of=_now(), source=_src())
+        self.assertNotEqual(a.id, b.id)
 
     def test_default_confidence_is_medium(self):
-        item = KnowledgeItem(item_type="generic", as_of=self._now())
+        item = _ConcreteKnowledge(as_of=_now(), source=_src())
         self.assertEqual(item.confidence, "medium")
 
+    def test_default_schema_version(self):
+        item = _ConcreteKnowledge(as_of=_now(), source=_src())
+        self.assertEqual(item.schema_version, "1.0")
+
+    def test_created_at_auto(self):
+        before = datetime.now(timezone.utc)
+        item = _ConcreteKnowledge(as_of=_now(), source=_src())
+        after = datetime.now(timezone.utc)
+        self.assertGreaterEqual(item.created_at, before)
+        self.assertLessEqual(item.created_at, after)
+
     def test_frozen(self):
-        item = KnowledgeItem(item_type="generic", as_of=self._now())
+        item = _ConcreteKnowledge(as_of=_now(), source=_src())
         with self.assertRaises(ValidationError):
             item.tags = ["new"]  # type: ignore[misc]
 
     def test_extra_forbidden(self):
         with self.assertRaises(ValidationError):
-            KnowledgeItem(
-                item_type="generic",
-                as_of=self._now(),
+            _ConcreteKnowledge(
+                as_of=_now(),
+                source=_src(),
                 unexpected_field=1,  # type: ignore[call-arg]
             )
+
+    def test_embedding_text_default_raises(self):
+        # BaseKnowledge.embedding_text raises NotImplementedError; subclasses
+        # must override. We test via a class that doesn't override.
+        class _NoEmbed(BaseKnowledge):
+            item_type: str = "no_embed"  # pyright: ignore[reportIncompatibleVariableOverride]
+
+        item = _NoEmbed(as_of=_now(), source=_src())
+        with self.assertRaises(NotImplementedError):
+            item.embedding_text()
+
+    def test_embedding_text_override(self):
+        item = _ConcreteKnowledge(as_of=_now(), source=_src(), payload="hello")
+        self.assertEqual(item.embedding_text(), "hello")
+
+    def test_extraction_optional(self):
+        item = _ConcreteKnowledge(as_of=_now(), source=_src())
+        self.assertIsNone(item.extraction)
+
+    def test_extraction_round_trip(self):
+        ext = ExtractionRef(
+            flow="paper_flow", model="gpt-4o", extracted_at=_now()
+        )
+        item = _ConcreteKnowledge(as_of=_now(), source=_src(), extraction=ext)
+        assert item.extraction is not None
+        self.assertEqual(item.extraction.flow, "paper_flow")
 
 
 class PackageExportTests(unittest.TestCase):
     def test_top_level_imports(self):
         from quantmind.knowledge import (
+            BaseKnowledge,
             Citation,
             Earnings,
-            KnowledgeItem,
+            ExtractionRef,
+            FlattenKnowledge,
+            GraphKnowledge,
             News,
             Paper,
+            PaperKnowledgeCard,
+            SourceRef,
+            TreeKnowledge,
+            TreeNode,
         )
 
-        self.assertTrue(issubclass(Paper, KnowledgeItem))
-        self.assertTrue(issubclass(News, KnowledgeItem))
-        self.assertTrue(issubclass(Earnings, KnowledgeItem))
+        self.assertTrue(issubclass(FlattenKnowledge, BaseKnowledge))
+        self.assertTrue(issubclass(TreeKnowledge, BaseKnowledge))
+        self.assertTrue(issubclass(GraphKnowledge, BaseKnowledge))
+        self.assertTrue(issubclass(News, FlattenKnowledge))
+        self.assertTrue(issubclass(Earnings, FlattenKnowledge))
+        self.assertTrue(issubclass(PaperKnowledgeCard, FlattenKnowledge))
+        self.assertTrue(issubclass(Paper, TreeKnowledge))
+        # Ensure side-imports are real classes
         self.assertEqual(Citation.__name__, "Citation")
+        self.assertEqual(SourceRef.__name__, "SourceRef")
+        self.assertEqual(ExtractionRef.__name__, "ExtractionRef")
+        self.assertEqual(TreeNode.__name__, "TreeNode")
 
 
 if __name__ == "__main__":

--- a/tests/knowledge/test_earnings.py
+++ b/tests/knowledge/test_earnings.py
@@ -1,0 +1,36 @@
+"""Tests for knowledge.earnings."""
+
+import unittest
+from datetime import datetime, timezone
+
+from quantmind.knowledge.earnings import Earnings
+
+
+class EarningsTests(unittest.TestCase):
+    def test_minimal(self):
+        e = Earnings(
+            as_of=datetime(2026, 4, 26, tzinfo=timezone.utc),
+            ticker="AAPL",
+            period="2026Q1",
+        )
+        self.assertEqual(e.item_type, "earnings")
+        self.assertIsNone(e.revenue)
+        self.assertEqual(e.surprise_flags, [])
+
+    def test_full(self):
+        e = Earnings(
+            as_of=datetime(2026, 4, 26, tzinfo=timezone.utc),
+            ticker="AAPL",
+            period="2026Q1",
+            revenue=120.0,
+            eps=1.55,
+            guidance="Raised FY revenue guide",
+            surprise_flags=["eps_beat", "revenue_beat"],
+            transcript_quote="Demand remains robust ...",
+        )
+        self.assertEqual(e.revenue, 120.0)
+        self.assertEqual(e.surprise_flags, ["eps_beat", "revenue_beat"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge/test_earnings.py
+++ b/tests/knowledge/test_earnings.py
@@ -3,13 +3,23 @@
 import unittest
 from datetime import datetime, timezone
 
+from quantmind.knowledge._base import SourceRef
 from quantmind.knowledge.earnings import Earnings
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 26, tzinfo=timezone.utc)
+
+
+def _src() -> SourceRef:
+    return SourceRef(kind="http", uri="https://ir.example.com/q1.pdf")
 
 
 class EarningsTests(unittest.TestCase):
     def test_minimal(self):
         e = Earnings(
-            as_of=datetime(2026, 4, 26, tzinfo=timezone.utc),
+            as_of=_now(),
+            source=_src(),
             ticker="AAPL",
             period="2026Q1",
         )
@@ -19,7 +29,8 @@ class EarningsTests(unittest.TestCase):
 
     def test_full(self):
         e = Earnings(
-            as_of=datetime(2026, 4, 26, tzinfo=timezone.utc),
+            as_of=_now(),
+            source=_src(),
             ticker="AAPL",
             period="2026Q1",
             revenue=120.0,
@@ -30,6 +41,19 @@ class EarningsTests(unittest.TestCase):
         )
         self.assertEqual(e.revenue, 120.0)
         self.assertEqual(e.surprise_flags, ["eps_beat", "revenue_beat"])
+
+    def test_embedding_text(self):
+        e = Earnings(
+            as_of=_now(),
+            source=_src(),
+            ticker="AAPL",
+            period="2026Q1",
+            guidance="Raised FY guide",
+        )
+        self.assertEqual(
+            e.embedding_text(),
+            "AAPL 2026Q1 earnings\nRaised FY guide",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/knowledge/test_factor.py
+++ b/tests/knowledge/test_factor.py
@@ -1,0 +1,40 @@
+"""Tests for knowledge.factor (stub schema)."""
+
+import unittest
+from datetime import datetime, timezone
+
+from quantmind.knowledge._base import SourceRef
+from quantmind.knowledge.factor import Factor
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 27, tzinfo=timezone.utc)
+
+
+def _src() -> SourceRef:
+    return SourceRef(kind="manual")
+
+
+class FactorTests(unittest.TestCase):
+    def test_minimal(self):
+        f = Factor(as_of=_now(), source=_src(), factor_name="momentum_12_1")
+        self.assertEqual(f.item_type, "factor")
+        self.assertEqual(f.factor_name, "momentum_12_1")
+        self.assertIsNone(f.universe)
+
+    def test_embedding_text(self):
+        f = Factor(
+            as_of=_now(),
+            source=_src(),
+            factor_name="value",
+            universe="us_equities",
+        )
+        self.assertEqual(f.embedding_text(), "factor value on us_equities")
+
+    def test_embedding_text_default_universe(self):
+        f = Factor(as_of=_now(), source=_src(), factor_name="size")
+        self.assertEqual(f.embedding_text(), "factor size on unspecified")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge/test_graph.py
+++ b/tests/knowledge/test_graph.py
@@ -1,0 +1,22 @@
+"""Tests for knowledge._graph — placeholder semantics."""
+
+import unittest
+
+from quantmind.knowledge._base import BaseKnowledge
+from quantmind.knowledge._graph import GraphKnowledge
+
+
+class GraphKnowledgePlaceholderTests(unittest.TestCase):
+    def test_class_inherits_base(self):
+        # The class itself exists so users can type-hint it.
+        self.assertTrue(issubclass(GraphKnowledge, BaseKnowledge))
+
+    def test_subclassing_blocked(self):
+        with self.assertRaises(NotImplementedError):
+
+            class _AttemptedGraph(GraphKnowledge):
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge/test_news.py
+++ b/tests/knowledge/test_news.py
@@ -5,30 +5,56 @@ from datetime import datetime, timezone
 
 from pydantic import ValidationError
 
+from quantmind.knowledge._base import SourceRef
 from quantmind.knowledge.news import News
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 26, tzinfo=timezone.utc)
+
+
+def _src() -> SourceRef:
+    return SourceRef(kind="rss", uri="https://feeds.example.com/markets")
 
 
 class NewsTests(unittest.TestCase):
     def test_minimal(self):
         n = News(
-            as_of=datetime(2026, 4, 26, tzinfo=timezone.utc),
+            as_of=_now(),
+            source=_src(),
             headline="Fed holds rates",
             event_type="monetary_policy",
-            timestamp=datetime(2026, 4, 26, tzinfo=timezone.utc),
+            timestamp=_now(),
         )
         self.assertEqual(n.item_type, "news")
         self.assertEqual(n.sentiment, "neutral")
         self.assertEqual(n.materiality, "medium")
+        self.assertEqual(n.entities, [])
 
     def test_sentiment_enum(self):
         with self.assertRaises(ValidationError):
             News(
-                as_of=datetime(2026, 4, 26, tzinfo=timezone.utc),
+                as_of=_now(),
+                source=_src(),
                 headline="x",
                 event_type="x",
-                timestamp=datetime(2026, 4, 26, tzinfo=timezone.utc),
+                timestamp=_now(),
                 sentiment="ecstatic",  # type: ignore[arg-type]
             )
+
+    def test_embedding_text(self):
+        n = News(
+            as_of=_now(),
+            source=_src(),
+            headline="Fed holds rates",
+            event_type="monetary_policy",
+            timestamp=_now(),
+            entities=["FOMC", "USD"],
+        )
+        self.assertEqual(
+            n.embedding_text(),
+            "Fed holds rates\nmonetary_policy\nFOMC, USD",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/knowledge/test_news.py
+++ b/tests/knowledge/test_news.py
@@ -1,0 +1,35 @@
+"""Tests for knowledge.news."""
+
+import unittest
+from datetime import datetime, timezone
+
+from pydantic import ValidationError
+
+from quantmind.knowledge.news import News
+
+
+class NewsTests(unittest.TestCase):
+    def test_minimal(self):
+        n = News(
+            as_of=datetime(2026, 4, 26, tzinfo=timezone.utc),
+            headline="Fed holds rates",
+            event_type="monetary_policy",
+            timestamp=datetime(2026, 4, 26, tzinfo=timezone.utc),
+        )
+        self.assertEqual(n.item_type, "news")
+        self.assertEqual(n.sentiment, "neutral")
+        self.assertEqual(n.materiality, "medium")
+
+    def test_sentiment_enum(self):
+        with self.assertRaises(ValidationError):
+            News(
+                as_of=datetime(2026, 4, 26, tzinfo=timezone.utc),
+                headline="x",
+                event_type="x",
+                timestamp=datetime(2026, 4, 26, tzinfo=timezone.utc),
+                sentiment="ecstatic",  # type: ignore[arg-type]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge/test_paper.py
+++ b/tests/knowledge/test_paper.py
@@ -1,35 +1,108 @@
-"""Tests for knowledge.paper."""
+"""Tests for knowledge.paper — Paper (Tree) + PaperKnowledgeCard (Flatten)."""
 
 import unittest
 from datetime import datetime, timezone
+from uuid import uuid4
 
-from quantmind.knowledge.paper import Paper
+from quantmind.knowledge._base import SourceRef
+from quantmind.knowledge._tree import TreeNode
+from quantmind.knowledge.paper import Paper, PaperKnowledgeCard
 
 
-class PaperTests(unittest.TestCase):
+def _now() -> datetime:
+    return datetime(2026, 4, 1, tzinfo=timezone.utc)
+
+
+def _src() -> SourceRef:
+    return SourceRef(kind="arxiv", uri="arxiv:2604.12345")
+
+
+def _single_node_paper(**overrides) -> Paper:
+    root_id = uuid4()
+    root = TreeNode(
+        node_id=root_id,
+        parent_id=None,
+        position=0,
+        title="On Cross-Sectional Momentum",
+        summary="Methodology for momentum factor on US equities.",
+    )
+    return Paper(
+        as_of=_now(),
+        source=_src(),
+        root_node_id=root_id,
+        nodes={root_id: root},
+        **overrides,
+    )
+
+
+class PaperTreeTests(unittest.TestCase):
     def test_minimal(self):
-        p = Paper(
-            as_of=datetime(2026, 4, 1, tzinfo=timezone.utc),
-            summary="A momentum study.",
-        )
+        p = _single_node_paper()
         self.assertEqual(p.item_type, "paper")
-        self.assertEqual(p.summary, "A momentum study.")
-        self.assertEqual(p.key_findings, [])
+        self.assertIsNone(p.arxiv_id)
+        self.assertEqual(p.authors, [])
         self.assertEqual(p.asset_classes, [])
+        self.assertEqual(p.root().title, "On Cross-Sectional Momentum")
+
+    def test_metadata(self):
+        p = _single_node_paper(
+            arxiv_id="2604.12345",
+            authors=["A. Smith", "B. Jones"],
+            asset_classes=["equities"],
+        )
+        self.assertEqual(p.arxiv_id, "2604.12345")
+        self.assertEqual(p.authors, ["A. Smith", "B. Jones"])
+        self.assertEqual(p.asset_classes, ["equities"])
+
+    def test_embedding_text_uses_root(self):
+        p = _single_node_paper()
+        self.assertEqual(
+            p.embedding_text(),
+            "On Cross-Sectional Momentum\n"
+            "Methodology for momentum factor on US equities.",
+        )
+
+
+class PaperKnowledgeCardTests(unittest.TestCase):
+    def test_minimal(self):
+        paper_id = uuid4()
+        card = PaperKnowledgeCard(
+            as_of=_now(),
+            source=_src(),
+            paper_id=paper_id,
+            summary="A momentum study on US equities.",
+        )
+        self.assertEqual(card.item_type, "paper_card")
+        self.assertEqual(card.paper_id, paper_id)
+        self.assertEqual(card.key_findings, [])
+        self.assertEqual(card.asset_classes, [])
 
     def test_full(self):
-        p = Paper(
-            as_of=datetime(2026, 4, 1, tzinfo=timezone.utc),
+        card = PaperKnowledgeCard(
+            as_of=_now(),
+            source=_src(),
+            paper_id=uuid4(),
             summary="s",
             methodology="m",
             key_findings=["f1", "f2"],
             limitations=["l1"],
             asset_classes=["equities"],
-            authors=["A. Smith"],
-            arxiv_id="2604.12345",
         )
-        self.assertEqual(p.arxiv_id, "2604.12345")
-        self.assertEqual(p.asset_classes, ["equities"])
+        self.assertEqual(card.methodology, "m")
+        self.assertEqual(card.key_findings, ["f1", "f2"])
+
+    def test_embedding_text(self):
+        card = PaperKnowledgeCard(
+            as_of=_now(),
+            source=_src(),
+            paper_id=uuid4(),
+            summary="momentum study",
+            key_findings=["beats SPX", "robust to costs"],
+        )
+        self.assertEqual(
+            card.embedding_text(),
+            "momentum study\nbeats SPX robust to costs",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/knowledge/test_paper.py
+++ b/tests/knowledge/test_paper.py
@@ -1,0 +1,36 @@
+"""Tests for knowledge.paper."""
+
+import unittest
+from datetime import datetime, timezone
+
+from quantmind.knowledge.paper import Paper
+
+
+class PaperTests(unittest.TestCase):
+    def test_minimal(self):
+        p = Paper(
+            as_of=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            summary="A momentum study.",
+        )
+        self.assertEqual(p.item_type, "paper")
+        self.assertEqual(p.summary, "A momentum study.")
+        self.assertEqual(p.key_findings, [])
+        self.assertEqual(p.asset_classes, [])
+
+    def test_full(self):
+        p = Paper(
+            as_of=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            summary="s",
+            methodology="m",
+            key_findings=["f1", "f2"],
+            limitations=["l1"],
+            asset_classes=["equities"],
+            authors=["A. Smith"],
+            arxiv_id="2604.12345",
+        )
+        self.assertEqual(p.arxiv_id, "2604.12345")
+        self.assertEqual(p.asset_classes, ["equities"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge/test_roundtrip.py
+++ b/tests/knowledge/test_roundtrip.py
@@ -1,0 +1,142 @@
+"""JSON round-trip tests for every concrete knowledge schema.
+
+These tests guard the contract that powers ``Agent(output_type=...)``: the
+LLM returns JSON, the Agents SDK calls ``model_validate_json`` on it, and
+the result must equal what we would have produced via ``model_dump_json``.
+Tree schemas are the trickiest because of ``dict[UUID, TreeNode]`` keys.
+"""
+
+import unittest
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from quantmind.knowledge import (
+    Earnings,
+    ExtractionRef,
+    Factor,
+    News,
+    Paper,
+    PaperKnowledgeCard,
+    SourceRef,
+    Thesis,
+    TreeNode,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 27, tzinfo=timezone.utc)
+
+
+def _src(kind: str = "manual") -> SourceRef:
+    return SourceRef(kind=kind)  # type: ignore[arg-type]
+
+
+def _ext() -> ExtractionRef:
+    return ExtractionRef(flow="test_flow", model="gpt-4o", extracted_at=_now())
+
+
+class FlattenRoundTripTests(unittest.TestCase):
+    def test_news(self):
+        n = News(
+            as_of=_now(),
+            source=_src("rss"),
+            extraction=_ext(),
+            headline="Fed holds rates",
+            event_type="monetary_policy",
+            timestamp=_now(),
+            entities=["FOMC"],
+        )
+        revived = News.model_validate_json(n.model_dump_json())
+        self.assertEqual(n, revived)
+
+    def test_earnings(self):
+        e = Earnings(
+            as_of=_now(),
+            source=_src("http"),
+            ticker="AAPL",
+            period="2026Q1",
+            revenue=120.0,
+            eps=1.55,
+            surprise_flags=["eps_beat"],
+        )
+        revived = Earnings.model_validate_json(e.model_dump_json())
+        self.assertEqual(e, revived)
+
+    def test_paper_knowledge_card(self):
+        card = PaperKnowledgeCard(
+            as_of=_now(),
+            source=_src("arxiv"),
+            paper_id=uuid4(),
+            summary="momentum study",
+            methodology="cross-sectional",
+            key_findings=["beats SPX"],
+            asset_classes=["equities"],
+        )
+        revived = PaperKnowledgeCard.model_validate_json(card.model_dump_json())
+        self.assertEqual(card, revived)
+
+    def test_factor(self):
+        f = Factor(
+            as_of=_now(),
+            source=_src(),
+            factor_name="value",
+            universe="us_equities",
+        )
+        revived = Factor.model_validate_json(f.model_dump_json())
+        self.assertEqual(f, revived)
+
+    def test_thesis(self):
+        t = Thesis(as_of=_now(), source=_src(), claim="USD softens")
+        revived = Thesis.model_validate_json(t.model_dump_json())
+        self.assertEqual(t, revived)
+
+
+class TreeRoundTripTests(unittest.TestCase):
+    def _build_paper(self) -> Paper:
+        leaf_id = uuid4()
+        root_id = uuid4()
+        leaf = TreeNode(
+            node_id=leaf_id,
+            parent_id=root_id,
+            position=0,
+            title="Methodology",
+            summary="cross-sectional momentum signal",
+            content="We rank stocks by 12-1 month returns ...",
+        )
+        root = TreeNode(
+            node_id=root_id,
+            parent_id=None,
+            position=0,
+            title="Cross-Sectional Momentum",
+            summary="paper-level summary",
+            children_ids=[leaf_id],
+        )
+        return Paper(
+            as_of=_now(),
+            source=_src("arxiv"),
+            extraction=_ext(),
+            arxiv_id="2604.12345",
+            authors=["A. Smith"],
+            asset_classes=["equities"],
+            root_node_id=root_id,
+            nodes={root_id: root, leaf_id: leaf},
+        )
+
+    def test_paper_dict_uuid_keys_round_trip(self):
+        p = self._build_paper()
+        revived = Paper.model_validate_json(p.model_dump_json())
+        self.assertEqual(p, revived)
+        # UUID keys are preserved through the JSON detour.
+        self.assertEqual(set(revived.nodes.keys()), set(p.nodes.keys()))
+        # Helper still works on the revived instance.
+        self.assertEqual(revived.root().title, "Cross-Sectional Momentum")
+
+    def test_paper_walk_dfs_after_round_trip(self):
+        p = self._build_paper()
+        revived = Paper.model_validate_json(p.model_dump_json())
+        titles = [n.title for n in revived.walk_dfs()]
+        self.assertEqual(titles, ["Cross-Sectional Momentum", "Methodology"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge/test_thesis.py
+++ b/tests/knowledge/test_thesis.py
@@ -1,0 +1,30 @@
+"""Tests for knowledge.thesis (stub schema)."""
+
+import unittest
+from datetime import datetime, timezone
+
+from quantmind.knowledge._base import SourceRef
+from quantmind.knowledge.thesis import Thesis
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 27, tzinfo=timezone.utc)
+
+
+def _src() -> SourceRef:
+    return SourceRef(kind="manual")
+
+
+class ThesisTests(unittest.TestCase):
+    def test_minimal(self):
+        t = Thesis(as_of=_now(), source=_src(), claim="USD weakens in H2 2026")
+        self.assertEqual(t.item_type, "thesis")
+        self.assertEqual(t.claim, "USD weakens in H2 2026")
+
+    def test_embedding_text_returns_claim(self):
+        t = Thesis(as_of=_now(), source=_src(), claim="rates higher for longer")
+        self.assertEqual(t.embedding_text(), "rates higher for longer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge/test_tree.py
+++ b/tests/knowledge/test_tree.py
@@ -1,0 +1,152 @@
+"""Tests for knowledge._tree — TreeNode + TreeKnowledge."""
+
+import unittest
+from datetime import datetime, timezone
+from typing import Literal
+from uuid import UUID, uuid4
+
+from pydantic import ValidationError
+
+from quantmind.knowledge._base import SourceRef
+from quantmind.knowledge._tree import TreeKnowledge, TreeNode
+
+
+def _now() -> datetime:
+    return datetime(2026, 4, 26, tzinfo=timezone.utc)
+
+
+def _src() -> SourceRef:
+    return SourceRef(kind="manual")
+
+
+class _SampleTree(TreeKnowledge):
+    item_type: Literal["sample_tree"] = "sample_tree"  # pyright: ignore[reportIncompatibleVariableOverride]
+
+
+def _make_tree() -> _SampleTree:
+    """Three-level tree:
+
+    root
+    ├── a
+    │   ├── a1
+    │   └── a2
+    └── b
+    """
+    a1_id, a2_id = uuid4(), uuid4()
+    a_id = uuid4()
+    b_id = uuid4()
+    root_id = uuid4()
+    a1 = TreeNode(
+        node_id=a1_id,
+        parent_id=a_id,
+        position=0,
+        title="A1",
+        summary="leaf a1",
+    )
+    a2 = TreeNode(
+        node_id=a2_id,
+        parent_id=a_id,
+        position=1,
+        title="A2",
+        summary="leaf a2",
+    )
+    a = TreeNode(
+        node_id=a_id,
+        parent_id=root_id,
+        position=0,
+        title="A",
+        summary="branch a",
+        children_ids=[a1_id, a2_id],
+    )
+    b = TreeNode(
+        node_id=b_id,
+        parent_id=root_id,
+        position=1,
+        title="B",
+        summary="leaf b",
+    )
+    root = TreeNode(
+        node_id=root_id,
+        parent_id=None,
+        position=0,
+        title="Root",
+        summary="root summary",
+        children_ids=[a_id, b_id],
+    )
+    return _SampleTree(
+        as_of=_now(),
+        source=_src(),
+        root_node_id=root_id,
+        nodes={n.node_id: n for n in [root, a, b, a1, a2]},
+    )
+
+
+class TreeNodeTests(unittest.TestCase):
+    def test_minimal(self):
+        n = TreeNode(title="t", summary="s")
+        self.assertEqual(n.title, "t")
+        self.assertEqual(n.summary, "s")
+        self.assertIsNone(n.content)
+        self.assertEqual(n.children_ids, [])
+        self.assertIsInstance(n.node_id, UUID)
+
+    def test_default_node_id_unique(self):
+        a = TreeNode(title="t", summary="s")
+        b = TreeNode(title="t", summary="s")
+        self.assertNotEqual(a.node_id, b.node_id)
+
+    def test_extra_forbidden(self):
+        with self.assertRaises(ValidationError):
+            TreeNode(title="t", summary="s", garbage=1)  # type: ignore[call-arg]
+
+    def test_frozen(self):
+        n = TreeNode(title="t", summary="s")
+        with self.assertRaises(ValidationError):
+            n.title = "z"  # type: ignore[misc]
+
+    def test_default_embedding_text(self):
+        n = TreeNode(title="Methodology", summary="We use X to do Y.")
+        self.assertEqual(n.embedding_text(), "Methodology\nWe use X to do Y.")
+
+
+class TreeKnowledgeTests(unittest.TestCase):
+    def test_root_helper(self):
+        tree = _make_tree()
+        root = tree.root()
+        self.assertEqual(root.title, "Root")
+        self.assertIsNone(root.parent_id)
+
+    def test_children_of(self):
+        tree = _make_tree()
+        children = tree.children_of(tree.root_node_id)
+        titles = [c.title for c in children]
+        self.assertEqual(titles, ["A", "B"])
+
+    def test_walk_dfs_order(self):
+        tree = _make_tree()
+        order = [n.title for n in tree.walk_dfs()]
+        self.assertEqual(order, ["Root", "A", "A1", "A2", "B"])
+
+    def test_find_path_root(self):
+        tree = _make_tree()
+        path = tree.find_path(tree.root_node_id)
+        self.assertEqual([n.title for n in path], ["Root"])
+
+    def test_find_path_leaf(self):
+        tree = _make_tree()
+        # Find a1 from the tree's flat node map.
+        a1 = next(n for n in tree.nodes.values() if n.title == "A1")
+        path = tree.find_path(a1.node_id)
+        self.assertEqual([n.title for n in path], ["Root", "A", "A1"])
+
+    def test_find_path_unknown(self):
+        tree = _make_tree()
+        self.assertEqual(tree.find_path(uuid4()), [])
+
+    def test_embedding_text_uses_root(self):
+        tree = _make_tree()
+        self.assertEqual(tree.embedding_text(), "Root\nroot summary")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Lands `quantmind/knowledge/` as a **data standard with three shapes** plus the `quantmind/configs/` skeleton. The knowledge schema is the contract every downstream module (flows, utils, retrieval, future `KnowledgeStore`) builds on; this PR ships schema only — the storage layer is specified but lands separately.

### `quantmind/knowledge/` — three-shape data standard

- **`BaseKnowledge`** — root for every shape. Carries `id` (auto UUID), `item_type`, `schema_version`, `as_of` (mandatory), `created_at`, `source: SourceRef` (typed provenance — no bare strings), `extraction: ExtractionRef | None`, `confidence`, `citations`, `tags`, `disclaimers`, plus an `embedding_text()` contract that subclasses MUST override so the future store knows what to embed.
- **`FlattenKnowledge`** — atomic-card shape. Subclasses: `News`, `Earnings`, `PaperKnowledgeCard`.
- **`TreeKnowledge`** — hierarchical-artifact shape. Holds `root_node_id` plus a flat `nodes: dict[UUID, TreeNode]` map. Helpers: `root()`, `children_of()`, `walk_dfs()`, `find_path()`. Default `embedding_text()` delegates to root. Subclass: `Paper` (whole paper as section tree).
- **`GraphKnowledge`** — placeholder. The class exists for type-hinting `BaseKnowledge | FlattenKnowledge | TreeKnowledge | GraphKnowledge`, but `__init_subclass__` raises `NotImplementedError` until the shape is finalised in a later PR.

`Citation` gains optional `tree_id` / `node_id` anchors for tree-rooted citations. The full design rationale (PageIndex-style navigation, embedding as pre-filter not replacement, future SQLite + `sqlite-vec` backend, Python-interface contract for `KnowledgeStore`) is captured in the local design spec.

### `quantmind/configs/`

Unchanged from the original PR3: `BaseFlowCfg` + `BaseInput` plus per-flow `<Name>FlowCfg` and `<Name>Input` discriminated unions for paper / news / earnings.

### Other changes

- `openai-agents>=0.14` added as a hard dep so `BaseFlowCfg.model_settings: ModelSettings | None` is honoured.
- `import-linter` contracts: `knowledge` is a leaf; `configs` may only depend on `knowledge`.
- `quantmind/config/registry._discover_flows_in_path` made resilient to `OSError` from `Path.rglob` (transitional code; deleted in PR5).
- `basedpyright`'s `reportIncompatibleVariableOverride` disabled so the Pydantic v2 idiom of narrowing a `str` field to `Literal[...]` in subclasses (used throughout the discriminator pattern) does not produce spurious errors.

Old `quantmind/models/{content,paper,analysis}.py` and `quantmind/config/*` stay in place; transitional `parsers/`, `sources/`, `flow/`, `llm/` still depend on them and they get deleted in PR4-PR5.

Part of #71.

## Test plan

- [x] `bash scripts/verify.sh` passes locally (259 tests, coverage 68.43% ≥ 60%)
- [ ] CI verify workflow green on the PR
- [ ] `python -c "from quantmind.knowledge import Paper, PaperKnowledgeCard, News, Earnings, FlattenKnowledge, TreeKnowledge, GraphKnowledge; print('OK')"` prints `OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>