### PR TITLE
feat: mind/memory MVP + trajectory archive (PR6 of OpenAI Agents SDK migration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ docs/superpowers/
 .coverage
 htmlcov/
 coverage.xml
+/.qm-memory/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,31 +29,33 @@ quantmind/
 Key principle: QuantMind does NOT rebuild Agent runtime, lifecycle hooks, tracing,
 multi-agent handoff, or tool framework. Those come from `openai-agents`.
 
-## Current Repository State (after PR #70 / #73 / #74 / #75 / PR5)
+## Current Repository State (after PR #70 / #73 / #74 / #75 / #76 / PR6)
 
 | Module | Status | Notes |
 |--------|--------|-------|
 | `quantmind/knowledge/` | landed (PR3) | data standard with three shapes: `FlattenKnowledge` (`News` / `Earnings` / `PaperKnowledgeCard`), `TreeKnowledge` (`Paper`), `GraphKnowledge` (placeholder); shared base = `BaseKnowledge` with typed `SourceRef` / `ExtractionRef` provenance + `embedding_text()` contract |
 | `quantmind/configs/` | landed (PR3) | `BaseFlowCfg` / `BaseInput` + per-flow cfg + discriminated-union input types |
 | `quantmind/preprocess/` | landed (PR4) | `fetch/` (`fetch_arxiv` / `fetch_url` / `resolve_doi` / `read_local_file` returning `Fetched` / `RawPaper` / `CrossrefMetadata` frozen dataclasses) + `format/` (`pdf_to_markdown` via PyMuPDF, `html_to_markdown` via trafilatura) + `clean.py` + `time.py`; leaf module — only depends on `quantmind.utils` |
-| `quantmind/flows/` | landed (PR5) | apex layer: `paper_flow` (`PaperInput` → `Paper` via SDK Agent), `batch_run` + `BatchResult` (bounded-concurrency fan-out, `memory=` rejected by design), `_runner.run_with_observability` + `_compose_hooks` + `_archive_run_artifacts` (PR6 stub); only depends on configs/knowledge/preprocess/utils + `agents` SDK |
+| `quantmind/flows/` | landed (PR5, refined PR6) | apex layer: `paper_flow` (`PaperInput` → `Paper` via SDK Agent, now wired with `memory.mcp_servers()` + `memory.tools()`), `batch_run` + `BatchResult` (bounded-concurrency fan-out, `memory=` rejected by design), `_runner.run_with_observability` (PR6: `try/finally` invokes `MemoryRunHooks.persist`); depends on configs/knowledge/preprocess/utils + `mind` + `agents` SDK |
 | `quantmind/magic.py` | landed (PR5) | `resolve_magic_input(natural_language, *, target_flow, ...) -> (input, cfg)` plus `preview_resolve` debug helper; introspects flow signatures and runs a lightweight resolver Agent with `output_type=ResolvedFlowConfig[InputT, CfgT]` |
+| `quantmind/mind/memory/` | landed (PR6) | `Memory` Protocol (granular: `tools()` / `mcp_servers()` / `run_hooks()` / `reset()`) + `FilesystemMemory` MVP (MCP filesystem server via `npx`) + `MemoryRunHooks` accumulator + `RunRecord` trajectory archive under `<memory_dir>/runs/` (atomic write + `runs.jsonl` index); sixth import-linter contract pins `mind` as bounded |
 | `quantmind/utils/logger.py` | permanent | only general-purpose utility |
 
 PR5 removed the transitional packages (`quantmind/{flow,llm,config,models}/`
 and their tests under `tests/{config,models}/`); PR4 had already removed
 `quantmind/parsers/`, `quantmind/sources/`, and `quantmind/utils/tmp.py`.
-The codebase has now converged to the five permanent module roots
-(`flows/`, `configs/`, `knowledge/`, `preprocess/`, `mind/`) plus
-`magic.py` and `utils/`.
+PR6 added `quantmind/mind/memory/` and tightened the `paper_flow` /
+`_runner` signatures to consume the `Memory` Protocol directly.
+
+The codebase now has six permanent module roots (`flows/`, `configs/`,
+`knowledge/`, `preprocess/`, `mind/`) plus `magic.py` and `utils/`.
 
 `basedpyright` runs in standard mode across the whole `quantmind/`
-package — there are no per-module exclusions left. Five `import-linter`
+package — there are no per-module exclusions left. Six `import-linter`
 contracts pin the dependency graph: `utils` and `knowledge` are leaves,
 `configs` only depends on `knowledge`, `preprocess` only depends on
-`utils`, and `flows + magic` is the apex (cannot import the deleted
-transitional packages, which are listed in the contract as a tripwire
-against accidental re-introduction).
+`utils`, `flows + magic` is the apex, and `mind` is a bounded subsystem
+(cannot import `flows` / `magic` / the deleted transitional packages).
 
 ## Development Commands
 
@@ -173,7 +175,7 @@ issue instead.
 | #73 (merged) | Golden Harness — `scripts/verify.sh` with ruff + basedpyright + import-linter + pytest --cov, plus matching CI |
 | #74 (merged) | `knowledge/` data standard (Flatten / Tree / Graph shapes) + `configs/` skeleton; `openai-agents>=0.14` introduced for `BaseFlowCfg.model_settings` |
 | #75 (merged) | `preprocess/` (fetch + format two layers); deletes `parsers/` + `sources/` + `utils/tmp.py`; coverage floor 60→65; 4th import-linter contract |
-| PR5 (this PR) | `flows/` (`paper_flow` + `batch_run` + `BatchResult` + `_runner`) + `magic.py`; deletes `quantmind/{flow,llm,config,models}/`; coverage floor 65→75; 5th import-linter contract pins `flows + magic` as apex |
-| PR6 | `mind/memory/filesystem` MVP + trajectory archive (fills `_archive_run_artifacts` stub) |
+| #76 (merged) | `flows/` (`paper_flow` + `batch_run` + `BatchResult` + `_runner`) + `magic.py`; deletes `quantmind/{flow,llm,config,models}/`; coverage floor 65→75; 5th import-linter contract pins `flows + magic` as apex |
+| PR6 (this PR) | `mind/memory/filesystem` MVP + trajectory archive: `Memory` Protocol + `FilesystemMemory` (MCP filesystem server) + `MemoryRunHooks` + `RunRecord`; tightens `paper_flow.memory` + `_runner` to consume `Memory \| None`; replaces the PR5 `_archive_run_artifacts` stub with `try/finally` invoking `MemoryRunHooks.persist`; 6th import-linter contract pins `mind` boundaries |
 | PR7 | `mind/store/` + SQLite + `sqlite-vec` MVP; introduces `preprocess/chunk.py` with `tiktoken` |
 | PR8+ | Second flow (news/earnings) / observability cookbook / longer-term modules |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,18 +61,30 @@ contracts pin the dependency graph: `utils` and `knowledge` are leaves,
 
 ### Environment
 
+One-shot bootstrap (recommended):
+
+```bash
+bash scripts/setup.sh
+```
+
+This creates `.venv`, installs Python deps (`uv pip install -e ".[dev]"`),
+and audits external (non-Python) deps via `scripts/check_system_deps.py`.
+Optional deps that are missing are reported informationally; required
+deps that are missing fail the script.
+
+Manual equivalent:
+
 ```bash
 uv venv
 source .venv/bin/activate
 uv pip install -e ".[dev]"
+.venv/bin/python scripts/check_system_deps.py   # optional audit
 ```
 
-**Optional Node.js prerequisite.** `FilesystemMemory` (in
-`quantmind/mind/memory/`) launches the MCP filesystem server via
-`npx -y @modelcontextprotocol/server-filesystem`, so any code or
-example that constructs a `FilesystemMemory` needs Node.js + `npx`
-on PATH. Skip if you do not use cross-step memory. Verify with
-`node -v` and `npx --version`.
+**Adding a new external dependency** (e.g., `tiktoken` is pip; node /
+`sqlite-vec` / etc. are external): append one row to
+`scripts/check_system_deps.py::_DEPS`. README install flow does not
+change — `scripts/setup.sh` picks it up automatically.
 
 ### Verify (canonical local check)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ issue instead.
 - ❌ Introduce class-based `BaseFlow` / plugin registry / hook discovery
 - ❌ Wrap `from agents import ...` in a QuantMind-side facade — use the SDK directly
 - ❌ Mix `batch_run` and `memory` (mutually exclusive in MVP; `batch_run` rejects
-  `memory=` at the signature layer — design doc §4.3.5)
+  `memory=` at the signature layer)
 - ❌ Use `Dict[str, Any]` in init functions; use Pydantic models
 - ❌ Add hard deps on observability platforms (Langfuse / Logfire / etc.); document
   integration via `add_trace_processor()` in user-facing cookbook only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ source .venv/bin/activate
 uv pip install -e ".[dev]"
 ```
 
+**Optional Node.js prerequisite.** `FilesystemMemory` (in
+`quantmind/mind/memory/`) launches the MCP filesystem server via
+`npx -y @modelcontextprotocol/server-filesystem`, so any code or
+example that constructs a `FilesystemMemory` needs Node.js + `npx`
+on PATH. Skip if you do not use cross-step memory. Verify with
+`node -v` and `npx --version`.
+
 ### Verify (canonical local check)
 
 `scripts/verify.sh` is the single source of truth for "is this branch

--- a/README.md
+++ b/README.md
@@ -152,6 +152,29 @@ We use [uv](https://github.com/astral-sh/uv) for fast and reliable Python packag
    uv pip install -e .
    ```
 
+5. **Optional — Install Node.js + `npx` (only if you plan to use `FilesystemMemory`):**
+
+   `FilesystemMemory` launches the MCP filesystem server through `npx`,
+   so cross-step memory examples need a Node.js toolchain. Skip this if
+   you do not call `paper_flow(..., memory=FilesystemMemory(...))`.
+
+   ```bash
+   # macOS (Homebrew)
+   brew install node
+
+   # Linux (Debian/Ubuntu)
+   curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+   sudo apt-get install -y nodejs
+
+   # Verify
+   node -v       # >= 18.x recommended
+   npx --version
+   ```
+
+   The first run of `npx -y @modelcontextprotocol/server-filesystem`
+   downloads the package into the local npm cache; subsequent runs
+   reuse it.
+
 ### 📚 Usage Examples
 
 #### Run a single paper through `paper_flow`

