### PR TITLE
Fix Paper output schema compatibility with OpenAI Agents strict schema validation

### DIFF
--- a/quantmind/flows/paper.py
+++ b/quantmind/flows/paper.py
@@ -13,7 +13,7 @@ flow, fork this file (Layer 3 — design doc §9).
 
 from typing import Any, TypeVar
 
-from agents import Agent, RunHooks, Tool
+from agents import Agent, AgentOutputSchema, RunHooks, Tool
 
 from quantmind.configs import PaperFlowCfg
 from quantmind.configs.paper import (
@@ -86,6 +86,11 @@ async def paper_flow(
     """
     cfg = cfg or PaperFlowCfg()
     out_type: type[Paper] = output_type or Paper  # type: ignore[assignment]
+    resolved_output_type: Any = (
+        AgentOutputSchema(Paper, strict_json_schema=False)
+        if out_type is Paper
+        else out_type
+    )
 
     raw_md, source_meta = await _fetch_and_format(input)
 
@@ -98,7 +103,7 @@ async def paper_flow(
         ),
         "model": cfg.model,
         "tools": list(extra_tools or []),
-        "output_type": out_type,
+        "output_type": resolved_output_type,
         "input_guardrails": list(extra_input_guardrails or []),
         "output_guardrails": list(extra_output_guardrails or []),
     }


### PR DESCRIPTION
## Problem

OpenAI Agents strict schema validation rejects `Paper` as an `Agent` output type because `TreeKnowledge.nodes` is a dict-valued field and the generated JSON schema includes `additionalProperties`.

## Observed error

"Strict JSON schema is enabled, but the output type is not valid..."

"additionalProperties should not be set for object types."

## Environment

- Python 3.12.13
- openai-agents 0.17.5
- QuantMind commit before patch: 8e218884a6cec3122ba42f9fa2277d593b907361

## Fix

Wrap the default `Paper` output type with `AgentOutputSchema(Paper, strict_json_schema=False)` when `output_type` is the base `Paper` class. Custom output types continue to pass through unchanged.

## Validation

- `paper_flow` runs successfully on `RawText` input (downstream wrapper smoke on OpenAI Agents 0.17.5)
- Downstream wrapper validates emitted output through a vendor schema and adapter mapping
- Existing validation/tests:
  - `bash scripts/verify.sh`: ruff format, ruff check, basedpyright, lint-imports — **PASS**
  - `pytest --cov`: **232 passed**, 1 failed (`test_local_file_branch` — Windows `/tmp` vs `\tmp` path assertion; unrelated to this patch)
  - Coverage **89.49%** (75% floor met)