--- a/README.md
+++ b/README.md
@@ -146,34 +146,29 @@ We use [uv](https://github.com/astral-sh/uv) for fast and reliable Python packag
    .venv\Scripts\activate
    ```
 
-4. **Install dependencies:**
+4. **One-shot setup (recommended):**
 
    ```bash
-   uv pip install -e .
+   bash scripts/setup.sh
    ```
 
-5. **Optional — Install Node.js + `npx` (only if you plan to use `FilesystemMemory`):**
+   This creates `.venv`, installs Python deps (editable, with `[dev]`
+   extras), and audits non-Python dependencies (Node.js / `npx`,
+   etc.). Missing **required** deps fail the script with a clear hint;
+   missing **optional** deps are reported informationally so you know
+   what is unavailable (e.g., `FilesystemMemory` needs Node.js).
 
-   `FilesystemMemory` launches the MCP filesystem server through `npx`,
-   so cross-step memory examples need a Node.js toolchain. Skip this if
-   you do not call `paper_flow(..., memory=FilesystemMemory(...))`.
+   Adding a new external dependency in a future PR means appending one
+   row to `scripts/check_system_deps.py` — the install flow above
+   stays unchanged.
+
+   **Manual fallback** (equivalent to `setup.sh`):
 
    ```bash
-   # macOS (Homebrew)
-   brew install node
-
-   # Linux (Debian/Ubuntu)
-   curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
-   sudo apt-get install -y nodejs
-
-   # Verify
-   node -v       # >= 18.x recommended
-   npx --version
+   uv venv
+   uv pip install -e ".[dev]"
+   .venv/bin/python scripts/check_system_deps.py   # optional audit
    ```
-
-   The first run of `npx -y @modelcontextprotocol/server-filesystem`
-   downloads the package into the local npm cache; subsequent runs
-   reuse it.
 
 ### 📚 Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -224,10 +224,43 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+#### Persistent memory across a serial loop
+
+```python
+import asyncio
+
+from quantmind.configs.paper import ArxivIdentifier
+from quantmind.flows import paper_flow
+from quantmind.mind.memory import FilesystemMemory
+
+
+async def main() -> None:
+    mem = FilesystemMemory("./.qm-memory")
+    arxiv_ids = ["2401.12345", "2402.67890", "2403.11111"]
+    for paper_id in arxiv_ids:
+        paper = await paper_flow(
+            ArxivIdentifier(id=paper_id),
+            memory=mem,
+        )
+        print(paper.title)
+    # Trajectory records are now under ./.qm-memory/runs/.
+
+
+asyncio.run(main())
+```
+
+`FilesystemMemory` requires Node.js + `npx` on PATH (the SDK launches
+`@modelcontextprotocol/server-filesystem` over stdio). Each run also
+writes `<memory_dir>/runs/<run_id>.json` and appends a one-line
+summary to `<memory_dir>/runs.jsonl`. `FilesystemMemory` is for serial
+loops only — `batch_run` rejects `memory=` at the signature layer
+(see design doc §4.3.5).
+
 > **Note**: QuantMind is mid-migration to OpenAI Agents SDK
-> (see [#71](https://github.com/LLMQuant/quant-mind/issues/71)). PR5 lands the
-> apex layer (`flows/` + `magic.py`); the remaining work is the `mind/`
-> memory + store layer scheduled for PR6 and PR7.
+> (see [#71](https://github.com/LLMQuant/quant-mind/issues/71)). PR6 lands
+> `mind/memory/` (Memory Protocol + `FilesystemMemory` MVP + trajectory
+> archive); the remaining work is the `mind/store/` knowledge layer
+> scheduled for PR7+.
 
 ---
 
@@ -235,10 +268,11 @@ asyncio.run(main())
 
 - [x] Better `flow` design for user-friendly usage
 - [x] First production level example (Quant Paper Agent)
-- [ ] Migrate Agent layer to OpenAI Agents SDK
-- [ ] Standardize knowledge format with `knowledge/` (Pydantic-based)
+- [x] Migrate Agent layer to OpenAI Agents SDK
+- [x] Standardize knowledge format with `knowledge/` (Pydantic-based)
+- [x] Cross-step working memory (`mind/memory`) for serial document processing
 - [ ] Additional content sources (financial news, blogs, reports)
-- [ ] Cross-step working memory (`mind/memory`) for batch document processing
+- [ ] `mind/store/` — durable knowledge store with hybrid retrieval (PR7+)
 
 ---
 
@@ -252,18 +286,10 @@ QuantMind is designed with a larger vision: to become a comprehensive intelligen
 The foundation we're building today—starting with papers—will expand to encompass the entire financial information ecosystem.
 
 > [!NOTE]
-> **Future Conceptual Example (PR6 brings `FilesystemMemory`):**
->
-> ```python
-> from quantmind.configs.paper import ArxivIdentifier
-> from quantmind.flows import paper_flow
-> from quantmind.knowledge import Paper
-> from quantmind.mind.memory import FilesystemMemory  # PR6
->
-> memory = FilesystemMemory("./mem/factor-research/")
-> for arxiv_id in arxiv_ids:
->     paper: Paper = await paper_flow(ArxivIdentifier(id=arxiv_id), memory=memory)
-> ```
+> **`FilesystemMemory` landed in PR6.** See the runbook example above
+> (*Persistent memory across a serial loop*) for the canonical usage.
+> Future cognitive layers (`mind/store`, `mind/summarize_run`) build on
+> this foundation — they share the same `<memory_dir>/` layout.
 
 This future state represents our commitment to moving beyond simple data aggregation and toward genuine machine intelligence in the financial domain.
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ from quantmind.mind.memory import FilesystemMemory
 
 async def main() -> None:
     mem = FilesystemMemory("./.qm-memory")
-    arxiv_ids = ["2401.12345", "2402.67890", "2403.11111"]
+    arxiv_ids = ["1706.03762", "1810.04805", "2005.11401"]
     for paper_id in arxiv_ids:
         paper = await paper_flow(
             ArxivIdentifier(id=paper_id),
@@ -250,10 +250,11 @@ asyncio.run(main())
 ```
 
 `FilesystemMemory` requires Node.js + `npx` on PATH (the SDK launches
-`@modelcontextprotocol/server-filesystem` over stdio). Each run also
-writes `<memory_dir>/runs/<run_id>.json` and appends a one-line
-summary to `<memory_dir>/runs.jsonl`. `FilesystemMemory` is for serial
-loops only — `batch_run` rejects `memory=` at the signature layer.
+`@modelcontextprotocol/server-filesystem` over stdio). The Agent sees
+`<memory_dir>/workspace/` (`notes/` and `items/`); system trajectory
+records stay outside that MCP root under `<memory_dir>/runs/<run_id>.json`
+and `<memory_dir>/runs.jsonl`. `FilesystemMemory` is for serial loops
+only — `batch_run` rejects `memory=` at the signature layer.
 
 > **Note**: QuantMind is mid-migration to OpenAI Agents SDK
 > (see [#71](https://github.com/LLMQuant/quant-mind/issues/71)). PR6 lands

--- a/README.md
+++ b/README.md
@@ -253,8 +253,7 @@ asyncio.run(main())
 `@modelcontextprotocol/server-filesystem` over stdio). Each run also
 writes `<memory_dir>/runs/<run_id>.json` and appends a one-line
 summary to `<memory_dir>/runs.jsonl`. `FilesystemMemory` is for serial
-loops only — `batch_run` rejects `memory=` at the signature layer
-(see design doc §4.3.5).
+loops only — `batch_run` rejects `memory=` at the signature layer.
 
 > **Note**: QuantMind is mid-migration to OpenAI Agents SDK
 > (see [#71](https://github.com/LLMQuant/quant-mind/issues/71)). PR6 lands

--- a/examples/memory/01_basic.py
+++ b/examples/memory/01_basic.py
@@ -43,7 +43,7 @@ async def main() -> None:
         ),
         memory=mem,
     )
-    print(f"Extracted paper: {paper.title!r}")
+    print(f"Extracted paper: {paper.nodes[paper.root_node_id].title!r}")
 
     # Show what landed under .qm-memory/.
     print(f"\nMemory layout under {memory_dir}:")

--- a/examples/memory/01_basic.py
+++ b/examples/memory/01_basic.py
@@ -1,0 +1,62 @@
+"""01 — The shortest memory run.
+
+Builds a ``FilesystemMemory``, runs ``paper_flow`` once with it, then
+prints what the trajectory archive looks like on disk afterwards.
+
+What to look for:
+
+- ``./.qm-memory/`` is created with ``notes/`` ``items/`` ``runs/`` and
+  a seeded ``README.md`` (the agent's own usage guide for the dir).
+- One ``runs/<run_id>.json`` file lands per ``paper_flow`` call.
+- ``runs.jsonl`` gets one new line per call (a denormalised index of
+  the per-run files — handy for `jq` / `pandas`).
+
+Prerequisites: OPENAI_API_KEY in env, Node.js + npx on PATH.
+
+Run:
+    python examples/memory/01_basic.py
+"""
+
+import asyncio
+from pathlib import Path
+
+from quantmind.configs.paper import RawText
+from quantmind.flows import paper_flow
+from quantmind.mind.memory import FilesystemMemory
+
+
+async def main() -> None:
+    memory_dir = Path("./.qm-memory")
+    mem = FilesystemMemory(memory_dir)
+
+    # A tiny paper-shaped input keeps cost low; swap in
+    # ``ArxivIdentifier(id="...")`` to see a real extraction end to end.
+    paper = await paper_flow(
+        RawText(
+            text=(
+                "# Toy paper\n\n"
+                "Title: Cross-sectional momentum, simplified\n"
+                "Author: Demo\n\n"
+                "Body: We illustrate momentum on a 3-stock universe."
+            )
+        ),
+        memory=mem,
+    )
+    print(f"Extracted paper: {paper.title!r}")
+
+    # Show what landed under .qm-memory/.
+    print(f"\nMemory layout under {memory_dir}:")
+    for child in sorted(memory_dir.rglob("*")):
+        if child.is_file():
+            print(
+                f"  {child.relative_to(memory_dir)}  ({child.stat().st_size}B)"
+            )
+
+    runs_jsonl = memory_dir / "runs.jsonl"
+    if runs_jsonl.exists():
+        print(f"\nLast line of {runs_jsonl}:")
+        print(runs_jsonl.read_text().splitlines()[-1][:200] + " ...")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/memory/01_basic.py
+++ b/examples/memory/01_basic.py
@@ -5,11 +5,12 @@ prints what the trajectory archive looks like on disk afterwards.
 
 What to look for:
 
-- ``./.qm-memory/`` is created with ``notes/`` ``items/`` ``runs/`` and
+- ``./.qm-memory/workspace/`` is created with ``notes/`` ``items/`` and
   a seeded ``README.md`` (the agent's own usage guide for the dir).
-- One ``runs/<run_id>.json`` file lands per ``paper_flow`` call.
-- ``runs.jsonl`` gets one new line per call (a denormalised index of
-  the per-run files — handy for `jq` / `pandas`).
+- One ``./.qm-memory/runs/<run_id>.json`` file lands per
+  ``paper_flow`` call.
+- ``./.qm-memory/runs.jsonl`` gets one new line per call (a
+  denormalised index of the per-run files — handy for `jq` / `pandas`).
 
 Prerequisites: OPENAI_API_KEY in env, Node.js + npx on PATH.
 

--- a/examples/memory/02_serial_loop.py
+++ b/examples/memory/02_serial_loop.py
@@ -1,0 +1,75 @@
+"""02 — Serial loop sharing one FilesystemMemory.
+
+The point of cross-step memory is letting run N see what runs 1..N-1
+left behind. ``FilesystemMemory`` exposes ``notes/`` and ``items/`` to
+the Agent through an MCP filesystem server, so the Agent can list /
+read / write files there during its own turn.
+
+What to look for:
+
+- ``./.qm-memory/runs/`` accumulates one trajectory record per loop
+  iteration (3 here).
+- ``./.qm-memory/notes/`` may grow if the Agent decides to write notes
+  while extracting (it sees the seeded ``README.md`` and is encouraged
+  to do so).
+- ``./.qm-memory/runs.jsonl`` has 3 appended lines after this script.
+
+This is the "memory-accumulating workflow" pattern. ``batch_run``
+rejects ``memory=`` at the signature level — for memory accumulation
+you write the loop yourself, exactly like below.
+
+Prerequisites: OPENAI_API_KEY, Node.js + npx, network.
+
+Run:
+    python examples/memory/02_serial_loop.py
+"""
+
+import asyncio
+from pathlib import Path
+
+from quantmind.configs.paper import RawText
+from quantmind.flows import paper_flow
+from quantmind.mind.memory import FilesystemMemory
+
+_FAKE_PAPERS = [
+    (
+        "# Momentum returns 1\n"
+        "Title: Cross-sectional momentum on US equities\n"
+        "Body: Long winners short losers monthly."
+    ),
+    (
+        "# Momentum returns 2\n"
+        "Title: Time-series momentum on commodities\n"
+        "Body: 12-month look-back, monthly rebalance."
+    ),
+    (
+        "# Momentum returns 3\n"
+        "Title: Combining XS and TS momentum\n"
+        "Body: 50/50 equal weight composite."
+    ),
+]
+
+
+async def main() -> None:
+    mem = FilesystemMemory(Path("./.qm-memory"))
+
+    for idx, body in enumerate(_FAKE_PAPERS, start=1):
+        print(f"\n=== run {idx}/3 ===")
+        paper = await paper_flow(RawText(text=body), memory=mem)
+        print(f"  -> {paper.title!r}")
+
+    # Quick post-run summary.
+    runs_dir = mem.memory_dir / "runs"
+    print(
+        f"\nTrajectory files: {len(list(runs_dir.glob('*.json')))} in {runs_dir}"
+    )
+
+    notes_dir = mem.memory_dir / "notes"
+    notes = list(notes_dir.glob("*"))
+    print(f"Notes the agent left: {len(notes)} in {notes_dir}")
+    for n in notes[:5]:
+        print(f"  - {n.name}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/memory/02_serial_loop.py
+++ b/examples/memory/02_serial_loop.py
@@ -9,9 +9,9 @@ What to look for:
 
 - ``./.qm-memory/runs/`` accumulates one trajectory record per loop
   iteration (3 here).
-- ``./.qm-memory/notes/`` may grow if the Agent decides to write notes
-  while extracting (it sees the seeded ``README.md`` and is encouraged
-  to do so).
+- ``./.qm-memory/workspace/notes/`` may grow if the Agent decides to
+  write notes while extracting (it sees the seeded ``README.md`` and is
+  encouraged to do so).
 - ``./.qm-memory/runs.jsonl`` has 3 appended lines after this script.
 
 This is the "memory-accumulating workflow" pattern. ``batch_run``
@@ -64,7 +64,7 @@ async def main() -> None:
         f"\nTrajectory files: {len(list(runs_dir.glob('*.json')))} in {runs_dir}"
     )
 
-    notes_dir = mem.memory_dir / "notes"
+    notes_dir = mem.workspace / "notes"
     notes = list(notes_dir.glob("*"))
     print(f"Notes the agent left: {len(notes)} in {notes_dir}")
     for n in notes[:5]:

--- a/examples/memory/02_serial_loop.py
+++ b/examples/memory/02_serial_loop.py
@@ -56,7 +56,7 @@ async def main() -> None:
     for idx, body in enumerate(_FAKE_PAPERS, start=1):
         print(f"\n=== run {idx}/3 ===")
         paper = await paper_flow(RawText(text=body), memory=mem)
-        print(f"  -> {paper.title!r}")
+        print(f"  -> {paper.nodes[paper.root_node_id].title!r}")
 
     # Quick post-run summary.
     runs_dir = mem.memory_dir / "runs"

--- a/examples/memory/03_inspect_trajectory.py
+++ b/examples/memory/03_inspect_trajectory.py
@@ -1,0 +1,59 @@
+"""03 — Read trajectory archive offline.
+
+After 01 / 02 have run, this script needs no network and no npx — it
+opens ``runs.jsonl`` and aggregates the ``RunRecord`` fields so you
+can see exactly what ``MemoryRunHooks`` captured: timing, token usage,
+LLM call breakdown, tool calls.
+
+This is also the right shape for building dashboards / cost reports
+later: each line is one self-contained run record.
+
+Run:
+    python examples/memory/03_inspect_trajectory.py ./.qm-memory
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    memory_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "./.qm-memory")
+    runs_jsonl = memory_dir / "runs.jsonl"
+    if not runs_jsonl.exists():
+        print(f"No {runs_jsonl}. Run 01_basic.py or 02_serial_loop.py first.")
+        sys.exit(1)
+
+    records = [
+        json.loads(line) for line in runs_jsonl.read_text().splitlines() if line
+    ]
+    print(f"Loaded {len(records)} run record(s) from {runs_jsonl}\n")
+
+    # Per-run summary.
+    for r in records:
+        toks = r["tokens_total"]
+        print(
+            f"  {r['run_id']}  "
+            f"workflow={r['workflow_name']}  "
+            f"duration={r['duration_seconds']:.2f}s  "
+            f"in={toks['input']}/out={toks['output']}  "
+            f"llm_calls={len(r['llm_calls'])}  "
+            f"tool_calls={len(r['tool_calls'])}  "
+            f"error={r['error']!r}"
+        )
+
+    # Aggregate.
+    total_in = sum(r["tokens_total"]["input"] for r in records)
+    total_out = sum(r["tokens_total"]["output"] for r in records)
+    total_dur = sum(r["duration_seconds"] for r in records)
+    n_failed = sum(1 for r in records if r["error"])
+    print()
+    print(
+        f"Aggregate: tokens_in={total_in} tokens_out={total_out} "
+        f"total_duration={total_dur:.2f}s "
+        f"failed={n_failed}/{len(records)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/memory/03_inspect_trajectory.py
+++ b/examples/memory/03_inspect_trajectory.py
@@ -46,7 +46,7 @@ def main() -> None:
     total_in = sum(r["tokens_total"]["input"] for r in records)
     total_out = sum(r["tokens_total"]["output"] for r in records)
     total_dur = sum(r["duration_seconds"] for r in records)
-    n_failed = sum(1 for r in records if r["error"])
+    n_failed = sum(1 for r in records if r["error"] is not None)
     print()
     print(
         f"Aggregate: tokens_in={total_in} tokens_out={total_out} "

--- a/examples/memory/04_custom_run_hooks.py
+++ b/examples/memory/04_custom_run_hooks.py
@@ -93,7 +93,7 @@ async def main() -> None:
         memory=mem,
         extra_run_hooks=[ConsoleLoggerHooks()],
     )
-    print(f"\nExtracted: {paper.title!r}")
+    print(f"\nExtracted: {paper.nodes[paper.root_node_id].title!r}")
     print(
         f"\nTrajectory file: "
         f"{sorted((mem.memory_dir / 'runs').glob('*.json'))[-1]}"

--- a/examples/memory/04_custom_run_hooks.py
+++ b/examples/memory/04_custom_run_hooks.py
@@ -1,0 +1,95 @@
+"""04 — Custom RunHooks composing with MemoryRunHooks.
+
+``paper_flow`` accepts ``extra_run_hooks=[...]`` so you can attach
+your own ``RunHooks`` (logger, metrics emitter, slack ping, ...)
+alongside the built-in ``MemoryRunHooks`` that ``FilesystemMemory``
+contributes. The runner composes them all into one fan-out hook that
+fires every lifecycle event for every registered hook in registration
+order.
+
+What to look for:
+
+- ``[memory]`` lines printed by the built-in MemoryRunHooks aren't
+  visible (it accumulates silently, then writes ``runs/<id>.json``
+  in ``finally``).
+- ``[my-logger]`` lines below come from ``ConsoleLoggerHooks``, the
+  custom hook we plug in here.
+
+Prerequisites: OPENAI_API_KEY, Node.js + npx.
+
+Run:
+    python examples/memory/04_custom_run_hooks.py
+"""
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from agents import RunHooks
+
+from quantmind.configs.paper import RawText
+from quantmind.flows import paper_flow
+from quantmind.mind.memory import FilesystemMemory
+
+
+class ConsoleLoggerHooks(RunHooks[Any]):
+    """Tiny example hook that prints lifecycle events to stdout."""
+
+    async def on_agent_start(self, context: Any, agent: Any) -> None:
+        print(
+            f"[my-logger] agent start name={agent.name!r} model={agent.model!r}"
+        )
+
+    async def on_llm_start(self, *_: Any, **__: Any) -> None:
+        print("[my-logger] llm start")
+
+    async def on_llm_end(self, context: Any, agent: Any, response: Any) -> None:
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            print(
+                f"[my-logger] llm end tokens_in={getattr(usage, 'input_tokens', 0)} "
+                f"tokens_out={getattr(usage, 'output_tokens', 0)}"
+            )
+        else:
+            print("[my-logger] llm end (no usage info)")
+
+    async def on_tool_start(self, context: Any, agent: Any, tool: Any) -> None:
+        print(f"[my-logger] tool start name={getattr(tool, 'name', '?')!r}")
+
+    async def on_tool_end(
+        self, context: Any, agent: Any, tool: Any, result: Any
+    ) -> None:
+        snippet = (
+            (str(result)[:60] + "...") if len(str(result)) > 60 else result
+        )
+        print(
+            f"[my-logger] tool end name={getattr(tool, 'name', '?')!r} "
+            f"result={snippet!r}"
+        )
+
+    async def on_agent_end(self, context: Any, agent: Any, output: Any) -> None:
+        print(f"[my-logger] agent end output_type={type(output).__name__}")
+
+
+async def main() -> None:
+    mem = FilesystemMemory(Path("./.qm-memory"))
+
+    paper = await paper_flow(
+        RawText(
+            text=(
+                "# Toy paper\n\nTitle: Custom-hook demo\n\n"
+                "Body: Show that user RunHooks fire alongside MemoryRunHooks."
+            )
+        ),
+        memory=mem,
+        extra_run_hooks=[ConsoleLoggerHooks()],
+    )
+    print(f"\nExtracted: {paper.title!r}")
+    print(
+        f"\nTrajectory file: "
+        f"{sorted((mem.memory_dir / 'runs').glob('*.json'))[-1]}"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/memory/04_custom_run_hooks.py
+++ b/examples/memory/04_custom_run_hooks.py
@@ -70,6 +70,15 @@ class ConsoleLoggerHooks(RunHooks[Any]):
     async def on_agent_end(self, context: Any, agent: Any, output: Any) -> None:
         print(f"[my-logger] agent end output_type={type(output).__name__}")
 
+    async def on_handoff(
+        self, context: Any, from_agent: Any, to_agent: Any
+    ) -> None:
+        print(
+            f"[my-logger] handoff "
+            f"{getattr(from_agent, 'name', '?')!r} -> "
+            f"{getattr(to_agent, 'name', '?')!r}"
+        )
+
 
 async def main() -> None:
     mem = FilesystemMemory(Path("./.qm-memory"))

--- a/examples/memory/05_deepseek.py
+++ b/examples/memory/05_deepseek.py
@@ -59,7 +59,10 @@ async def main() -> None:
         cfg=cfg,
         memory=mem,
     )
-    print(f"Extracted paper: {paper.title!r}")
+    root = paper.nodes[paper.root_node_id]
+    print(f"Extracted paper: {root.title!r}")
+    print(f"  authors: {list(paper.authors)}")
+    print(f"  nodes:   {len(paper.nodes)}")
 
     # Sanity-check that the trajectory record landed and captured
     # provider-correct token usage.

--- a/examples/memory/05_deepseek.py
+++ b/examples/memory/05_deepseek.py
@@ -1,0 +1,71 @@
+"""05 — Same flow, DeepSeek model. Only the model string changes.
+
+This is the headline ergonomic claim of QuantMind's provider layer:
+to point the flow at a different LLM provider, you change ONE thing
+on the cfg:
+
+    PaperFlowCfg(model="deepseek-chat")     # vs "gpt-4o"
+
+QuantMind's provider auto-detector (``quantmind.flows._providers``)
+reads the model-name prefix, looks up the right SDK client class
+(Chat Completions for DeepSeek, Responses for OpenAI), resolves the
+API key from the matching env var (``DEEPSEEK_API_KEY``), forces
+``tracing_disabled=True`` so the SDK does not try to upload traces
+to ``platform.openai.com``, and hands a fully-built Model object to
+the Agent.
+
+Adding a new provider in the future means appending one row to
+``_PROVIDERS`` — this example file does not change.
+
+Prerequisites:
+
+- ``bash scripts/setup.sh`` already run (creates .venv, installs deps,
+  audits node/npx).
+- ``export DEEPSEEK_API_KEY="sk-..."`` in your shell (or .env).
+- Node.js + ``npx`` on PATH for ``FilesystemMemory`` to launch its
+  MCP filesystem server. ``scripts/check_system_deps.py`` confirms
+  this for you.
+
+Run:
+    python examples/memory/05_deepseek.py
+"""
+
+import asyncio
+from pathlib import Path
+
+from quantmind.configs import PaperFlowCfg
+from quantmind.configs.paper import RawText
+from quantmind.flows import paper_flow
+from quantmind.mind.memory import FilesystemMemory
+
+
+async def main() -> None:
+    mem = FilesystemMemory(Path("./.qm-memory"))
+
+    # *** This is the entire provider switch. ***
+    # No `set_default_openai_client`, no `AsyncOpenAI(...)` boilerplate,
+    # no `set_tracing_disabled(True)`. The flow handles it internally.
+    cfg = PaperFlowCfg(model="deepseek-chat")
+
+    paper = await paper_flow(
+        RawText(
+            text=(
+                "# Toy paper for DeepSeek smoke test\n\n"
+                "Title: Cross-sectional momentum, simplified\n"
+                "Author: Demo\n\n"
+                "Body: We illustrate momentum on a 3-stock universe."
+            )
+        ),
+        cfg=cfg,
+        memory=mem,
+    )
+    print(f"Extracted paper: {paper.title!r}")
+
+    # Sanity-check that the trajectory record landed and captured
+    # provider-correct token usage.
+    runs = sorted((mem.memory_dir / "runs").glob("*.json"))
+    print(f"\nTrajectory file: {runs[-1]}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -1,0 +1,45 @@
+# `mind/memory` examples
+
+Small runnable scripts that walk you through `FilesystemMemory` +
+`MemoryRunHooks` end to end. Each one is self-contained — read the
+top-of-file comment block for what it shows.
+
+## Prerequisites
+
+- `pip install -e ".[dev]"` (so `quantmind` is importable).
+- `OPENAI_API_KEY` set in your shell (the real Agent run uses an LLM).
+- Node.js + `npx` on PATH — `FilesystemMemory` launches
+  `@modelcontextprotocol/server-filesystem` over stdio. Examples 01,
+  02, and 04 spawn a real MCP subprocess; example 03 only reads disk.
+
+## What each script demonstrates
+
+| # | Script | What you learn |
+|---|--------|----------------|
+| 01 | `01_basic.py` | The shortest possible memory run: build a `FilesystemMemory`, pass it to `paper_flow`, then look at the disk layout that gets created (`notes/`, `items/`, `runs/`, `runs.jsonl`). |
+| 02 | `02_serial_loop.py` | Process several inputs in a serial `for` loop sharing one `FilesystemMemory`. Each run can read what previous runs left in `notes/` via the MCP filesystem server. (`batch_run` rejects `memory=` by design — for memory-accumulating workflows, you write the loop yourself.) |
+| 03 | `03_inspect_trajectory.py` | Disk-only analysis: open `runs.jsonl`, parse the `RunRecord` JSON, and aggregate tokens / durations across runs. No network or `npx` needed. |
+| 04 | `04_custom_run_hooks.py` | Compose your own `RunHooks` (e.g., a custom logger) alongside the built-in `MemoryRunHooks` via the `extra_run_hooks=` kwarg. Both hooks fire for every lifecycle event in the order you registered them. |
+
+## Run them
+
+```bash
+# from the repo root, after installing
+python examples/memory/01_basic.py
+python examples/memory/02_serial_loop.py
+python examples/memory/03_inspect_trajectory.py ./.qm-memory
+python examples/memory/04_custom_run_hooks.py
+```
+
+All four examples write under `./.qm-memory/` (a directory created
+under your current working directory). Delete it freely between runs;
+nothing is shared with your other projects.
+
+## A note on `cfg.archive_trajectory`
+
+`FilesystemMemory.run_hooks()` returns the `MemoryRunHooks` instance
+that produces `runs/<run_id>.json` and the `runs.jsonl` index. The
+runner only attaches it when `cfg.archive_trajectory` is `True`
+(the default). If you set it to `False`, the agent still gets the
+`mcp_servers` + `tools` from your `Memory` (so it can read previous
+notes) — only the trajectory archive is suppressed.

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -16,8 +16,8 @@ top-of-file comment block for what it shows.
 
 | # | Script | What you learn |
 |---|--------|----------------|
-| 01 | `01_basic.py` | The shortest possible memory run: build a `FilesystemMemory`, pass it to `paper_flow`, then look at the disk layout that gets created (`notes/`, `items/`, `runs/`, `runs.jsonl`). |
-| 02 | `02_serial_loop.py` | Process several inputs in a serial `for` loop sharing one `FilesystemMemory`. Each run can read what previous runs left in `notes/` via the MCP filesystem server. (`batch_run` rejects `memory=` by design — for memory-accumulating workflows, you write the loop yourself.) |
+| 01 | `01_basic.py` | The shortest possible memory run: build a `FilesystemMemory`, pass it to `paper_flow`, then look at the disk layout that gets created (`workspace/notes/`, `workspace/items/`, `runs/`, `runs.jsonl`). |
+| 02 | `02_serial_loop.py` | Process several inputs in a serial `for` loop sharing one `FilesystemMemory`. Each run can read what previous runs left in `workspace/notes/` via the MCP filesystem server. (`batch_run` rejects `memory=` by design — for memory-accumulating workflows, you write the loop yourself.) |
 | 03 | `03_inspect_trajectory.py` | Disk-only analysis: open `runs.jsonl`, parse the `RunRecord` JSON, and aggregate tokens / durations across runs. No network or `npx` needed. |
 | 04 | `04_custom_run_hooks.py` | Compose your own `RunHooks` (e.g., a custom logger) alongside the built-in `MemoryRunHooks` via the `extra_run_hooks=` kwarg. Both hooks fire for every lifecycle event in the order you registered them. |
 
@@ -34,6 +34,10 @@ python examples/memory/04_custom_run_hooks.py
 All four examples write under `./.qm-memory/` (a directory created
 under your current working directory). Delete it freely between runs;
 nothing is shared with your other projects.
+
+`FilesystemMemory` exposes only `./.qm-memory/workspace/` to the Agent.
+The trajectory archive remains system-managed under `./.qm-memory/runs/`
+and `./.qm-memory/runs.jsonl`.
 
 ## A note on `cfg.archive_trajectory`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Tests don't need module/function docstrings or strict bugbear rules.
 "tests/**/*.py" = ["D", "B"]
+# Example scripts: top-of-file module docstring is enough; per-function
+# docstrings just clutter short demos.
+"examples/**/*.py" = ["D"]
 "**/__init__.py" = ["D104", "F401"]
 
 [tool.ruff.lint.pycodestyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,22 @@ forbidden_modules = [
     "quantmind.models",
 ]
 
+[[tool.importlinter.contracts]]
+name = "mind only depends on knowledge/configs/preprocess/utils + agents SDK"
+type = "forbidden"
+source_modules = ["quantmind.mind"]
+# `mind` MUST NOT import `flows` or `magic` (those depend on `mind`,
+# so the reverse would create a cycle). The deleted transitional
+# packages remain as tripwires against accidental re-introduction.
+forbidden_modules = [
+    "quantmind.flows",
+    "quantmind.magic",
+    "quantmind.config",
+    "quantmind.flow",
+    "quantmind.llm",
+    "quantmind.models",
+]
+
 # ----------------------------------------------------------------------------
 # pytest: configuration + coverage gate
 # ----------------------------------------------------------------------------

--- a/quantmind/flows/_providers.py
+++ b/quantmind/flows/_providers.py
@@ -35,6 +35,20 @@ _CfgT = TypeVar("_CfgT", bound=BaseFlowCfg)
 
 
 @dataclass(frozen=True, slots=True)
+class ProviderCapabilities:
+    """Provider capability flags consumed by flow output handling."""
+
+    name: str
+    supports_json_schema: bool
+    """True = provider accepts ``response_format={"type":"json_schema",...}``
+    (OpenAI-style structured outputs). False = provider only supports the
+    looser ``{"type":"json_object"}`` mode, in which case the flow must
+    inject the Pydantic schema into the instructions and validate the
+    raw JSON string after the run.
+    """
+
+
+@dataclass(frozen=True, slots=True)
 class _ProviderConfig:
     """How to talk to a specific LLM provider."""
 
@@ -47,6 +61,7 @@ class _ProviderConfig:
     tracing_supported: (
         bool  # False = force-disable to avoid 4xx to platform.openai.com
     )
+    supports_json_schema: bool  # False = paper_flow uses json_object + parse
 
 
 # Order matters: the first prefix that matches ``cfg.model.lower()`` wins.
@@ -62,6 +77,7 @@ _PROVIDERS: tuple[tuple[str, _ProviderConfig], ...] = (
             api_key_env="DEEPSEEK_API_KEY",
             use_chat_completions=True,
             tracing_supported=False,
+            supports_json_schema=False,
         ),
     ),
     (
@@ -72,6 +88,7 @@ _PROVIDERS: tuple[tuple[str, _ProviderConfig], ...] = (
             api_key_env="OPENAI_API_KEY",
             use_chat_completions=False,
             tracing_supported=True,
+            supports_json_schema=True,
         ),
     ),
     (
@@ -82,6 +99,7 @@ _PROVIDERS: tuple[tuple[str, _ProviderConfig], ...] = (
             api_key_env="OPENAI_API_KEY",
             use_chat_completions=False,
             tracing_supported=True,
+            supports_json_schema=True,
         ),
     ),
     (
@@ -92,6 +110,7 @@ _PROVIDERS: tuple[tuple[str, _ProviderConfig], ...] = (
             api_key_env="OPENAI_API_KEY",
             use_chat_completions=False,
             tracing_supported=True,
+            supports_json_schema=True,
         ),
     ),
 )
@@ -107,6 +126,15 @@ def _resolve(model: str) -> _ProviderConfig:
         if model_lc.startswith(prefix):
             return cfg
     return _DEFAULT_PROVIDER
+
+
+def provider_capabilities(model: str) -> ProviderCapabilities:
+    """Public capability lookup for flow output-handling branches."""
+    provider = _resolve(model)
+    return ProviderCapabilities(
+        name=provider.name,
+        supports_json_schema=provider.supports_json_schema,
+    )
 
 
 @lru_cache(maxsize=16)

--- a/quantmind/flows/_providers.py
+++ b/quantmind/flows/_providers.py
@@ -1,0 +1,165 @@
+"""Provider auto-detection: map ``cfg.model`` to the right SDK Model + cfg defaults.
+
+User-facing API stays minimal — they just set ``cfg.model="deepseek-chat"``
+(or any supported provider's model id). This module:
+
+1. Resolves the provider from the model-name prefix.
+2. Reads the right API key env var.
+3. Builds the SDK ``Model`` (Chat Completions for non-OpenAI providers
+   that lack the Responses API; Responses for OpenAI families).
+4. Returns a cfg copy with ``tracing_disabled`` force-set when the
+   provider cannot upload traces to ``platform.openai.com``.
+
+**Adding a provider:** append one row to ``_PROVIDERS``. No other code
+or docs change.
+
+This intentionally is *not* a QuantMind facade over the SDK — it does
+not wrap ``agents.Agent`` or ``openai.AsyncOpenAI``; it only assembles
+the SDK's existing types with provider-correct defaults so that
+end-users do not need to repeat the boilerplate themselves.
+"""
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import TypeVar
+
+from agents import Model
+from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
+from agents.models.openai_responses import OpenAIResponsesModel
+from openai import AsyncOpenAI
+
+from quantmind.configs import BaseFlowCfg
+
+_CfgT = TypeVar("_CfgT", bound=BaseFlowCfg)
+
+
+@dataclass(frozen=True, slots=True)
+class _ProviderConfig:
+    """How to talk to a specific LLM provider."""
+
+    name: str
+    base_url: str | None  # None = OpenAI SDK default
+    api_key_env: str
+    use_chat_completions: (
+        bool  # True = legacy ChatCompletions API; False = Responses
+    )
+    tracing_supported: (
+        bool  # False = force-disable to avoid 4xx to platform.openai.com
+    )
+
+
+# Order matters: the first prefix that matches ``cfg.model.lower()`` wins.
+# More specific prefixes (e.g., "o1-") therefore come before generic ones
+# (e.g., "gpt-"). If you add a provider, place it at a sensible spot in
+# the priority order.
+_PROVIDERS: tuple[tuple[str, _ProviderConfig], ...] = (
+    (
+        "deepseek-",
+        _ProviderConfig(
+            name="deepseek",
+            base_url="https://api.deepseek.com/v1",
+            api_key_env="DEEPSEEK_API_KEY",
+            use_chat_completions=True,
+            tracing_supported=False,
+        ),
+    ),
+    (
+        "o1-",
+        _ProviderConfig(
+            name="openai",
+            base_url=None,
+            api_key_env="OPENAI_API_KEY",
+            use_chat_completions=False,
+            tracing_supported=True,
+        ),
+    ),
+    (
+        "o3-",
+        _ProviderConfig(
+            name="openai",
+            base_url=None,
+            api_key_env="OPENAI_API_KEY",
+            use_chat_completions=False,
+            tracing_supported=True,
+        ),
+    ),
+    (
+        "gpt-",
+        _ProviderConfig(
+            name="openai",
+            base_url=None,
+            api_key_env="OPENAI_API_KEY",
+            use_chat_completions=False,
+            tracing_supported=True,
+        ),
+    ),
+)
+
+
+_DEFAULT_PROVIDER: _ProviderConfig = _PROVIDERS[-1][1]
+
+
+def _resolve(model: str) -> _ProviderConfig:
+    """Match ``model`` to a known provider; fall back to OpenAI defaults."""
+    model_lc = model.lower()
+    for prefix, cfg in _PROVIDERS:
+        if model_lc.startswith(prefix):
+            return cfg
+    return _DEFAULT_PROVIDER
+
+
+@lru_cache(maxsize=16)
+def _get_client(base_url: str | None, api_key: str) -> AsyncOpenAI:
+    """Cache one ``AsyncOpenAI`` per ``(base_url, api_key)`` pair.
+
+    Two paper_flow calls with the same provider should reuse a single
+    client (fewer sockets, fewer TLS handshakes). The cache key includes
+    the api_key so per-tenant clients in a multi-tenant deployment stay
+    isolated.
+    """
+    if base_url is None:
+        return AsyncOpenAI(api_key=api_key)
+    return AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+
+def configure_provider(cfg: _CfgT) -> tuple[Model, _CfgT]:
+    """Resolve ``cfg.model`` → ``(SDK Model, effective cfg)``.
+
+    The returned ``Model`` is meant to be assigned directly to
+    ``Agent(model=...)``. The returned cfg is a copy of the input with
+    provider-required defaults applied (currently:
+    ``tracing_disabled=True`` when the provider can't accept Responses /
+    can't upload traces to OpenAI).
+
+    Raises:
+        RuntimeError: When the resolved provider's API key env var is
+            unset. The message names the env var so users can fix it
+            without digging through SDK code.
+    """
+    provider = _resolve(cfg.model)
+    api_key = os.environ.get(provider.api_key_env)
+    if not api_key:
+        raise RuntimeError(
+            f"Model {cfg.model!r} maps to provider {provider.name!r}; "
+            f"please export {provider.api_key_env} in your environment "
+            "before running the flow."
+        )
+    client = _get_client(provider.base_url, api_key)
+
+    model_obj: Model
+    if provider.use_chat_completions:
+        model_obj = OpenAIChatCompletionsModel(
+            model=cfg.model, openai_client=client
+        )
+    else:
+        model_obj = OpenAIResponsesModel(model=cfg.model, openai_client=client)
+
+    effective = cfg.model_copy(
+        update={
+            "tracing_disabled": (
+                cfg.tracing_disabled or not provider.tracing_supported
+            )
+        }
+    )
+    return model_obj, effective

--- a/quantmind/flows/_runner.py
+++ b/quantmind/flows/_runner.py
@@ -2,9 +2,10 @@
 
 `run_with_observability` wraps `Runner.run` with `RunConfig` derived from
 `BaseFlowCfg`, composes user-supplied `RunHooks` (the SDK accepts only a
-single hooks instance per run), and orchestrates the
-`MemoryRunHooks.persist()` call in `finally` so failed runs still
-produce a trajectory record.
+single hooks instance per run), and orchestrates the trajectory archive
+in `finally` so failed runs still produce a `RunRecord` (with `error`
+set). The persistence call is guarded so its own failure never masks
+the original run exception.
 """
 
 from typing import Any
@@ -12,7 +13,10 @@ from typing import Any
 from agents import Agent, RunConfig, RunHooks, Runner
 
 from quantmind.configs import BaseFlowCfg
-from quantmind.mind.memory import Memory, MemoryRunHooks
+from quantmind.mind.memory import Memory
+from quantmind.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 async def run_with_observability(
@@ -33,8 +37,9 @@ async def run_with_observability(
             ``"quantmind.<agent.name>"`` when unset.
         memory: Optional ``Memory`` implementation. When set and
             ``cfg.archive_trajectory`` is True, ``memory.run_hooks()``
-            participates in the run and ``MemoryRunHooks.persist()``
-            is invoked in ``finally`` (so failures archive too).
+            participates in the run; if the returned hook exposes a
+            ``persist(...)`` coroutine (duck-typed) it is invoked in
+            ``finally`` so failures archive too.
         extra_run_hooks: User-supplied hooks composed after the memory
             hook.
 
@@ -49,14 +54,14 @@ async def run_with_observability(
         tracing_disabled=cfg.tracing_disabled,
     )
 
-    memory_hooks: MemoryRunHooks | None = None
+    persistable_hook: Any = None
     hooks_list: list[RunHooks[Any]] = []
     if memory is not None and cfg.archive_trajectory:
         h = memory.run_hooks()
         if h is not None:
             hooks_list.append(h)
-            if isinstance(h, MemoryRunHooks):
-                memory_hooks = h
+            if callable(getattr(h, "persist", None)):
+                persistable_hook = h
     hooks_list.extend(extra_run_hooks)
     composed = _compose_hooks(hooks_list)
 
@@ -75,13 +80,26 @@ async def run_with_observability(
         error = exc
         raise
     finally:
-        if memory_hooks is not None:
-            await memory_hooks.persist(
-                workflow_name=workflow_name,
-                result=result,
-                error=error,
-                input_payload=input,
-            )
+        if persistable_hook is not None:
+            try:
+                await persistable_hook.persist(
+                    workflow_name=workflow_name,
+                    result=result,
+                    error=error,
+                    input_payload=input,
+                )
+            except BaseException as persist_exc:
+                # Never let an archive failure mask an in-flight run
+                # exception (which is the user's actual problem). When
+                # the run succeeded, surface the archive failure normally.
+                if error is None:
+                    raise
+                logger.warning(
+                    "Failed to persist trajectory record after run failure "
+                    "(%s); original error preserved.",
+                    persist_exc,
+                    exc_info=True,
+                )
 
 
 def _compose_hooks(

--- a/quantmind/flows/_runner.py
+++ b/quantmind/flows/_runner.py
@@ -2,9 +2,9 @@
 
 `run_with_observability` wraps `Runner.run` with `RunConfig` derived from
 `BaseFlowCfg`, composes user-supplied `RunHooks` (the SDK accepts only a
-single hooks instance per run), and leaves a no-op call site for the
-PR6 trajectory archive. Flow modules call this instead of touching the
-SDK directly so observability behaviour stays in one place.
+single hooks instance per run), and orchestrates the
+`MemoryRunHooks.persist()` call in `finally` so failed runs still
+produce a trajectory record.
 """
 
 from typing import Any
@@ -12,6 +12,7 @@ from typing import Any
 from agents import Agent, RunConfig, RunHooks, Runner
 
 from quantmind.configs import BaseFlowCfg
+from quantmind.mind.memory import Memory, MemoryRunHooks
 
 
 async def run_with_observability(
@@ -19,7 +20,7 @@ async def run_with_observability(
     input: str | list[Any],
     *,
     cfg: BaseFlowCfg,
-    memory: object | None = None,
+    memory: Memory | None = None,
     extra_run_hooks: list[RunHooks[Any]],
 ) -> Any:
     """Build `RunConfig` + composed hooks, run the agent, return final output.
@@ -30,12 +31,12 @@ async def run_with_observability(
         cfg: Flow configuration. Tracing fields and ``max_turns`` are
             forwarded to the SDK; ``workflow_name`` falls back to
             ``"quantmind.<agent.name>"`` when unset.
-        memory: PR6 ``Memory`` placeholder. Currently unused at runtime;
-            the value is forwarded to the trajectory-archive stub so PR6
-            can wire it in without changing call sites.
-        extra_run_hooks: User-supplied hooks. Composed with any
-            memory-derived hooks (none in PR5) into a single
-            ``RunHooks`` instance.
+        memory: Optional ``Memory`` implementation. When set and
+            ``cfg.archive_trajectory`` is True, ``memory.run_hooks()``
+            participates in the run and ``MemoryRunHooks.persist()``
+            is invoked in ``finally`` (so failures archive too).
+        extra_run_hooks: User-supplied hooks composed after the memory
+            hook.
 
     Returns:
         ``RunResult.final_output`` typed by the agent's ``output_type``.
@@ -47,29 +48,40 @@ async def run_with_observability(
         trace_include_sensitive_data=cfg.trace_include_sensitive_data,
         tracing_disabled=cfg.tracing_disabled,
     )
-    hooks = _compose_hooks(_collect_hooks(memory, extra_run_hooks))
-    result = await Runner.run(
-        agent,
-        input,
-        run_config=run_cfg,
-        hooks=hooks,
-        max_turns=cfg.max_turns,
-    )
-    _archive_run_artifacts(cfg, memory, result)
-    return result.final_output
 
+    memory_hooks: MemoryRunHooks | None = None
+    hooks_list: list[RunHooks[Any]] = []
+    if memory is not None and cfg.archive_trajectory:
+        h = memory.run_hooks()
+        if h is not None:
+            hooks_list.append(h)
+            if isinstance(h, MemoryRunHooks):
+                memory_hooks = h
+    hooks_list.extend(extra_run_hooks)
+    composed = _compose_hooks(hooks_list)
 
-def _collect_hooks(
-    memory: object | None,
-    extras: list[RunHooks[Any]],
-) -> list[RunHooks[Any]]:
-    """Return hooks in run order: memory hooks first (PR6), then extras."""
-    hooks: list[RunHooks[Any]] = []
-    # PR6 will append `memory.run_hooks()` here when `memory` exposes the
-    # `Memory` Protocol. PR5 keeps `memory` opaque and contributes no hooks.
-    del memory
-    hooks.extend(extras)
-    return hooks
+    result: Any = None
+    error: BaseException | None = None
+    try:
+        result = await Runner.run(
+            agent,
+            input,
+            run_config=run_cfg,
+            hooks=composed,
+            max_turns=cfg.max_turns,
+        )
+        return result.final_output
+    except BaseException as exc:
+        error = exc
+        raise
+    finally:
+        if memory_hooks is not None:
+            await memory_hooks.persist(
+                workflow_name=workflow_name,
+                result=result,
+                error=error,
+                input_payload=input,
+            )
 
 
 def _compose_hooks(
@@ -87,8 +99,7 @@ class _CompositeRunHooks(RunHooks[Any]):
     """Fan out every lifecycle method to each wrapped hook in order.
 
     Exceptions from earlier hooks short-circuit the rest by design — hooks
-    are integral to the run, not best-effort. PR6's archive hook should
-    catch its own exceptions internally if it wants resilience.
+    are integral to the run, not best-effort.
     """
 
     def __init__(self, inner: list[RunHooks[Any]]) -> None:
@@ -121,17 +132,3 @@ class _CompositeRunHooks(RunHooks[Any]):
     async def on_tool_end(self, *args: Any, **kwargs: Any) -> None:
         for h in self._inner:
             await h.on_tool_end(*args, **kwargs)
-
-
-def _archive_run_artifacts(
-    cfg: BaseFlowCfg,
-    memory: object | None,
-    result: Any,
-) -> None:
-    """No-op stub. PR6 writes a trajectory record under ``<memory_dir>/runs/``.
-
-    Kept as a real call site (rather than commented-out) so PR6 changes
-    one function body, not the runner's public path.
-    """
-    del cfg, memory, result
-    return None

--- a/quantmind/flows/_runner.py
+++ b/quantmind/flows/_runner.py
@@ -8,6 +8,7 @@ set). The persistence call is guarded so its own failure never masks
 the original run exception.
 """
 
+from contextlib import AsyncExitStack
 from typing import Any
 
 from agents import Agent, RunConfig, RunHooks, Runner
@@ -68,14 +69,22 @@ async def run_with_observability(
     result: Any = None
     error: BaseException | None = None
     try:
-        result = await Runner.run(
-            agent,
-            input,
-            run_config=run_cfg,
-            hooks=composed,
-            max_turns=cfg.max_turns,
-        )
-        return result.final_output
+        # MCP servers are async context managers; the SDK does NOT
+        # auto-connect them — list_tools() raises if connect() was
+        # never called. We enter them here so the agent's Runner.run
+        # sees connected servers, and exit them on the way out so the
+        # ``npx`` subprocesses are reaped even on exception.
+        async with AsyncExitStack() as mcp_stack:
+            for server in getattr(agent, "mcp_servers", []) or []:
+                await mcp_stack.enter_async_context(server)
+            result = await Runner.run(
+                agent,
+                input,
+                run_config=run_cfg,
+                hooks=composed,
+                max_turns=cfg.max_turns,
+            )
+            return result.final_output
     except BaseException as exc:
         error = exc
         raise

--- a/quantmind/flows/batch.py
+++ b/quantmind/flows/batch.py
@@ -2,8 +2,8 @@
 
 `batch_run` is the single concurrency primitive QuantMind ships in MVP.
 It does NOT support `memory=`; for memory-accumulating workflows users
-write a serial `for` loop themselves (design doc §4.3.5). This keeps the
-batch path stateless and free of cross-run race hazards.
+write a serial `for` loop themselves. This keeps the batch path
+stateless and free of cross-run race hazards.
 """
 
 import asyncio
@@ -93,8 +93,7 @@ async def batch_run(
         raise ValueError(
             "batch_run does not support `memory=` in MVP. For "
             "memory-accumulating workflows write a serial loop instead: "
-            "`for inp in inputs: await flow_fn(inp, cfg=cfg, memory=memory)`. "
-            "See design doc §4.3.5."
+            "`for inp in inputs: await flow_fn(inp, cfg=cfg, memory=memory)`."
         )
     if concurrency < 1:
         raise ValueError(f"concurrency must be >= 1, got {concurrency}")

--- a/quantmind/flows/paper.py
+++ b/quantmind/flows/paper.py
@@ -24,6 +24,7 @@ from quantmind.configs.paper import (
     PaperInput,
     RawText,
 )
+from quantmind.flows._providers import configure_provider
 from quantmind.flows._runner import run_with_observability
 from quantmind.knowledge import Paper
 from quantmind.mind.memory import Memory
@@ -92,6 +93,11 @@ async def paper_flow(
 
     raw_md, source_meta = await _fetch_and_format(input)
 
+    # Resolve the provider from cfg.model so the user only needs to set
+    # the model string (e.g., "deepseek-chat" vs "gpt-4o") — no manual
+    # client / api / tracing setup required at the call site.
+    agent_model, cfg = configure_provider(cfg)
+
     mcp_servers = memory.mcp_servers() if memory is not None else []
     memory_tools = memory.tools() if memory is not None else []
 
@@ -102,7 +108,7 @@ async def paper_flow(
         "instructions": _compose_instructions(
             _DEFAULT_INSTRUCTIONS, extra_instructions, cfg
         ),
-        "model": cfg.model,
+        "model": agent_model,
         "tools": [*(extra_tools or []), *memory_tools],
         "mcp_servers": mcp_servers,
         "output_type": out_type,

--- a/quantmind/flows/paper.py
+++ b/quantmind/flows/paper.py
@@ -11,9 +11,11 @@ or the keyword arguments on this function (Layer 2). To swap the whole
 flow, fork this file (Layer 3).
 """
 
-from typing import Any, TypeVar
+import dataclasses
+import json
+from typing import Any, TypeVar, cast
 
-from agents import Agent, RunHooks, Tool
+from agents import Agent, AgentOutputSchema, ModelSettings, RunHooks, Tool
 
 from quantmind.configs import PaperFlowCfg
 from quantmind.configs.paper import (
@@ -24,7 +26,7 @@ from quantmind.configs.paper import (
     PaperInput,
     RawText,
 )
-from quantmind.flows._providers import configure_provider
+from quantmind.flows._providers import configure_provider, provider_capabilities
 from quantmind.flows._runner import run_with_observability
 from quantmind.knowledge import Paper
 from quantmind.mind.memory import Memory
@@ -97,34 +99,90 @@ async def paper_flow(
     # the model string (e.g., "deepseek-chat" vs "gpt-4o") — no manual
     # client / api / tracing setup required at the call site.
     agent_model, cfg = configure_provider(cfg)
+    caps = provider_capabilities(cfg.model)
 
     mcp_servers = memory.mcp_servers() if memory is not None else []
     memory_tools = memory.tools() if memory is not None else []
 
-    # Agent's `model_settings` parameter is non-optional (defaults to a
-    # fresh ``ModelSettings()``); only forward when cfg has one set.
+    base_instructions = _compose_instructions(
+        _DEFAULT_INSTRUCTIONS, extra_instructions, cfg
+    )
+
+    # Two output-handling paths:
+    #
+    # 1. supports_json_schema=True  (OpenAI, ...):
+    #      AgentOutputSchema drives ``response_format={"type":"json_schema"}``.
+    #      The SDK validates against the schema server-side and returns a
+    #      Pydantic instance directly.
+    #
+    # 2. supports_json_schema=False (DeepSeek, ...):
+    #      Provider only accepts ``{"type":"json_object"}`` JSON mode. We
+    #      embed the Pydantic schema text in the instructions, set
+    #      ``model_settings.extra_body.response_format`` to json_object,
+    #      keep output_type=None so the Agent returns the raw string, and
+    #      validate locally with ``out_type.model_validate_json``.
+    if caps.supports_json_schema:
+        instructions = base_instructions
+        # Non-strict still gives Pydantic validation on the SDK side
+        # without forcing every field to be required.
+        output_type_arg: Any = AgentOutputSchema(
+            out_type, strict_json_schema=False
+        )
+        effective_model_settings = cfg.model_settings
+    else:
+        instructions = (
+            base_instructions + "\n\nIMPORTANT — output format:\n"
+            "Return ONLY a single JSON object (no prose, no markdown "
+            "fences) that conforms to this JSON Schema. Every field "
+            "marked as `format: uuid` MUST be a real RFC 4122 UUID "
+            "(e.g., `12345678-1234-5678-1234-567812345678`); do NOT "
+            "emit placeholder strings like `root-uuid-here`. Every "
+            "field marked as `format: date-time` MUST be an ISO 8601 "
+            "timestamp.\n\n"
+            f"```json\n{json.dumps(out_type.model_json_schema(), ensure_ascii=False)}\n```\n"
+        )
+        output_type_arg = None  # raw string return; we parse below
+        # Merge json_object response_format into any user-provided
+        # model_settings.extra_body.
+        base_ms = cfg.model_settings or ModelSettings()
+        # ``extra_body`` is typed as ``httpx.Body`` (a narrow union) but
+        # the SDK forwards it as kwargs to AsyncOpenAI's request layer
+        # which accepts any JSON-serialisable dict. We cast to keep the
+        # branch type-clean without loosening the SDK's signature.
+        existing_extra: dict[str, Any] = dict(
+            cast(dict[str, Any], base_ms.extra_body or {})
+        )
+        existing_extra["response_format"] = {"type": "json_object"}
+        effective_model_settings = dataclasses.replace(
+            base_ms, extra_body=cast(Any, existing_extra)
+        )
+
     agent_kwargs: dict[str, Any] = {
         "name": "paper_extractor",
-        "instructions": _compose_instructions(
-            _DEFAULT_INSTRUCTIONS, extra_instructions, cfg
-        ),
+        "instructions": instructions,
         "model": agent_model,
         "tools": [*(extra_tools or []), *memory_tools],
         "mcp_servers": mcp_servers,
-        "output_type": out_type,
         "input_guardrails": list(extra_input_guardrails or []),
         "output_guardrails": list(extra_output_guardrails or []),
     }
-    if cfg.model_settings is not None:
-        agent_kwargs["model_settings"] = cfg.model_settings
+    if output_type_arg is not None:
+        agent_kwargs["output_type"] = output_type_arg
+    if effective_model_settings is not None:
+        agent_kwargs["model_settings"] = effective_model_settings
     agent: Agent[Any] = Agent(**agent_kwargs)
-    return await run_with_observability(
+    result = await run_with_observability(
         agent,
         _format_input(raw_md, source_meta),
         cfg=cfg,
         memory=memory,
         extra_run_hooks=list(extra_run_hooks or []),
     )
+
+    if caps.supports_json_schema:
+        return result
+    # json_object path: result is a raw string; parse + validate.
+    return out_type.model_validate_json(_extract_json(result))
 
 
 async def _fetch_and_format(
@@ -214,3 +272,24 @@ def _format_input(raw_md: str, source_meta: dict[str, Any]) -> str:
     return (
         f"--- Source metadata ---\n{header}\n\n--- Paper content ---\n{raw_md}"
     )
+
+
+def _extract_json(raw: str) -> str:
+    r"""Strip optional markdown fences around a JSON payload.
+
+    Even when the system prompt forbids markdown fences, some models
+    still wrap their output in ``\`\`\`json ... \`\`\``. We strip that
+    one common case so ``model_validate_json`` does not choke on it;
+    everything else is left untouched and Pydantic surfaces a clear
+    error if the payload is still not valid JSON.
+    """
+    s = raw.strip()
+    if not s.startswith("```"):
+        return s
+    lines = s.splitlines()
+    # Drop the opening fence (``` or ```json).
+    lines = lines[1:]
+    # Drop the closing fence, if present.
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()

--- a/quantmind/flows/paper.py
+++ b/quantmind/flows/paper.py
@@ -26,6 +26,7 @@ from quantmind.configs.paper import (
 )
 from quantmind.flows._runner import run_with_observability
 from quantmind.knowledge import Paper
+from quantmind.mind.memory import Memory
 from quantmind.preprocess.fetch import (
     Fetched,
     fetch_arxiv,
@@ -68,15 +69,17 @@ async def paper_flow(
     extra_tools: list[Tool] | None = None,
     extra_instructions: str | None = None,
     output_type: type[P] | None = None,
-    memory: object | None = None,
+    memory: Memory | None = None,
     extra_run_hooks: list[RunHooks[Any]] | None = None,
     extra_input_guardrails: list[Any] | None = None,
     extra_output_guardrails: list[Any] | None = None,
 ) -> P | Paper:
     """Extract a ``Paper`` from a typed ``PaperInput``.
 
-    See design doc §4.1 for the rationale on each kwarg. ``memory`` is a
-    PR6 placeholder — non-None values are accepted but unused in PR5.
+    See design doc §4.1 for the rationale on each kwarg. When ``memory``
+    is supplied, ``memory.mcp_servers()`` and ``memory.tools()`` flow
+    through to the Agent unconditionally; trajectory archiving is gated
+    separately by ``cfg.archive_trajectory`` inside the runner.
 
     Raises:
         UnsupportedContentTypeError: When fetched bytes are not PDF /
@@ -89,6 +92,9 @@ async def paper_flow(
 
     raw_md, source_meta = await _fetch_and_format(input)
 
+    mcp_servers = memory.mcp_servers() if memory is not None else []
+    memory_tools = memory.tools() if memory is not None else []
+
     # Agent's `model_settings` parameter is non-optional (defaults to a
     # fresh ``ModelSettings()``); only forward when cfg has one set.
     agent_kwargs: dict[str, Any] = {
@@ -97,7 +103,8 @@ async def paper_flow(
             _DEFAULT_INSTRUCTIONS, extra_instructions, cfg
         ),
         "model": cfg.model,
-        "tools": list(extra_tools or []),
+        "tools": [*(extra_tools or []), *memory_tools],
+        "mcp_servers": mcp_servers,
         "output_type": out_type,
         "input_guardrails": list(extra_input_guardrails or []),
         "output_guardrails": list(extra_output_guardrails or []),

--- a/quantmind/flows/paper.py
+++ b/quantmind/flows/paper.py
@@ -8,7 +8,7 @@ variants, fetches and converts the raw payload to markdown via
 
 Customization happens through the configured ``PaperFlowCfg`` (Layer 1)
 or the keyword arguments on this function (Layer 2). To swap the whole
-flow, fork this file (Layer 3 — design doc §9).
+flow, fork this file (Layer 3).
 """
 
 from typing import Any, TypeVar
@@ -76,10 +76,10 @@ async def paper_flow(
 ) -> P | Paper:
     """Extract a ``Paper`` from a typed ``PaperInput``.
 
-    See design doc §4.1 for the rationale on each kwarg. When ``memory``
-    is supplied, ``memory.mcp_servers()`` and ``memory.tools()`` flow
-    through to the Agent unconditionally; trajectory archiving is gated
-    separately by ``cfg.archive_trajectory`` inside the runner.
+    When ``memory`` is supplied, ``memory.mcp_servers()`` and
+    ``memory.tools()`` flow through to the Agent unconditionally;
+    trajectory archiving is gated separately by
+    ``cfg.archive_trajectory`` inside the runner.
 
     Raises:
         UnsupportedContentTypeError: When fetched bytes are not PDF /

--- a/quantmind/mind/__init__.py
+++ b/quantmind/mind/__init__.py
@@ -1,0 +1,10 @@
+"""quantmind.mind — cognitive layer.
+
+PR6 introduces ``mind/memory/`` (Memory Protocol + filesystem backend).
+PR7+ will add ``mind/store/`` (knowledge store) and
+``mind/summarize_run`` (trajectory summariser).
+"""
+
+from quantmind.mind.memory import Memory
+
+__all__ = ["Memory"]

--- a/quantmind/mind/__init__.py
+++ b/quantmind/mind/__init__.py
@@ -5,6 +5,6 @@ PR7+ will add ``mind/store/`` (knowledge store) and
 ``mind/summarize_run`` (trajectory summariser).
 """
 
-from quantmind.mind.memory import Memory
+from quantmind.mind.memory import FilesystemMemory, Memory, MemoryRunHooks
 
-__all__ = ["Memory"]
+__all__ = ["FilesystemMemory", "Memory", "MemoryRunHooks"]

--- a/quantmind/mind/memory/__init__.py
+++ b/quantmind/mind/memory/__init__.py
@@ -1,5 +1,7 @@
 """quantmind.mind.memory — Memory Protocol + filesystem MVP backend."""
 
 from quantmind.mind.memory._protocol import Memory
+from quantmind.mind.memory._run_hooks import MemoryRunHooks
+from quantmind.mind.memory.filesystem import FilesystemMemory
 
-__all__ = ["Memory"]
+__all__ = ["FilesystemMemory", "Memory", "MemoryRunHooks"]

--- a/quantmind/mind/memory/__init__.py
+++ b/quantmind/mind/memory/__init__.py
@@ -1,0 +1,5 @@
+"""quantmind.mind.memory — Memory Protocol + filesystem MVP backend."""
+
+from quantmind.mind.memory._protocol import Memory
+
+__all__ = ["Memory"]

--- a/quantmind/mind/memory/_protocol.py
+++ b/quantmind/mind/memory/_protocol.py
@@ -1,0 +1,35 @@
+"""Memory Protocol — granular cross-step working memory contract.
+
+Each method has its own narrow surface so concrete implementations can
+opt in to whichever channel(s) they need (in-process tools, MCP servers,
+lifecycle hooks). The Protocol does NOT prescribe MCP — see design doc
+\u00a711.2 for the rationale: future backends like an embedding-based
+``ChromaMemory`` are tool-only, while the MVP ``FilesystemMemory`` is
+MCP-based.
+"""
+
+from typing import Any, Protocol, runtime_checkable
+
+from agents import RunHooks, Tool
+from agents.mcp import MCPServer
+
+
+@runtime_checkable
+class Memory(Protocol):
+    """Cross-step working memory exposed to a flow's Agent."""
+
+    def tools(self) -> list[Tool]:
+        """In-process ``@function_tool`` list for the Agent."""
+        ...
+
+    def mcp_servers(self) -> list[MCPServer]:
+        """MCP servers exposed to the Agent."""
+        ...
+
+    def run_hooks(self) -> RunHooks[Any] | None:
+        """Lifecycle hooks for accounting / archiving / item indexing."""
+        ...
+
+    async def reset(self) -> None:
+        """Wipe the memory area. Implementations may be no-ops."""
+        ...

--- a/quantmind/mind/memory/_protocol.py
+++ b/quantmind/mind/memory/_protocol.py
@@ -2,10 +2,9 @@
 
 Each method has its own narrow surface so concrete implementations can
 opt in to whichever channel(s) they need (in-process tools, MCP servers,
-lifecycle hooks). The Protocol does NOT prescribe MCP — see design doc
-\u00a711.2 for the rationale: future backends like an embedding-based
-``ChromaMemory`` are tool-only, while the MVP ``FilesystemMemory`` is
-MCP-based.
+lifecycle hooks). The Protocol does NOT prescribe MCP: a future
+embedding-based ``ChromaMemory`` could be tool-only, while the MVP
+``FilesystemMemory`` is MCP-based — both satisfy this same Protocol.
 """
 
 from typing import Any, Protocol, runtime_checkable

--- a/quantmind/mind/memory/_run_hooks.py
+++ b/quantmind/mind/memory/_run_hooks.py
@@ -45,7 +45,7 @@ def _safe_repr(obj: Any) -> str:
     dump = getattr(obj, "model_dump_json", None)
     if callable(dump):
         try:
-            return dump()
+            return str(dump())
         except Exception:  # noqa: BLE001
             pass
     return str(obj)
@@ -75,7 +75,7 @@ class MemoryRunHooks(RunHooks[Any]):
         self._llm_timer_start: float | None = None
         self._tool_timer_starts: dict[int, float] = {}
 
-    async def on_agent_start(self, ctx: Any, agent: Any) -> None:
+    async def on_agent_start(self, context: Any, agent: Any) -> None:
         self._started_at = datetime.now(timezone.utc)
         self._agent_name = str(getattr(agent, "name", "") or "")
         self._agent_model = str(getattr(agent, "model", "") or "")
@@ -86,7 +86,7 @@ class MemoryRunHooks(RunHooks[Any]):
     async def on_llm_start(self, *_: Any, **__: Any) -> None:
         self._llm_timer_start = time.monotonic()
 
-    async def on_llm_end(self, ctx: Any, agent: Any, response: Any) -> None:
+    async def on_llm_end(self, context: Any, agent: Any, response: Any) -> None:
         duration = (
             (time.monotonic() - self._llm_timer_start)
             if self._llm_timer_start is not None
@@ -106,11 +106,11 @@ class MemoryRunHooks(RunHooks[Any]):
             }
         )
 
-    async def on_tool_start(self, ctx: Any, agent: Any, tool: Any) -> None:
+    async def on_tool_start(self, context: Any, agent: Any, tool: Any) -> None:
         self._tool_timer_starts[id(tool)] = time.monotonic()
 
     async def on_tool_end(
-        self, ctx: Any, agent: Any, tool: Any, result: Any
+        self, context: Any, agent: Any, tool: Any, result: Any
     ) -> None:
         start = self._tool_timer_starts.pop(id(tool), None)
         duration = (time.monotonic() - start) if start is not None else 0.0
@@ -123,7 +123,7 @@ class MemoryRunHooks(RunHooks[Any]):
             }
         )
 
-    async def on_agent_end(self, ctx: Any, agent: Any, output: Any) -> None:
+    async def on_agent_end(self, context: Any, agent: Any, output: Any) -> None:
         self._ended_at = datetime.now(timezone.utc)
         self._output_summary = _truncate(_safe_repr(output))
 

--- a/quantmind/mind/memory/_run_hooks.py
+++ b/quantmind/mind/memory/_run_hooks.py
@@ -1,0 +1,172 @@
+"""``MemoryRunHooks`` — per-run lifecycle accumulator + ``persist()``.
+
+Constructed fresh per ``paper_flow`` invocation by
+``FilesystemMemory.run_hooks()``. Each lifecycle method accumulates
+metrics; the runner calls ``persist()`` in a ``finally`` block so
+runs that fail still produce a trajectory record (with ``error``
+set to ``str(exc)``).
+"""
+
+import asyncio
+import hashlib
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agents import RunHooks
+
+from quantmind.mind.memory._trajectory import (
+    RunRecord,
+    generate_run_id,
+    write_run_record,
+)
+
+_SUMMARY_LIMIT = 500
+_TRUNC_SUFFIX = "... [truncated]"
+
+
+def _truncate(s: str, limit: int = _SUMMARY_LIMIT) -> str:
+    if len(s) <= limit:
+        return s
+    head = limit - len(_TRUNC_SUFFIX)
+    return s[:head] + _TRUNC_SUFFIX
+
+
+def _instructions_hash(instructions: str | None) -> str:
+    if not instructions:
+        return ""
+    return hashlib.sha256(instructions.encode("utf-8")).hexdigest()[:16]
+
+
+def _safe_repr(obj: Any) -> str:
+    if obj is None:
+        return ""
+    dump = getattr(obj, "model_dump_json", None)
+    if callable(dump):
+        try:
+            return dump()
+        except Exception:  # noqa: BLE001
+            pass
+    return str(obj)
+
+
+class MemoryRunHooks(RunHooks[Any]):
+    """Per-run lifecycle accumulator that persists a ``RunRecord``.
+
+    State lives on the instance and is written exactly once via
+    ``persist`` — typically called by the runner in a ``finally``
+    block so failed runs still archive.
+    """
+
+    def __init__(self, *, memory_dir: Path, archive_lock: asyncio.Lock) -> None:
+        self._memory_dir = memory_dir
+        self._archive_lock = archive_lock
+
+        self._started_at: datetime | None = None
+        self._ended_at: datetime | None = None
+        self._agent_name: str = ""
+        self._agent_model: str = ""
+        self._instructions_hash: str = ""
+        self._output_summary: str = ""
+        self._llm_calls: list[dict[str, Any]] = []
+        self._tool_calls: list[dict[str, Any]] = []
+
+        self._llm_timer_start: float | None = None
+        self._tool_timer_starts: dict[int, float] = {}
+
+    async def on_agent_start(self, ctx: Any, agent: Any) -> None:
+        self._started_at = datetime.now(timezone.utc)
+        self._agent_name = str(getattr(agent, "name", "") or "")
+        self._agent_model = str(getattr(agent, "model", "") or "")
+        self._instructions_hash = _instructions_hash(
+            getattr(agent, "instructions", None)
+        )
+
+    async def on_llm_start(self, *_: Any, **__: Any) -> None:
+        self._llm_timer_start = time.monotonic()
+
+    async def on_llm_end(self, ctx: Any, agent: Any, response: Any) -> None:
+        duration = (
+            (time.monotonic() - self._llm_timer_start)
+            if self._llm_timer_start is not None
+            else 0.0
+        )
+        self._llm_timer_start = None
+        usage = getattr(response, "usage", None)
+        tokens_in = int(getattr(usage, "input_tokens", 0) or 0)
+        tokens_out = int(getattr(usage, "output_tokens", 0) or 0)
+        model = str(getattr(agent, "model", "") or "")
+        self._llm_calls.append(
+            {
+                "tokens_in": tokens_in,
+                "tokens_out": tokens_out,
+                "duration_s": round(duration, 4),
+                "model": model,
+            }
+        )
+
+    async def on_tool_start(self, ctx: Any, agent: Any, tool: Any) -> None:
+        self._tool_timer_starts[id(tool)] = time.monotonic()
+
+    async def on_tool_end(
+        self, ctx: Any, agent: Any, tool: Any, result: Any
+    ) -> None:
+        start = self._tool_timer_starts.pop(id(tool), None)
+        duration = (time.monotonic() - start) if start is not None else 0.0
+        name = str(getattr(tool, "name", "") or "")
+        self._tool_calls.append(
+            {
+                "name": name,
+                "args": (_truncate(str(result)) if result is not None else ""),
+                "duration_s": round(duration, 4),
+            }
+        )
+
+    async def on_agent_end(self, ctx: Any, agent: Any, output: Any) -> None:
+        self._ended_at = datetime.now(timezone.utc)
+        self._output_summary = _truncate(_safe_repr(output))
+
+    async def persist(
+        self,
+        *,
+        workflow_name: str,
+        result: Any,
+        error: BaseException | None,
+        input_payload: Any,
+    ) -> None:
+        """Build a ``RunRecord`` from accumulated state and write it.
+
+        Called by the runner in ``finally`` so failed runs archive too.
+        """
+        ended = self._ended_at or datetime.now(timezone.utc)
+        started = self._started_at or ended
+        tokens_total = {
+            "input": sum(c["tokens_in"] for c in self._llm_calls),
+            "output": sum(c["tokens_out"] for c in self._llm_calls),
+        }
+        record = RunRecord(
+            schema_version=1,
+            run_id=generate_run_id(started),
+            workflow_name=workflow_name,
+            trace_id=(getattr(result, "trace_id", None) if result else None),
+            started_at=started,
+            ended_at=ended,
+            duration_seconds=round((ended - started).total_seconds(), 4),
+            agent={
+                "name": self._agent_name,
+                "model": self._agent_model,
+                "instructions_hash": self._instructions_hash,
+            },
+            llm_calls=list(self._llm_calls),
+            tool_calls=list(self._tool_calls),
+            memory_ops={"files_read": [], "files_written": []},
+            tokens_total=tokens_total,
+            cost_estimate_usd=0.0,
+            input_summary=_truncate(_safe_repr(input_payload)),
+            output_summary=self._output_summary,
+            error=str(error) if error is not None else None,
+        )
+        await write_run_record(
+            self._memory_dir, record, archive_lock=self._archive_lock
+        )

--- a/quantmind/mind/memory/_run_hooks.py
+++ b/quantmind/mind/memory/_run_hooks.py
@@ -46,9 +46,26 @@ def _safe_repr(obj: Any) -> str:
     if callable(dump):
         try:
             return str(dump())
-        except Exception:  # noqa: BLE001
+        except (TypeError, ValueError):
+            # Pydantic SerializationError subclasses ValueError; other
+            # errors should not be swallowed. Fall through to ``str(obj)``.
             pass
     return str(obj)
+
+
+def _format_error(error: BaseException | None) -> str | None:
+    """Produce a non-empty string for any ``BaseException`` (or ``None``).
+
+    ``str(KeyboardInterrupt())`` and ``str(asyncio.CancelledError())`` are
+    both ``""``; relying on that in a trajectory record would make the
+    error field indistinguishable from "no error" downstream. We therefore
+    always include the exception type, plus the message when present.
+    """
+    if error is None:
+        return None
+    message = str(error)
+    type_name = type(error).__name__
+    return f"{type_name}: {message}" if message else type_name
 
 
 class MemoryRunHooks(RunHooks[Any]):
@@ -115,10 +132,15 @@ class MemoryRunHooks(RunHooks[Any]):
         start = self._tool_timer_starts.pop(id(tool), None)
         duration = (time.monotonic() - start) if start is not None else 0.0
         name = str(getattr(tool, "name", "") or "")
+        # The SDK's ``on_tool_end`` passes the tool's *result* string, not
+        # the *args* — naming the field accordingly avoids downstream
+        # consumers (e.g., dashboards) misreading what they get.
         self._tool_calls.append(
             {
                 "name": name,
-                "args": (_truncate(str(result)) if result is not None else ""),
+                "result_preview": (
+                    _truncate(str(result)) if result is not None else ""
+                ),
                 "duration_s": round(duration, 4),
             }
         )
@@ -165,7 +187,7 @@ class MemoryRunHooks(RunHooks[Any]):
             cost_estimate_usd=0.0,
             input_summary=_truncate(_safe_repr(input_payload)),
             output_summary=self._output_summary,
-            error=str(error) if error is not None else None,
+            error=_format_error(error),
         )
         await write_run_record(
             self._memory_dir, record, archive_lock=self._archive_lock

--- a/quantmind/mind/memory/_trajectory.py
+++ b/quantmind/mind/memory/_trajectory.py
@@ -1,0 +1,99 @@
+"""Trajectory archive: ``RunRecord`` schema + atomic writer.
+
+Each ``Runner.run`` invocation produces one ``RunRecord`` that is
+serialised to ``<memory_dir>/runs/<run_id>.json`` (atomic via
+``os.replace``) and appended to ``<memory_dir>/runs.jsonl`` (one
+JSON line per run, append-only).
+
+Cross-process concurrency is undefined; an ``asyncio.Lock`` (held by
+the calling ``FilesystemMemory``) serialises writes within a single
+Python process.
+"""
+
+import asyncio
+import json
+import os
+import secrets
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+_BASE36 = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+
+@dataclass(frozen=True, slots=True)
+class RunRecord:
+    """A single QuantMind flow run trajectory record."""
+
+    schema_version: int
+    run_id: str
+    workflow_name: str
+    trace_id: str | None
+    started_at: datetime
+    ended_at: datetime
+    duration_seconds: float
+    agent: dict[str, str]
+    llm_calls: list[dict[str, Any]]
+    tool_calls: list[dict[str, Any]]
+    memory_ops: dict[str, list[str]]
+    tokens_total: dict[str, int]
+    cost_estimate_usd: float
+    input_summary: str
+    output_summary: str
+    error: str | None
+
+
+def generate_run_id(now: datetime) -> str:
+    """Build ``YYYYMMDDTHHMMSSmmm`` (UTC) plus 3 base36 random chars."""
+    stamp = now.strftime("%Y%m%dT%H%M%S") + f"{now.microsecond // 1000:03d}"
+    suffix = "".join(secrets.choice(_BASE36) for _ in range(3))
+    return f"{stamp}{suffix}"
+
+
+def _to_jsonable(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat().replace("+00:00", "Z")
+    raise TypeError(
+        f"Object of type {type(value).__name__} is not JSON serialisable"
+    )
+
+
+def _serialise(record: RunRecord) -> str:
+    return json.dumps(
+        asdict(record),
+        default=_to_jsonable,
+        ensure_ascii=False,
+    )
+
+
+async def write_run_record(
+    memory_dir: Path,
+    record: RunRecord,
+    *,
+    archive_lock: asyncio.Lock,
+) -> None:
+    """Persist ``record`` atomically and append to ``runs.jsonl``.
+
+    Atomicity:
+
+    - The per-run JSON file is written to ``<run_id>.json.tmp`` and
+      then ``os.replace``-d into place; same-FS rename is atomic on
+      POSIX, preventing partial reads.
+    - The ``runs.jsonl`` append is serialised across one Python
+      process via ``archive_lock``; cross-process concurrency is
+      unsupported (documented in ``FilesystemMemory``).
+    """
+    payload = _serialise(record)
+    runs_dir = memory_dir / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    final = runs_dir / f"{record.run_id}.json"
+    tmp = runs_dir / f"{record.run_id}.json.tmp"
+    tmp.write_text(payload, encoding="utf-8")
+    os.replace(tmp, final)
+
+    index = memory_dir / "runs.jsonl"
+    async with archive_lock:
+        with index.open("a", encoding="utf-8") as fh:
+            fh.write(payload)
+            fh.write("\n")

--- a/quantmind/mind/memory/_trajectory.py
+++ b/quantmind/mind/memory/_trajectory.py
@@ -7,7 +7,10 @@ JSON line per run, append-only).
 
 Cross-process concurrency is undefined; an ``asyncio.Lock`` (held by
 the calling ``FilesystemMemory``) serialises writes within a single
-Python process.
+Python process. Both files and their parent directory entries are
+``flush()``ed / ``os.fsync``ed before the writer returns so a crash
+immediately after ``await write_run_record(...)`` does not leave the
+per-run JSON or the ``runs.jsonl`` line lost in the kernel cache.
 """
 
 import asyncio
@@ -45,9 +48,14 @@ class RunRecord:
 
 
 def generate_run_id(now: datetime) -> str:
-    """Build ``YYYYMMDDTHHMMSSmmm`` (UTC) plus 3 base36 random chars."""
+    """Build ``YYYYMMDDTHHMMSSmmm`` (UTC) plus 6 base36 random chars.
+
+    6 chars give ``36**6 ≈ 2.2e9`` possibilities per millisecond. With
+    realistic LLM-bound run rates (seconds per call) the birthday-paradox
+    collision probability is negligible.
+    """
     stamp = now.strftime("%Y%m%dT%H%M%S") + f"{now.microsecond // 1000:03d}"
-    suffix = "".join(secrets.choice(_BASE36) for _ in range(3))
+    suffix = "".join(secrets.choice(_BASE36) for _ in range(6))
     return f"{stamp}{suffix}"
 
 
@@ -67,6 +75,14 @@ def _serialise(record: RunRecord) -> str:
     )
 
 
+def _fsync_directory(path: Path) -> None:
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
 async def write_run_record(
     memory_dir: Path,
     record: RunRecord,
@@ -77,23 +93,35 @@ async def write_run_record(
 
     Atomicity:
 
-    - The per-run JSON file is written to ``<run_id>.json.tmp`` and
-      then ``os.replace``-d into place; same-FS rename is atomic on
-      POSIX, preventing partial reads.
+    - The per-run JSON file is written to a unique
+      ``.<run_id>.<rand>.tmp`` and ``os.replace``-d into place — POSIX
+      guarantees the rename is atomic on the same filesystem. The
+      unique tmp name keeps two writers from clobbering each other's
+      ``.tmp`` even if their ``run_id`` happens to collide.
     - The ``runs.jsonl`` append is serialised across one Python
       process via ``archive_lock``; cross-process concurrency is
       unsupported (documented in ``FilesystemMemory``).
+    - Both files and their parent directory entries are explicitly
+      ``flush()`` + ``os.fsync`` before the writer returns, so a crash
+      directly after this coroutine awaits will not lose the run record.
     """
     payload = _serialise(record)
     runs_dir = memory_dir / "runs"
     runs_dir.mkdir(parents=True, exist_ok=True)
     final = runs_dir / f"{record.run_id}.json"
-    tmp = runs_dir / f"{record.run_id}.json.tmp"
-    tmp.write_text(payload, encoding="utf-8")
+    tmp = runs_dir / f".{record.run_id}.{secrets.token_hex(8)}.tmp"
+    with tmp.open("w", encoding="utf-8") as fh:
+        fh.write(payload)
+        fh.flush()
+        os.fsync(fh.fileno())
     os.replace(tmp, final)
+    _fsync_directory(runs_dir)
 
     index = memory_dir / "runs.jsonl"
     async with archive_lock:
         with index.open("a", encoding="utf-8") as fh:
             fh.write(payload)
             fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        _fsync_directory(memory_dir)

--- a/quantmind/mind/memory/filesystem.py
+++ b/quantmind/mind/memory/filesystem.py
@@ -1,0 +1,116 @@
+"""``FilesystemMemory`` — MVP cross-step memory backed by an MCP filesystem server.
+
+Layout::
+
+    <memory_dir>/
+        notes/                # agent's free-form working notes (markdown)
+        items/                # typed KnowledgeItem JSON (PR7+)
+        runs/                 # trajectory archive — runs/<run_id>.json
+        runs.jsonl            # append-only run index
+        README.md             # agent-facing usage guide
+
+Requires Node.js + ``npx`` on PATH (the SDK's ``MCPServerStdio`` spawns
+``npx -y @modelcontextprotocol/server-filesystem``). ``__init__`` does
+**not** pre-flight-check ``npx``; the SDK surfaces a clear error at run
+time when it is missing.
+"""
+
+import asyncio
+import shutil
+from pathlib import Path
+from typing import Any
+
+from agents import RunHooks, Tool
+from agents.mcp import MCPServer, MCPServerStdio
+
+from quantmind.mind.memory._run_hooks import MemoryRunHooks
+
+_AGENT_README_TEXT = """\
+# Memory directory for QuantMind flow run
+
+Available subdirectories:
+- `notes/` — your free-form working notes (markdown). Read existing notes
+  before writing new ones.
+- `items/` — structured KnowledgeItem JSON files emitted by previous runs.
+- `runs/` — system-managed run trajectory logs (do not edit).
+- `runs.jsonl` — append-only run index (system-managed, do not edit).
+
+Guidelines:
+1. BEFORE doing your task, list `notes/` and `items/` to see relevant
+   prior context.
+2. When you find a fact worth remembering, write a short markdown note
+   under `notes/`, named `<topic>_<short_slug>.md`.
+3. Don't repeat work. If the same item is already in `items/`, prefer
+   to reference rather than re-extract.
+"""
+
+
+def _is_forbidden_path(path: Path) -> bool:
+    return path == Path("/") or path == Path.home()
+
+
+class FilesystemMemory:
+    """Filesystem-backed cross-step memory using the MCP filesystem server.
+
+    Constructed once per serial loop / batch; passed to ``paper_flow``
+    via the ``memory=`` kwarg. Each ``run_hooks()`` invocation returns
+    a fresh ``MemoryRunHooks`` so per-run accumulator state is isolated;
+    they share the per-instance ``asyncio.Lock`` that serialises
+    ``runs.jsonl`` appends.
+    """
+
+    def __init__(self, memory_dir: str | Path) -> None:
+        self.memory_dir = Path(memory_dir).resolve()
+        if _is_forbidden_path(self.memory_dir):
+            raise ValueError(
+                "memory_dir must not be '/' or the user home directory; "
+                "choose a dedicated subdirectory."
+            )
+        for sub in ("notes", "items", "runs"):
+            (self.memory_dir / sub).mkdir(parents=True, exist_ok=True)
+        readme = self.memory_dir / "README.md"
+        if not readme.exists():
+            readme.write_text(_AGENT_README_TEXT, encoding="utf-8")
+        self._archive_lock = asyncio.Lock()
+
+    def tools(self) -> list[Tool]:
+        return []
+
+    def mcp_servers(self) -> list[MCPServer]:
+        return [
+            MCPServerStdio(
+                name="quantmind_memory_fs",
+                params={
+                    "command": "npx",
+                    "args": [
+                        "-y",
+                        "@modelcontextprotocol/server-filesystem",
+                        str(self.memory_dir),
+                    ],
+                },
+            )
+        ]
+
+    def run_hooks(self) -> RunHooks[Any] | None:
+        return MemoryRunHooks(
+            memory_dir=self.memory_dir,
+            archive_lock=self._archive_lock,
+        )
+
+    async def reset(self) -> None:
+        """Wipe ``notes/``, ``items/``, ``runs/``, and ``runs.jsonl``.
+
+        Destructive — irreversibly removes every file under those paths.
+        Re-creates the empty subdirectories and seeds the agent README
+        afterwards.
+        """
+        for sub in ("notes", "items", "runs"):
+            shutil.rmtree(self.memory_dir / sub, ignore_errors=True)
+        runs_jsonl = self.memory_dir / "runs.jsonl"
+        if runs_jsonl.exists():
+            runs_jsonl.unlink()
+        for sub in ("notes", "items", "runs"):
+            (self.memory_dir / sub).mkdir(parents=True, exist_ok=True)
+        readme = self.memory_dir / "README.md"
+        if not readme.exists():
+            readme.write_text(_AGENT_README_TEXT, encoding="utf-8")

--- a/quantmind/mind/memory/filesystem.py
+++ b/quantmind/mind/memory/filesystem.py
@@ -122,6 +122,12 @@ class FilesystemMemory:
         return []
 
     def mcp_servers(self) -> list[MCPServer]:
+        # The SDK default 5s timeout is too tight for the first run of
+        # `npx -y @modelcontextprotocol/server-filesystem` (npm has to
+        # resolve + extract the package on a cold cache, easily 10-20s
+        # on slow connections). Bumping to 30s keeps subsequent
+        # already-cached runs fast (~hundreds of ms to launch) while
+        # making the first-run experience reliable.
         return [
             MCPServerStdio(
                 name="quantmind_memory_fs",
@@ -133,6 +139,7 @@ class FilesystemMemory:
                         str(self.workspace),
                     ],
                 },
+                client_session_timeout_seconds=30.0,
             )
         ]
 

--- a/quantmind/mind/memory/filesystem.py
+++ b/quantmind/mind/memory/filesystem.py
@@ -3,11 +3,18 @@
 Layout::
 
     <memory_dir>/
-        notes/                # agent's free-form working notes (markdown)
-        items/                # typed KnowledgeItem JSON (PR7+)
-        runs/                 # trajectory archive — runs/<run_id>.json
-        runs.jsonl            # append-only run index
-        README.md             # agent-facing usage guide
+        .quantmind-memory     # marker — guards against using a non-QM directory
+        workspace/            # MCP root (Agent-visible)
+            notes/            # Agent's free-form working notes (markdown)
+            items/            # typed KnowledgeItem JSON (PR7+)
+            README.md         # Agent-facing usage guide
+        runs/                 # system-only trajectory archive (NOT exposed to Agent)
+            <run_id>.json
+        runs.jsonl            # system-only append-only run index
+
+The MCP filesystem server is rooted at ``workspace/`` so the Agent
+cannot read or write the trajectory archive — that keeps run records
+tamper-proof under prompt injection.
 
 Requires Node.js + ``npx`` on PATH (the SDK's ``MCPServerStdio`` spawns
 ``npx -y @modelcontextprotocol/server-filesystem``). ``__init__`` does
@@ -26,14 +33,12 @@ from agents.mcp import MCPServer, MCPServerStdio
 from quantmind.mind.memory._run_hooks import MemoryRunHooks
 
 _AGENT_README_TEXT = """\
-# Memory directory for QuantMind flow run
+# Memory workspace for QuantMind flow run
 
 Available subdirectories:
 - `notes/` — your free-form working notes (markdown). Read existing notes
   before writing new ones.
 - `items/` — structured KnowledgeItem JSON files emitted by previous runs.
-- `runs/` — system-managed run trajectory logs (do not edit).
-- `runs.jsonl` — append-only run index (system-managed, do not edit).
 
 Guidelines:
 1. BEFORE doing your task, list `notes/` and `items/` to see relevant
@@ -44,9 +49,24 @@ Guidelines:
    to reference rather than re-extract.
 """
 
+_MARKER_NAME = ".quantmind-memory"
+
+_FORBIDDEN_PATHS = frozenset(
+    {
+        Path("/"),
+        Path.home(),
+        Path("/tmp"),
+        Path("/var"),
+        Path("/etc"),
+        Path("/usr"),
+        Path("/opt"),
+        Path("/private"),
+    }
+)
+
 
 def _is_forbidden_path(path: Path) -> bool:
-    return path == Path("/") or path == Path.home()
+    return path in _FORBIDDEN_PATHS
 
 
 class FilesystemMemory:
@@ -57,20 +77,45 @@ class FilesystemMemory:
     a fresh ``MemoryRunHooks`` so per-run accumulator state is isolated;
     they share the per-instance ``asyncio.Lock`` that serialises
     ``runs.jsonl`` appends.
+
+    The Agent only sees ``workspace/``; ``runs/`` and ``runs.jsonl``
+    are out-of-reach.
     """
 
     def __init__(self, memory_dir: str | Path) -> None:
         self.memory_dir = Path(memory_dir).resolve()
         if _is_forbidden_path(self.memory_dir):
             raise ValueError(
-                "memory_dir must not be '/' or the user home directory; "
-                "choose a dedicated subdirectory."
+                f"memory_dir {self.memory_dir!s} is on the protected list "
+                f"({sorted(str(p) for p in _FORBIDDEN_PATHS)}); choose a "
+                "dedicated subdirectory."
             )
-        for sub in ("notes", "items", "runs"):
-            (self.memory_dir / sub).mkdir(parents=True, exist_ok=True)
-        readme = self.memory_dir / "README.md"
+
+        marker = self.memory_dir / _MARKER_NAME
+        if (
+            self.memory_dir.exists()
+            and any(self.memory_dir.iterdir())
+            and not marker.exists()
+        ):
+            raise ValueError(
+                f"memory_dir {self.memory_dir!s} is non-empty and lacks the "
+                f"{_MARKER_NAME!r} marker; refusing to manage it. Either "
+                "point FilesystemMemory at an empty / fresh directory, or "
+                f"add an empty {_MARKER_NAME!r} file to claim the directory."
+            )
+
+        self.memory_dir.mkdir(parents=True, exist_ok=True)
+        marker.touch(exist_ok=True)
+
+        self.workspace = self.memory_dir / "workspace"
+        for sub in ("notes", "items"):
+            (self.workspace / sub).mkdir(parents=True, exist_ok=True)
+        (self.memory_dir / "runs").mkdir(parents=True, exist_ok=True)
+
+        readme = self.workspace / "README.md"
         if not readme.exists():
             readme.write_text(_AGENT_README_TEXT, encoding="utf-8")
+
         self._archive_lock = asyncio.Lock()
 
     def tools(self) -> list[Tool]:
@@ -85,7 +130,7 @@ class FilesystemMemory:
                     "args": [
                         "-y",
                         "@modelcontextprotocol/server-filesystem",
-                        str(self.memory_dir),
+                        str(self.workspace),
                     ],
                 },
             )
@@ -98,19 +143,28 @@ class FilesystemMemory:
         )
 
     async def reset(self) -> None:
-        """Wipe ``notes/``, ``items/``, ``runs/``, and ``runs.jsonl``.
+        """Wipe ``workspace/`` and ``runs/`` plus ``runs.jsonl``.
 
         Destructive — irreversibly removes every file under those paths.
-        Re-creates the empty subdirectories and seeds the agent README
-        afterwards.
+        The marker file is preserved so subsequent ``FilesystemMemory``
+        constructions on the same directory remain allowed. Deletion
+        errors are NOT silently swallowed: ``shutil.rmtree`` is called
+        without ``ignore_errors`` so any underlying issue (permission,
+        in-use file, ...) surfaces to the caller.
         """
-        for sub in ("notes", "items", "runs"):
-            shutil.rmtree(self.memory_dir / sub, ignore_errors=True)
-        runs_jsonl = self.memory_dir / "runs.jsonl"
-        if runs_jsonl.exists():
-            runs_jsonl.unlink()
-        for sub in ("notes", "items", "runs"):
-            (self.memory_dir / sub).mkdir(parents=True, exist_ok=True)
-        readme = self.memory_dir / "README.md"
+        for sub_path in (self.workspace, self.memory_dir / "runs"):
+            sub_resolved = sub_path.resolve()
+            if not sub_resolved.is_relative_to(self.memory_dir):
+                raise ValueError(
+                    f"Refusing to delete outside memory_dir: {sub_resolved!s}"
+                )
+            if sub_resolved.exists():
+                shutil.rmtree(sub_resolved)
+        (self.memory_dir / "runs.jsonl").unlink(missing_ok=True)
+
+        for sub in ("notes", "items"):
+            (self.workspace / sub).mkdir(parents=True, exist_ok=True)
+        (self.memory_dir / "runs").mkdir(parents=True, exist_ok=True)
+        readme = self.workspace / "README.md"
         if not readme.exists():
             readme.write_text(_AGENT_README_TEXT, encoding="utf-8")

--- a/scripts/check_system_deps.py
+++ b/scripts/check_system_deps.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Check system-level (non-Python) dependencies for QuantMind.
+
+Python deps are managed by ``pyproject.toml`` + ``uv pip install``.
+This script enumerates the *additional* system tools certain optional
+features rely on at runtime, prints their status, and exits non-zero
+when a **required** dep is missing. Optional deps are reported with
+their install hint but do not fail the check.
+
+**Adding a new dependency:** append one entry to ``_DEPS``. The
+README install flow does not need to change.
+
+Standalone:
+
+    python scripts/check_system_deps.py
+
+From the setup script:
+
+    bash scripts/setup.sh   # also calls this at the end
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class SystemDep:
+    """One non-Python external tool QuantMind may need at runtime."""
+
+    name: str  # human display name
+    binary: str  # executable to look for on PATH
+    version_args: tuple[str, ...]  # arguments that print a version
+    feature: str  # which QuantMind feature requires it
+    required: bool  # True = blocks setup; False = informational
+    install_hint: str  # short install hint shown when missing
+
+
+_DEPS: tuple[SystemDep, ...] = (
+    SystemDep(
+        name="Node.js",
+        binary="node",
+        version_args=("--version",),
+        feature="FilesystemMemory (MCP filesystem server)",
+        required=False,
+        install_hint=(
+            "brew install node  # macOS\n"
+            "    sudo apt-get install -y nodejs  # Debian/Ubuntu"
+        ),
+    ),
+    SystemDep(
+        name="npx",
+        binary="npx",
+        version_args=("--version",),
+        feature="FilesystemMemory (MCP filesystem server)",
+        required=False,
+        install_hint="installed alongside Node.js",
+    ),
+    # PR7+ will likely append: SystemDep("sqlite-vec", ...), etc.
+)
+
+
+def _probe(dep: SystemDep) -> tuple[bool, str]:
+    """Return ``(found, info)`` for a single dependency."""
+    path = shutil.which(dep.binary)
+    if path is None:
+        return False, "not found on PATH"
+    try:
+        completed = subprocess.run(
+            [path, *dep.version_args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, f"probe failed: {exc}"
+    if completed.returncode != 0:
+        return False, f"version check failed (rc={completed.returncode})"
+    output = completed.stdout or completed.stderr
+    first_line = (
+        output.strip().splitlines()[0]
+        if output.strip()
+        else "(no version output)"
+    )
+    return True, first_line
+
+
+def main() -> int:
+    """Run the audit and return a process exit code (0 = OK, 1 = blocker)."""
+    print("Checking QuantMind system dependencies\n")
+    missing_required: list[SystemDep] = []
+    missing_optional: list[SystemDep] = []
+
+    for dep in _DEPS:
+        ok, info = _probe(dep)
+        if ok:
+            status = "✓ OK"
+        elif dep.required:
+            status = "✗ MISSING (required)"
+            missing_required.append(dep)
+        else:
+            status = "· MISSING (optional)"
+            missing_optional.append(dep)
+        print(f"  {status:<22s} {dep.name:<10s}  {info}")
+        print(f"  {'':<22s}   used by: {dep.feature}")
+        if not ok:
+            for line in dep.install_hint.splitlines():
+                print(f"  {'':<22s}   install: {line}")
+        print()
+
+    if missing_required:
+        names = ", ".join(d.name for d in missing_required)
+        print(f"✗ {len(missing_required)} required dep(s) missing: {names}")
+        return 1
+
+    if missing_optional:
+        names = ", ".join(d.name for d in missing_optional)
+        print(
+            f"All required deps OK. Optional missing: {names} "
+            "(install only if you use the listed features)."
+        )
+    else:
+        print("All system deps present (required + optional).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# QuantMind one-shot setup: Python deps via uv + system dep audit.
+#
+# Idempotent — safe to re-run after pulling new dependencies. Adding
+# new external (non-Python) deps means appending one row to
+# scripts/check_system_deps.py; this script does not need to change.
+#
+# Usage:
+#   bash scripts/setup.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "[ERROR] uv not on PATH. Install it first:"
+  echo "    curl -LsSf https://astral.sh/uv/install.sh | sh"
+  echo "    # or:  pip install uv"
+  exit 1
+fi
+
+echo "==> [1/3] Creating venv (.venv) if missing"
+uv venv
+
+# Bind uv to *this project's* venv explicitly. Without this, `uv pip
+# install` may resolve to a different interpreter (e.g., an active
+# conda env) and install there instead, which leaves .venv empty.
+export VIRTUAL_ENV="$PWD/.venv"
+PY="$VIRTUAL_ENV/bin/python"
+
+echo
+echo "==> [2/3] Installing Python deps (editable, with dev extras)"
+uv pip install --python "$PY" -e ".[dev]"
+
+echo
+echo "==> [3/3] Checking system (non-Python) dependencies"
+# We don't fail setup on *optional* deps; check_system_deps.py exits
+# non-zero only when a required dep is missing.
+"$PY" scripts/check_system_deps.py
+
+echo
+echo "==> Setup complete."
+echo "    source .venv/bin/activate"
+echo "    bash scripts/verify.sh   # full local check before push"

--- a/tests/flows/test_paper.py
+++ b/tests/flows/test_paper.py
@@ -216,6 +216,7 @@ class FormatInputTests(unittest.TestCase):
         self.assertNotIn("b:", out)
 
 
+@patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=False)
 class PaperFlowTests(unittest.IsolatedAsyncioTestCase):
     async def test_happy_path_arxiv(self) -> None:
         raw_paper = RawPaper(
@@ -347,6 +348,7 @@ class PaperFlowTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("model_settings", seen)
 
 
+@patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=False)
 class PaperFlowMemoryWiringTests(unittest.IsolatedAsyncioTestCase):
     async def test_memory_mcp_servers_passed_to_agent(self) -> None:
         import tempfile

--- a/tests/flows/test_paper.py
+++ b/tests/flows/test_paper.py
@@ -299,18 +299,6 @@ class PaperFlowTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(seen["input_guardrails"], [in_g])
         self.assertEqual(seen["output_guardrails"], [out_g])
 
-    async def test_memory_accepted_as_no_op(self) -> None:
-        with (
-            patch(
-                "quantmind.flows.paper.Agent",
-                return_value=MagicMock(),
-            ),
-            _patch_runner(_stub_paper()) as runner,
-        ):
-            await paper_flow(RawText(text="x"), memory=object())
-        # The runner sees the memory placeholder forwarded.
-        self.assertIsNotNone(runner.await_args.kwargs["memory"])
-
     async def test_extra_run_hooks_forwarded(self) -> None:
         class _H(RunHooks[Any]):
             pass
@@ -357,3 +345,89 @@ class PaperFlowTests(unittest.IsolatedAsyncioTestCase):
         ):
             await paper_flow(RawText(text="x"))
         self.assertNotIn("model_settings", seen)
+
+
+class PaperFlowMemoryWiringTests(unittest.IsolatedAsyncioTestCase):
+    async def test_memory_mcp_servers_passed_to_agent(self) -> None:
+        import tempfile
+
+        from quantmind.mind.memory import FilesystemMemory
+
+        seen: dict[str, Any] = {}
+
+        def _capture_agent(*_a: Any, **kwargs: Any) -> Any:
+            seen.update(kwargs)
+            return MagicMock()
+
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            with (
+                patch(
+                    "quantmind.flows.paper.Agent",
+                    side_effect=_capture_agent,
+                ),
+                _patch_runner(_stub_paper()),
+            ):
+                await paper_flow(RawText(text="hello"), memory=mem)
+        self.assertEqual(len(seen["mcp_servers"]), 1)
+
+    async def test_no_memory_yields_empty_mcp_servers_and_tools(
+        self,
+    ) -> None:
+        seen: dict[str, Any] = {}
+
+        def _capture_agent(*_a: Any, **kwargs: Any) -> Any:
+            seen.update(kwargs)
+            return MagicMock()
+
+        with (
+            patch("quantmind.flows.paper.Agent", side_effect=_capture_agent),
+            _patch_runner(_stub_paper()),
+        ):
+            await paper_flow(RawText(text="hello"))
+        self.assertEqual(seen["mcp_servers"], [])
+        self.assertEqual(seen["tools"], [])
+
+    async def test_memory_tools_appended_after_extra_tools(self) -> None:
+        from agents import function_tool
+
+        @function_tool
+        def _extra_tool() -> str:
+            return ""
+
+        @function_tool
+        def _memory_tool() -> str:
+            return ""
+
+        class _ToolMemory:
+            def tools(self) -> list:
+                return [_memory_tool]
+
+            def mcp_servers(self) -> list:
+                return []
+
+            def run_hooks(self) -> Any:
+                return None
+
+            async def reset(self) -> None:
+                return None
+
+        seen: dict[str, Any] = {}
+
+        def _capture_agent(*_a: Any, **kwargs: Any) -> Any:
+            seen.update(kwargs)
+            return MagicMock()
+
+        with (
+            patch("quantmind.flows.paper.Agent", side_effect=_capture_agent),
+            _patch_runner(_stub_paper()),
+        ):
+            await paper_flow(
+                RawText(text="x"),
+                extra_tools=[_extra_tool],
+                memory=_ToolMemory(),
+            )
+        # Order: extra_tools first, then memory_tools.
+        self.assertEqual(len(seen["tools"]), 2)
+        self.assertIs(seen["tools"][0], _extra_tool)
+        self.assertIs(seen["tools"][1], _memory_tool)

--- a/tests/flows/test_paper.py
+++ b/tests/flows/test_paper.py
@@ -274,7 +274,8 @@ class PaperFlowTests(unittest.IsolatedAsyncioTestCase):
             _patch_runner(_stub_paper()),
         ):
             await paper_flow(RawText(text="x"), output_type=MyPaper)
-        self.assertIs(seen["output_type"], MyPaper)
+        # paper_flow wraps the output_type in AgentOutputSchema(strict=False).
+        self.assertIs(seen["output_type"].output_type, MyPaper)
 
     async def test_extra_tools_and_guardrails_forwarded(self) -> None:
         seen: dict[str, Any] = {}
@@ -433,3 +434,92 @@ class PaperFlowMemoryWiringTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(seen["tools"]), 2)
         self.assertIs(seen["tools"][0], _extra_tool)
         self.assertIs(seen["tools"][1], _memory_tool)
+
+
+class ExtractJsonHelperTests(unittest.TestCase):
+    def test_bare_json_unchanged(self) -> None:
+        from quantmind.flows.paper import _extract_json
+
+        s = '{"k": "v"}'
+        self.assertEqual(_extract_json(s), s)
+
+    def test_strips_fences_with_language_tag(self) -> None:
+        from quantmind.flows.paper import _extract_json
+
+        s = '```json\n{"k": "v"}\n```'
+        self.assertEqual(_extract_json(s), '{"k": "v"}')
+
+    def test_strips_fences_without_language_tag(self) -> None:
+        from quantmind.flows.paper import _extract_json
+
+        s = '```\n{"k": "v"}\n```'
+        self.assertEqual(_extract_json(s), '{"k": "v"}')
+
+    def test_handles_trailing_whitespace(self) -> None:
+        from quantmind.flows.paper import _extract_json
+
+        s = '  ```json\n{"k": "v"}\n```\n\n'
+        self.assertEqual(_extract_json(s), '{"k": "v"}')
+
+
+@patch.dict("os.environ", {"DEEPSEEK_API_KEY": "sk-test-deepseek"}, clear=False)
+class PaperFlowJsonModeBranchTests(unittest.IsolatedAsyncioTestCase):
+    """Tests for the ``supports_json_schema=False`` branch (DeepSeek-like)."""
+
+    async def test_json_mode_path_skips_output_type_and_sets_extra_body(
+        self,
+    ) -> None:
+        seen: dict[str, Any] = {}
+
+        def _capture_agent(*_a: Any, **kwargs: Any) -> Any:
+            seen.update(kwargs)
+            return MagicMock()
+
+        stub_paper = _stub_paper()
+        # Runner returns a JSON string that round-trips through
+        # Paper.model_validate_json — the simplest reliable way is to
+        # round-trip the stub.
+        json_payload = stub_paper.model_dump_json()
+
+        with (
+            patch("quantmind.flows.paper.Agent", side_effect=_capture_agent),
+            patch(
+                "quantmind.flows.paper.run_with_observability",
+                new=AsyncMock(return_value=json_payload),
+            ),
+        ):
+            out = await paper_flow(
+                RawText(text="x"),
+                cfg=PaperFlowCfg(model="deepseek-chat"),
+            )
+
+        # output_type must NOT be set in the json_object path.
+        self.assertNotIn("output_type", seen)
+        # response_format=json_object must be in extra_body.
+        ms = seen["model_settings"]
+        self.assertEqual(
+            ms.extra_body["response_format"], {"type": "json_object"}
+        )
+        # Instructions must embed the schema for the model to follow.
+        self.assertIn("JSON Schema", seen["instructions"])
+        # Final return must be a parsed Paper instance, not the raw string.
+        self.assertIsInstance(out, Paper)
+        self.assertEqual(out.root_node_id, stub_paper.root_node_id)
+
+    async def test_json_mode_path_strips_markdown_fences(self) -> None:
+        stub_paper = _stub_paper()
+        json_payload = stub_paper.model_dump_json()
+        fenced = f"```json\n{json_payload}\n```"
+
+        with (
+            patch("quantmind.flows.paper.Agent", return_value=MagicMock()),
+            patch(
+                "quantmind.flows.paper.run_with_observability",
+                new=AsyncMock(return_value=fenced),
+            ),
+        ):
+            out = await paper_flow(
+                RawText(text="x"),
+                cfg=PaperFlowCfg(model="deepseek-chat"),
+            )
+        self.assertIsInstance(out, Paper)

--- a/tests/flows/test_providers.py
+++ b/tests/flows/test_providers.py
@@ -8,7 +8,12 @@ from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from agents.models.openai_responses import OpenAIResponsesModel
 
 from quantmind.configs import PaperFlowCfg
-from quantmind.flows._providers import _get_client, _resolve, configure_provider
+from quantmind.flows._providers import (
+    _get_client,
+    _resolve,
+    configure_provider,
+    provider_capabilities,
+)
 
 
 class ResolveTests(unittest.TestCase):
@@ -98,3 +103,19 @@ class ConfigureProviderTests(unittest.TestCase):
             m2, _ = configure_provider(cfg)
         # Both Model wrappers should share the same underlying client.
         self.assertIs(m1._client, m2._client)
+
+
+class ProviderCapabilitiesTests(unittest.TestCase):
+    def test_openai_supports_json_schema(self) -> None:
+        caps = provider_capabilities("gpt-4o")
+        self.assertTrue(caps.supports_json_schema)
+        self.assertEqual(caps.name, "openai")
+
+    def test_deepseek_lacks_json_schema(self) -> None:
+        caps = provider_capabilities("deepseek-chat")
+        self.assertFalse(caps.supports_json_schema)
+        self.assertEqual(caps.name, "deepseek")
+
+    def test_unknown_model_inherits_default_caps(self) -> None:
+        caps = provider_capabilities("some-future-model")
+        self.assertTrue(caps.supports_json_schema)  # fallback = OpenAI

--- a/tests/flows/test_providers.py
+++ b/tests/flows/test_providers.py
@@ -1,0 +1,100 @@
+"""Tests for ``quantmind.flows._providers``."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
+from agents.models.openai_responses import OpenAIResponsesModel
+
+from quantmind.configs import PaperFlowCfg
+from quantmind.flows._providers import _get_client, _resolve, configure_provider
+
+
+class ResolveTests(unittest.TestCase):
+    def test_gpt_prefix_resolves_to_openai_responses(self) -> None:
+        provider = _resolve("gpt-4o")
+        self.assertEqual(provider.name, "openai")
+        self.assertIsNone(provider.base_url)
+        self.assertFalse(provider.use_chat_completions)
+        self.assertTrue(provider.tracing_supported)
+
+    def test_deepseek_prefix_resolves_to_chat_completions(self) -> None:
+        provider = _resolve("deepseek-chat")
+        self.assertEqual(provider.name, "deepseek")
+        self.assertEqual(provider.base_url, "https://api.deepseek.com/v1")
+        self.assertTrue(provider.use_chat_completions)
+        self.assertFalse(provider.tracing_supported)
+
+    def test_o1_prefix_resolves_to_openai_responses(self) -> None:
+        provider = _resolve("o1-mini")
+        self.assertEqual(provider.name, "openai")
+        self.assertFalse(provider.use_chat_completions)
+
+    def test_o3_prefix_resolves_to_openai_responses(self) -> None:
+        provider = _resolve("o3-mini")
+        self.assertEqual(provider.name, "openai")
+
+    def test_unknown_model_falls_back_to_default_openai(self) -> None:
+        provider = _resolve("some-future-model")
+        # Falls back to OpenAI gpt-* row.
+        self.assertEqual(provider.name, "openai")
+
+    def test_resolution_is_case_insensitive(self) -> None:
+        self.assertEqual(_resolve("DEEPSEEK-Chat").name, "deepseek")
+        self.assertEqual(_resolve("GPT-4o").name, "openai")
+
+
+class ConfigureProviderTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Clear the AsyncOpenAI cache so each test starts clean.
+        _get_client.cache_clear()
+
+    def test_openai_returns_responses_model_with_unchanged_tracing(
+        self,
+    ) -> None:
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False):
+            cfg = PaperFlowCfg(model="gpt-4o", tracing_disabled=False)
+            model_obj, effective = configure_provider(cfg)
+        self.assertIsInstance(model_obj, OpenAIResponsesModel)
+        self.assertFalse(effective.tracing_disabled)
+
+    def test_deepseek_returns_chat_completions_with_tracing_forced_off(
+        self,
+    ) -> None:
+        with patch.dict(
+            os.environ, {"DEEPSEEK_API_KEY": "sk-deepseek"}, clear=False
+        ):
+            cfg = PaperFlowCfg(model="deepseek-chat", tracing_disabled=False)
+            model_obj, effective = configure_provider(cfg)
+        self.assertIsInstance(model_obj, OpenAIChatCompletionsModel)
+        self.assertTrue(effective.tracing_disabled)
+
+    def test_user_tracing_disabled_preserved_for_openai(self) -> None:
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False):
+            cfg = PaperFlowCfg(model="gpt-4o", tracing_disabled=True)
+            _, effective = configure_provider(cfg)
+        self.assertTrue(effective.tracing_disabled)
+
+    def test_missing_api_key_raises_with_clear_message(self) -> None:
+        # Wipe both env vars to make sure neither leaks into the test.
+        with patch.dict(
+            os.environ,
+            {},
+            clear=False,
+        ):
+            os.environ.pop("DEEPSEEK_API_KEY", None)
+            cfg = PaperFlowCfg(model="deepseek-chat")
+            with self.assertRaises(RuntimeError) as ctx:
+                configure_provider(cfg)
+        msg = str(ctx.exception)
+        self.assertIn("DEEPSEEK_API_KEY", msg)
+        self.assertIn("deepseek", msg)
+
+    def test_client_is_cached_per_base_url_and_api_key(self) -> None:
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False):
+            cfg = PaperFlowCfg(model="gpt-4o")
+            m1, _ = configure_provider(cfg)
+            m2, _ = configure_provider(cfg)
+        # Both Model wrappers should share the same underlying client.
+        self.assertIs(m1._client, m2._client)

--- a/tests/flows/test_runner.py
+++ b/tests/flows/test_runner.py
@@ -241,7 +241,64 @@ class RunnerMemoryWiringTests(unittest.IsolatedAsyncioTestCase):
                     )
             self.assertEqual(mock_write.await_count, 1)
             record = mock_write.await_args.args[1]
-            self.assertEqual(record.error, "boom")
+            self.assertEqual(record.error, "RuntimeError: boom")
+
+    async def test_persist_failure_does_not_mask_run_error(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            cfg = PaperFlowCfg()
+            agent = MagicMock()
+            agent.name = "paper_extractor"
+            boom = RuntimeError("boom")
+            with (
+                patch(
+                    "quantmind.flows._runner.Runner.run",
+                    new=AsyncMock(side_effect=boom),
+                ),
+                patch(
+                    "quantmind.mind.memory._run_hooks.write_run_record",
+                    new=AsyncMock(side_effect=OSError("disk full")),
+                ) as mock_write,
+                patch("quantmind.flows._runner.logger.warning") as warning,
+            ):
+                with self.assertRaises(RuntimeError) as ctx:
+                    await run_with_observability(
+                        agent,
+                        "input",
+                        cfg=cfg,
+                        memory=mem,
+                        extra_run_hooks=[],
+                    )
+            self.assertIs(ctx.exception, boom)
+            self.assertEqual(mock_write.await_count, 1)
+            warning.assert_called_once()
+
+    async def test_persist_failure_surfaces_after_success(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            cfg = PaperFlowCfg()
+            agent = MagicMock()
+            agent.name = "paper_extractor"
+            with (
+                patch(
+                    "quantmind.flows._runner.Runner.run",
+                    new=AsyncMock(return_value=_FakeRunResult("done")),
+                ),
+                patch(
+                    "quantmind.mind.memory._run_hooks.write_run_record",
+                    new=AsyncMock(side_effect=OSError("disk full")),
+                ) as mock_write,
+            ):
+                with self.assertRaises(OSError) as ctx:
+                    await run_with_observability(
+                        agent,
+                        "input",
+                        cfg=cfg,
+                        memory=mem,
+                        extra_run_hooks=[],
+                    )
+            self.assertEqual(str(ctx.exception), "disk full")
+            self.assertEqual(mock_write.await_count, 1)
 
     async def test_archive_trajectory_false_skips_memory_hooks(
         self,

--- a/tests/flows/test_runner.py
+++ b/tests/flows/test_runner.py
@@ -1,5 +1,6 @@
 """Tests for ``quantmind.flows._runner``."""
 
+import tempfile
 import unittest
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,12 +9,11 @@ from agents import RunHooks
 
 from quantmind.configs import PaperFlowCfg
 from quantmind.flows._runner import (
-    _archive_run_artifacts,
-    _collect_hooks,
     _compose_hooks,
     _CompositeRunHooks,
     run_with_observability,
 )
+from quantmind.mind.memory import FilesystemMemory
 
 
 class _RecordingHooks(RunHooks[Any]):
@@ -45,6 +45,12 @@ class _RecordingHooks(RunHooks[Any]):
         self.log.append((self.label, "on_tool_end"))
 
 
+class _FakeRunResult:
+    def __init__(self, output: str = "ok") -> None:
+        self.final_output = output
+        self.trace_id = "trace_xyz"
+
+
 class ComposeHooksTests(unittest.TestCase):
     def test_empty_returns_none(self) -> None:
         self.assertIsNone(_compose_hooks([]))
@@ -73,7 +79,6 @@ class CompositeRunHooksTests(unittest.IsolatedAsyncioTestCase):
         await composite.on_handoff()
         await composite.on_tool_start()
         await composite.on_tool_end()
-        # Each method fires for both hooks in registration order.
         for method in (
             "on_llm_start",
             "on_llm_end",
@@ -98,26 +103,6 @@ class CompositeRunHooksTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(RuntimeError):
             await composite.on_llm_start()
         self.assertEqual(log, [])
-
-
-class CollectHooksTests(unittest.TestCase):
-    def test_memory_contributes_nothing_in_pr5(self) -> None:
-        extra = _RecordingHooks("a", [])
-        # PR5: memory is forwarded but unused.
-        self.assertEqual(_collect_hooks(None, [extra]), [extra])
-        self.assertEqual(_collect_hooks(object(), [extra]), [extra])
-
-    def test_no_extras_returns_empty(self) -> None:
-        self.assertEqual(_collect_hooks(None, []), [])
-
-
-class ArchiveStubTests(unittest.TestCase):
-    def test_archive_is_no_op(self) -> None:
-        cfg = PaperFlowCfg()
-        result = MagicMock()
-        # Must not raise, must return None, must not touch result.
-        self.assertIsNone(_archive_run_artifacts(cfg, None, result))
-        result.assert_not_called()
 
 
 class RunWithObservabilityTests(unittest.IsolatedAsyncioTestCase):
@@ -156,11 +141,10 @@ class RunWithObservabilityTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(run_cfg.trace_metadata, {"k": "v"})
         self.assertFalse(run_cfg.trace_include_sensitive_data)
         self.assertTrue(run_cfg.tracing_disabled)
-        # No hooks supplied -> Runner.run sees None.
         self.assertIsNone(call.kwargs["hooks"])
 
     async def test_workflow_name_falls_back_to_agent_name(self) -> None:
-        cfg = PaperFlowCfg()  # workflow_name = None
+        cfg = PaperFlowCfg()
         agent = MagicMock()
         agent.name = "paper_extractor"
         fake_result = MagicMock()
@@ -192,8 +176,115 @@ class RunWithObservabilityTests(unittest.IsolatedAsyncioTestCase):
                 agent,
                 "x",
                 cfg=cfg,
-                memory=object(),  # PR6 placeholder
+                memory=None,
                 extra_run_hooks=[hook],
             )
-        # Single hook -> passed through as-is, not wrapped in composite.
         self.assertIs(run_mock.await_args.kwargs["hooks"], hook)
+
+
+class RunnerMemoryWiringTests(unittest.IsolatedAsyncioTestCase):
+    async def test_persist_invoked_on_success(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            cfg = PaperFlowCfg()
+            agent = MagicMock()
+            agent.name = "paper_extractor"
+            with (
+                patch(
+                    "quantmind.flows._runner.Runner.run",
+                    new=AsyncMock(return_value=_FakeRunResult("done")),
+                ),
+                patch(
+                    "quantmind.mind.memory._run_hooks.write_run_record",
+                    new=AsyncMock(),
+                ) as mock_write,
+            ):
+                out = await run_with_observability(
+                    agent,
+                    "input",
+                    cfg=cfg,
+                    memory=mem,
+                    extra_run_hooks=[],
+                )
+            self.assertEqual(out, "done")
+            self.assertEqual(mock_write.await_count, 1)
+            record = mock_write.await_args.args[1]
+            self.assertIsNone(record.error)
+            self.assertEqual(record.trace_id, "trace_xyz")
+
+    async def test_persist_invoked_on_failure_with_error_string(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            cfg = PaperFlowCfg()
+            agent = MagicMock()
+            agent.name = "paper_extractor"
+            boom = RuntimeError("boom")
+            with (
+                patch(
+                    "quantmind.flows._runner.Runner.run",
+                    new=AsyncMock(side_effect=boom),
+                ),
+                patch(
+                    "quantmind.mind.memory._run_hooks.write_run_record",
+                    new=AsyncMock(),
+                ) as mock_write,
+            ):
+                with self.assertRaises(RuntimeError):
+                    await run_with_observability(
+                        agent,
+                        "input",
+                        cfg=cfg,
+                        memory=mem,
+                        extra_run_hooks=[],
+                    )
+            self.assertEqual(mock_write.await_count, 1)
+            record = mock_write.await_args.args[1]
+            self.assertEqual(record.error, "boom")
+
+    async def test_archive_trajectory_false_skips_memory_hooks(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            cfg = PaperFlowCfg(archive_trajectory=False)
+            agent = MagicMock()
+            agent.name = "paper_extractor"
+            with (
+                patch(
+                    "quantmind.flows._runner.Runner.run",
+                    new=AsyncMock(return_value=_FakeRunResult()),
+                ),
+                patch(
+                    "quantmind.mind.memory._run_hooks.write_run_record",
+                    new=AsyncMock(),
+                ) as mock_write,
+            ):
+                await run_with_observability(
+                    agent,
+                    "input",
+                    cfg=cfg,
+                    memory=mem,
+                    extra_run_hooks=[],
+                )
+            self.assertEqual(mock_write.await_count, 0)
+
+    async def test_no_memory_skips_persist(self) -> None:
+        cfg = PaperFlowCfg()
+        agent = MagicMock()
+        agent.name = "paper_extractor"
+        with (
+            patch(
+                "quantmind.flows._runner.Runner.run",
+                new=AsyncMock(return_value=_FakeRunResult()),
+            ),
+            patch(
+                "quantmind.mind.memory._run_hooks.write_run_record",
+                new=AsyncMock(),
+            ) as mock_write,
+        ):
+            await run_with_observability(
+                agent, "input", cfg=cfg, memory=None, extra_run_hooks=[]
+            )
+        self.assertEqual(mock_write.await_count, 0)

--- a/tests/mind/memory/test_filesystem.py
+++ b/tests/mind/memory/test_filesystem.py
@@ -7,25 +7,51 @@ from pathlib import Path
 from agents.mcp import MCPServerStdio
 
 from quantmind.mind.memory._run_hooks import MemoryRunHooks
-from quantmind.mind.memory.filesystem import FilesystemMemory
+from quantmind.mind.memory.filesystem import _MARKER_NAME, FilesystemMemory
 
 
 class FilesystemMemoryInitTests(unittest.TestCase):
     def test_creates_subdirs_and_readme(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             mem = FilesystemMemory(raw)
-            for sub in ("notes", "items", "runs"):
-                self.assertTrue((mem.memory_dir / sub).is_dir())
-            self.assertTrue((mem.memory_dir / "README.md").exists())
+            self.assertTrue((mem.memory_dir / _MARKER_NAME).exists())
+            self.assertTrue(mem.workspace.is_dir())
+            for sub in ("notes", "items"):
+                self.assertTrue((mem.workspace / sub).is_dir())
+            self.assertTrue((mem.memory_dir / "runs").is_dir())
+            self.assertTrue((mem.workspace / "README.md").exists())
 
     def test_readme_only_seeded_once(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             mem = FilesystemMemory(raw)
-            (mem.memory_dir / "README.md").write_text("custom")
+            (mem.workspace / "README.md").write_text("custom")
             FilesystemMemory(raw)
             self.assertEqual(
-                (mem.memory_dir / "README.md").read_text(), "custom"
+                (mem.workspace / "README.md").read_text(), "custom"
             )
+
+    def test_rejects_non_empty_directory_without_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw)
+            (path / "user-data.txt").write_text("x")
+            with self.assertRaises(ValueError):
+                FilesystemMemory(path)
+
+    def test_accepts_non_empty_directory_with_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw)
+            (path / _MARKER_NAME).touch()
+            (path / "user-data.txt").write_text("x")
+            mem = FilesystemMemory(path)
+            self.assertTrue(mem.workspace.is_dir())
+            self.assertTrue((path / "user-data.txt").exists())
+
+    def test_deleted_marker_rejects_existing_memory_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            (mem.memory_dir / _MARKER_NAME).unlink()
+            with self.assertRaises(ValueError):
+                FilesystemMemory(raw)
 
     def test_rejects_root_path(self) -> None:
         with self.assertRaises(ValueError):
@@ -48,6 +74,8 @@ class FilesystemMemoryMethodsTests(unittest.TestCase):
             servers = mem.mcp_servers()
             self.assertEqual(len(servers), 1)
             self.assertIsInstance(servers[0], MCPServerStdio)
+            self.assertEqual(servers[0].params.command, "npx")
+            self.assertEqual(servers[0].params.args[-1], str(mem.workspace))
 
     def test_mcp_servers_returns_fresh_instance_each_call(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
@@ -70,13 +98,16 @@ class FilesystemMemoryResetTests(unittest.IsolatedAsyncioTestCase):
     async def test_reset_wipes_subdirs_and_jsonl(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             mem = FilesystemMemory(raw)
-            (mem.memory_dir / "notes" / "n.md").write_text("x")
-            (mem.memory_dir / "items" / "i.json").write_text("{}")
+            (mem.workspace / "notes" / "n.md").write_text("x")
+            (mem.workspace / "items" / "i.json").write_text("{}")
             (mem.memory_dir / "runs" / "r.json").write_text("{}")
             (mem.memory_dir / "runs.jsonl").write_text("{}\n")
             await mem.reset()
-            for sub in ("notes", "items", "runs"):
-                self.assertTrue((mem.memory_dir / sub).is_dir())
-                self.assertEqual(list((mem.memory_dir / sub).iterdir()), [])
+            for sub in ("notes", "items"):
+                self.assertTrue((mem.workspace / sub).is_dir())
+                self.assertEqual(list((mem.workspace / sub).iterdir()), [])
+            self.assertTrue((mem.memory_dir / "runs").is_dir())
+            self.assertEqual(list((mem.memory_dir / "runs").iterdir()), [])
             self.assertFalse((mem.memory_dir / "runs.jsonl").exists())
-            self.assertTrue((mem.memory_dir / "README.md").exists())
+            self.assertTrue((mem.workspace / "README.md").exists())
+            self.assertTrue((mem.memory_dir / _MARKER_NAME).exists())

--- a/tests/mind/memory/test_filesystem.py
+++ b/tests/mind/memory/test_filesystem.py
@@ -1,0 +1,82 @@
+"""Tests for ``quantmind.mind.memory.filesystem``."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from agents.mcp import MCPServerStdio
+
+from quantmind.mind.memory._run_hooks import MemoryRunHooks
+from quantmind.mind.memory.filesystem import FilesystemMemory
+
+
+class FilesystemMemoryInitTests(unittest.TestCase):
+    def test_creates_subdirs_and_readme(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            for sub in ("notes", "items", "runs"):
+                self.assertTrue((mem.memory_dir / sub).is_dir())
+            self.assertTrue((mem.memory_dir / "README.md").exists())
+
+    def test_readme_only_seeded_once(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            (mem.memory_dir / "README.md").write_text("custom")
+            FilesystemMemory(raw)
+            self.assertEqual(
+                (mem.memory_dir / "README.md").read_text(), "custom"
+            )
+
+    def test_rejects_root_path(self) -> None:
+        with self.assertRaises(ValueError):
+            FilesystemMemory("/")
+
+    def test_rejects_home_path(self) -> None:
+        with self.assertRaises(ValueError):
+            FilesystemMemory(str(Path.home()))
+
+
+class FilesystemMemoryMethodsTests(unittest.TestCase):
+    def test_tools_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            self.assertEqual(mem.tools(), [])
+
+    def test_mcp_servers_returns_stdio_with_resolved_path(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            servers = mem.mcp_servers()
+            self.assertEqual(len(servers), 1)
+            self.assertIsInstance(servers[0], MCPServerStdio)
+
+    def test_mcp_servers_returns_fresh_instance_each_call(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            self.assertIsNot(mem.mcp_servers()[0], mem.mcp_servers()[0])
+
+    def test_run_hooks_returns_memory_run_hooks_with_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            h1 = mem.run_hooks()
+            h2 = mem.run_hooks()
+            self.assertIsInstance(h1, MemoryRunHooks)
+            self.assertIsNot(h1, h2)
+            assert isinstance(h1, MemoryRunHooks)
+            assert isinstance(h2, MemoryRunHooks)
+            self.assertIs(h1._archive_lock, h2._archive_lock)
+
+
+class FilesystemMemoryResetTests(unittest.IsolatedAsyncioTestCase):
+    async def test_reset_wipes_subdirs_and_jsonl(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem = FilesystemMemory(raw)
+            (mem.memory_dir / "notes" / "n.md").write_text("x")
+            (mem.memory_dir / "items" / "i.json").write_text("{}")
+            (mem.memory_dir / "runs" / "r.json").write_text("{}")
+            (mem.memory_dir / "runs.jsonl").write_text("{}\n")
+            await mem.reset()
+            for sub in ("notes", "items", "runs"):
+                self.assertTrue((mem.memory_dir / sub).is_dir())
+                self.assertEqual(list((mem.memory_dir / sub).iterdir()), [])
+            self.assertFalse((mem.memory_dir / "runs.jsonl").exists())
+            self.assertTrue((mem.memory_dir / "README.md").exists())

--- a/tests/mind/memory/test_protocol.py
+++ b/tests/mind/memory/test_protocol.py
@@ -1,0 +1,36 @@
+"""Tests for ``quantmind.mind.memory._protocol``."""
+
+import unittest
+from typing import Any
+
+from agents import RunHooks, Tool
+from agents.mcp import MCPServer
+
+from quantmind.mind.memory import Memory
+
+
+class _CompleteStub:
+    def tools(self) -> list[Tool]:
+        return []
+
+    def mcp_servers(self) -> list[MCPServer]:
+        return []
+
+    def run_hooks(self) -> RunHooks[Any] | None:
+        return None
+
+    async def reset(self) -> None:
+        return None
+
+
+class _MissingMethodStub:
+    def tools(self) -> list[Tool]:
+        return []
+
+
+class MemoryProtocolTests(unittest.TestCase):
+    def test_runtime_checkable_accepts_complete_stub(self) -> None:
+        self.assertIsInstance(_CompleteStub(), Memory)
+
+    def test_runtime_checkable_rejects_incomplete_stub(self) -> None:
+        self.assertNotIsInstance(_MissingMethodStub(), Memory)

--- a/tests/mind/memory/test_run_hooks.py
+++ b/tests/mind/memory/test_run_hooks.py
@@ -1,13 +1,14 @@
 """Tests for ``quantmind.mind.memory._run_hooks``."""
 
 import asyncio
+import json
 import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
-from quantmind.mind.memory._run_hooks import MemoryRunHooks
+from quantmind.mind.memory._run_hooks import MemoryRunHooks, _format_error
 
 
 def _make_hooks(tmpdir: Path) -> MemoryRunHooks:
@@ -76,6 +77,10 @@ class MemoryRunHooksLifecycleTests(unittest.IsolatedAsyncioTestCase):
             )
             self.assertEqual(len(hooks._tool_calls), 1)
             self.assertEqual(hooks._tool_calls[0]["name"], "read_file")
+            self.assertEqual(
+                hooks._tool_calls[0]["result_preview"], "file contents"
+            )
+            self.assertNotIn("args", hooks._tool_calls[0])
             self.assertGreaterEqual(hooks._tool_calls[0]["duration_s"], 0.0)
 
     async def test_on_agent_end_truncates_long_output(self) -> None:
@@ -134,4 +139,63 @@ class MemoryRunHooksPersistTests(unittest.IsolatedAsyncioTestCase):
                     input_payload="hi",
                 )
             record = mock_write.call_args.args[1]
-            self.assertEqual(record.error, "boom")
+            self.assertEqual(record.error, "ValueError: boom")
+
+    async def test_persist_writes_json_shape_end_to_end(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem_dir = Path(raw)
+            hooks = _make_hooks(mem_dir)
+            await hooks.on_agent_start(
+                SimpleNamespace(),
+                SimpleNamespace(name="a", model="gpt-4o", instructions="x"),
+            )
+            await hooks.on_tool_start(
+                SimpleNamespace(),
+                SimpleNamespace(),
+                SimpleNamespace(name="read_file"),
+            )
+            await hooks.on_tool_end(
+                SimpleNamespace(),
+                SimpleNamespace(),
+                SimpleNamespace(name="read_file"),
+                "file contents",
+            )
+            await hooks.on_agent_end(
+                SimpleNamespace(), SimpleNamespace(), "out"
+            )
+
+            await hooks.persist(
+                workflow_name="quantmind.paper_flow",
+                result=SimpleNamespace(trace_id="trace_xx"),
+                error=None,
+                input_payload="hello",
+            )
+
+            run_files = list((mem_dir / "runs").glob("*.json"))
+            self.assertEqual(len(run_files), 1)
+            payload = json.loads(run_files[0].read_text())
+            line = json.loads((mem_dir / "runs.jsonl").read_text())
+            self.assertEqual(payload["run_id"], line["run_id"])
+            self.assertEqual(payload["schema_version"], 1)
+            self.assertEqual(payload["trace_id"], "trace_xx")
+            self.assertIsNone(payload["error"])
+            self.assertEqual(
+                payload["tool_calls"][0]["result_preview"], "file contents"
+            )
+            self.assertNotIn("args", payload["tool_calls"][0])
+
+
+class FormatErrorTests(unittest.TestCase):
+    def test_none_stays_none(self) -> None:
+        self.assertIsNone(_format_error(None))
+
+    def test_message_includes_type_and_message(self) -> None:
+        self.assertEqual(_format_error(ValueError("boom")), "ValueError: boom")
+
+    def test_empty_message_uses_type_name(self) -> None:
+        self.assertEqual(
+            _format_error(KeyboardInterrupt()), "KeyboardInterrupt"
+        )
+        self.assertEqual(
+            _format_error(asyncio.CancelledError()), "CancelledError"
+        )

--- a/tests/mind/memory/test_run_hooks.py
+++ b/tests/mind/memory/test_run_hooks.py
@@ -1,0 +1,137 @@
+"""Tests for ``quantmind.mind.memory._run_hooks``."""
+
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from quantmind.mind.memory._run_hooks import MemoryRunHooks
+
+
+def _make_hooks(tmpdir: Path) -> MemoryRunHooks:
+    (tmpdir / "runs").mkdir(parents=True, exist_ok=True)
+    return MemoryRunHooks(memory_dir=tmpdir, archive_lock=asyncio.Lock())
+
+
+class MemoryRunHooksLifecycleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_on_agent_start_records_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            hooks = _make_hooks(Path(raw))
+            agent = SimpleNamespace(
+                name="paper_extractor",
+                model="gpt-4o",
+                instructions="extract papers",
+            )
+            await hooks.on_agent_start(SimpleNamespace(), agent)
+            self.assertEqual(hooks._agent_name, "paper_extractor")
+            self.assertEqual(hooks._agent_model, "gpt-4o")
+            self.assertEqual(len(hooks._instructions_hash), 16)
+
+    async def test_on_llm_end_accumulates_call(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            hooks = _make_hooks(Path(raw))
+            await hooks.on_agent_start(
+                SimpleNamespace(),
+                SimpleNamespace(name="a", model="gpt-4o", instructions=""),
+            )
+            await hooks.on_llm_start()
+            response = SimpleNamespace(
+                usage=SimpleNamespace(input_tokens=42, output_tokens=11)
+            )
+            await hooks.on_llm_end(
+                SimpleNamespace(),
+                SimpleNamespace(model="gpt-4o"),
+                response,
+            )
+            self.assertEqual(len(hooks._llm_calls), 1)
+            self.assertEqual(hooks._llm_calls[0]["tokens_in"], 42)
+            self.assertEqual(hooks._llm_calls[0]["tokens_out"], 11)
+
+    async def test_on_llm_end_handles_missing_usage(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            hooks = _make_hooks(Path(raw))
+            await hooks.on_llm_start()
+            await hooks.on_llm_end(
+                SimpleNamespace(),
+                SimpleNamespace(model="gpt-4o"),
+                SimpleNamespace(usage=None),
+            )
+            self.assertEqual(hooks._llm_calls[0]["tokens_in"], 0)
+            self.assertEqual(hooks._llm_calls[0]["tokens_out"], 0)
+
+    async def test_on_tool_pair_records_call(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            hooks = _make_hooks(Path(raw))
+            tool = SimpleNamespace(name="read_file")
+            await hooks.on_tool_start(
+                SimpleNamespace(), SimpleNamespace(), tool
+            )
+            await hooks.on_tool_end(
+                SimpleNamespace(),
+                SimpleNamespace(),
+                tool,
+                "file contents",
+            )
+            self.assertEqual(len(hooks._tool_calls), 1)
+            self.assertEqual(hooks._tool_calls[0]["name"], "read_file")
+            self.assertGreaterEqual(hooks._tool_calls[0]["duration_s"], 0.0)
+
+    async def test_on_agent_end_truncates_long_output(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            hooks = _make_hooks(Path(raw))
+            big = "x" * 1000
+            await hooks.on_agent_end(SimpleNamespace(), SimpleNamespace(), big)
+            self.assertTrue(hooks._output_summary.endswith("[truncated]"))
+            self.assertLessEqual(len(hooks._output_summary), 500)
+
+
+class MemoryRunHooksPersistTests(unittest.IsolatedAsyncioTestCase):
+    async def test_persist_success_writes_record_with_no_error(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem_dir = Path(raw)
+            hooks = _make_hooks(mem_dir)
+            await hooks.on_agent_start(
+                SimpleNamespace(),
+                SimpleNamespace(name="a", model="gpt-4o", instructions="x"),
+            )
+            await hooks.on_agent_end(
+                SimpleNamespace(), SimpleNamespace(), "out"
+            )
+            with patch(
+                "quantmind.mind.memory._run_hooks.write_run_record",
+                new=AsyncMock(),
+            ) as mock_write:
+                await hooks.persist(
+                    workflow_name="quantmind.paper_flow",
+                    result=SimpleNamespace(trace_id="trace_xx"),
+                    error=None,
+                    input_payload="hello",
+                )
+            args, _kwargs = mock_write.call_args
+            record = args[1]
+            self.assertEqual(record.workflow_name, "quantmind.paper_flow")
+            self.assertEqual(record.trace_id, "trace_xx")
+            self.assertIsNone(record.error)
+
+    async def test_persist_error_path_records_exception_string(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            mem_dir = Path(raw)
+            hooks = _make_hooks(mem_dir)
+            with patch(
+                "quantmind.mind.memory._run_hooks.write_run_record",
+                new=AsyncMock(),
+            ) as mock_write:
+                await hooks.persist(
+                    workflow_name="quantmind.paper_flow",
+                    result=None,
+                    error=ValueError("boom"),
+                    input_payload="hi",
+                )
+            record = mock_write.call_args.args[1]
+            self.assertEqual(record.error, "boom")

--- a/tests/mind/memory/test_trajectory.py
+++ b/tests/mind/memory/test_trajectory.py
@@ -52,7 +52,7 @@ class GenerateRunIdTests(unittest.TestCase):
     def test_format_matches_documented_shape(self) -> None:
         now = datetime(2026, 5, 8, 12, 30, 45, 123456, tzinfo=timezone.utc)
         run_id = generate_run_id(now)
-        self.assertRegex(run_id, r"^20260508T123045123[0-9a-z]{3}$")
+        self.assertRegex(run_id, r"^20260508T123045123[0-9a-z]{6}$")
 
     def test_different_calls_produce_different_ids(self) -> None:
         now = datetime(2026, 5, 8, 12, 30, 45, 123000, tzinfo=timezone.utc)
@@ -69,8 +69,8 @@ class WriteRunRecordTests(unittest.IsolatedAsyncioTestCase):
             await write_run_record(mem_dir, record, archive_lock=asyncio.Lock())
             target = mem_dir / "runs" / "rid001abc.json"
             self.assertTrue(target.exists())
-            tmp = mem_dir / "runs" / "rid001abc.json.tmp"
-            self.assertFalse(tmp.exists())
+            leftovers = list((mem_dir / "runs").glob(".rid001abc.*.tmp"))
+            self.assertEqual(leftovers, [])
             payload = json.loads(target.read_text())
             self.assertEqual(payload["run_id"], "rid001abc")
             self.assertEqual(

--- a/tests/mind/memory/test_trajectory.py
+++ b/tests/mind/memory/test_trajectory.py
@@ -1,0 +1,114 @@
+"""Tests for ``quantmind.mind.memory._trajectory``."""
+
+import asyncio
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from quantmind.mind.memory._trajectory import (
+    RunRecord,
+    generate_run_id,
+    write_run_record,
+)
+
+
+def _fixture_record(run_id: str) -> RunRecord:
+    started = datetime(2026, 5, 8, 12, 30, 45, 123000, tzinfo=timezone.utc)
+    ended = datetime(2026, 5, 8, 12, 30, 50, 456000, tzinfo=timezone.utc)
+    return RunRecord(
+        schema_version=1,
+        run_id=run_id,
+        workflow_name="quantmind.paper_flow",
+        trace_id="trace_abc",
+        started_at=started,
+        ended_at=ended,
+        duration_seconds=5.333,
+        agent={
+            "name": "paper_extractor",
+            "model": "gpt-4o",
+            "instructions_hash": "abc",
+        },
+        llm_calls=[
+            {
+                "tokens_in": 10,
+                "tokens_out": 5,
+                "duration_s": 0.5,
+                "model": "gpt-4o",
+            }
+        ],
+        tool_calls=[],
+        memory_ops={"files_read": [], "files_written": []},
+        tokens_total={"input": 10, "output": 5},
+        cost_estimate_usd=0.0,
+        input_summary="hello",
+        output_summary="world",
+        error=None,
+    )
+
+
+class GenerateRunIdTests(unittest.TestCase):
+    def test_format_matches_documented_shape(self) -> None:
+        now = datetime(2026, 5, 8, 12, 30, 45, 123456, tzinfo=timezone.utc)
+        run_id = generate_run_id(now)
+        self.assertRegex(run_id, r"^20260508T123045123[0-9a-z]{3}$")
+
+    def test_different_calls_produce_different_ids(self) -> None:
+        now = datetime(2026, 5, 8, 12, 30, 45, 123000, tzinfo=timezone.utc)
+        ids = {generate_run_id(now) for _ in range(50)}
+        self.assertGreater(len(ids), 40)
+
+
+class WriteRunRecordTests(unittest.IsolatedAsyncioTestCase):
+    async def test_writes_atomic_per_run_file(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            mem_dir = Path(raw_dir)
+            (mem_dir / "runs").mkdir()
+            record = _fixture_record("rid001abc")
+            await write_run_record(mem_dir, record, archive_lock=asyncio.Lock())
+            target = mem_dir / "runs" / "rid001abc.json"
+            self.assertTrue(target.exists())
+            tmp = mem_dir / "runs" / "rid001abc.json.tmp"
+            self.assertFalse(tmp.exists())
+            payload = json.loads(target.read_text())
+            self.assertEqual(payload["run_id"], "rid001abc")
+            self.assertEqual(
+                payload["started_at"], "2026-05-08T12:30:45.123000Z"
+            )
+
+    async def test_appends_one_line_to_runs_jsonl(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            mem_dir = Path(raw_dir)
+            (mem_dir / "runs").mkdir()
+            lock = asyncio.Lock()
+            await write_run_record(
+                mem_dir, _fixture_record("a01abc"), archive_lock=lock
+            )
+            await write_run_record(
+                mem_dir, _fixture_record("b02def"), archive_lock=lock
+            )
+            lines = (mem_dir / "runs.jsonl").read_text().splitlines()
+            self.assertEqual(len(lines), 2)
+            ids = [json.loads(line)["run_id"] for line in lines]
+            self.assertEqual(ids, ["a01abc", "b02def"])
+
+    async def test_concurrent_writes_serialise_under_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_dir:
+            mem_dir = Path(raw_dir)
+            (mem_dir / "runs").mkdir()
+            lock = asyncio.Lock()
+            await asyncio.gather(
+                write_run_record(
+                    mem_dir,
+                    _fixture_record("c01abc"),
+                    archive_lock=lock,
+                ),
+                write_run_record(
+                    mem_dir,
+                    _fixture_record("c02def"),
+                    archive_lock=lock,
+                ),
+            )
+            lines = (mem_dir / "runs.jsonl").read_text().splitlines()
+            self.assertEqual(len(lines), 2)


### PR DESCRIPTION
## Summary

- Adds `quantmind/mind/memory/` — `Memory` Protocol + `FilesystemMemory` MVP + `MemoryRunHooks` + `RunRecord` trajectory archive.
- Tightens `paper_flow.memory` from `object | None` to `Memory | None`; wires `memory.mcp_servers()` and `memory.tools()` into the Agent.
- Replaces the PR5 `_archive_run_artifacts` stub with a real `try/finally` + `MemoryRunHooks.persist` in `flows/_runner.py`; failed runs still archive (with `error` set).
- Adds a sixth `import-linter` contract pinning `mind` as a bounded subsystem.

## Architecture notes

- `FilesystemMemory` re-uses the SDK's `MCPServerStdio` directly (no QuantMind wrapper); the MCP filesystem server (`@modelcontextprotocol/server-filesystem`) handles the agent's read/write file access via `npx`.
- `MemoryRunHooks` accumulates LLM and tool call metrics across SDK lifecycle callbacks; the runner calls `persist()` in `finally` so failed runs still produce a trajectory record.
- `RunRecord` is a frozen `slots=True` dataclass; persistence is atomic via `tmp + os.replace` and serialised with an in-process `asyncio.Lock` for `runs.jsonl` appends. Cross-process concurrency is undefined behaviour and documented.
- `cost_estimate_usd` is `0.0` and `memory_ops` is empty in PR6 — both are filled in PR9 (`tiktoken` pricing + tool-call derivation).

## Verification

- `bash scripts/verify.sh` — five green steps:
  - `ruff format --check` — clean
  - `ruff check` — clean
  - `basedpyright` — 0 errors
  - `lint-imports` — 6 contracts kept, 0 broken
  - `pytest --cov` — 259 tests, 89.93% coverage (floor 75%)

## Test plan

- [x] `tests/mind/memory/{test_protocol,test_trajectory,test_run_hooks,test_filesystem}.py` — full coverage of the public surface, all SDK + MCP mocked.
- [x] `tests/flows/test_runner.py` — success + failure persist paths + `archive_trajectory=False` skip + `memory=None` skip.
- [x] `tests/flows/test_paper.py` — `mcp_servers` and `tools` wiring with a fake `Memory`.

Part of #71.