### PR TITLE
Fix paper_flow compatibility with OpenAI Agents SDK v0.17+

### DIFF
--- a/quantmind/flows/paper.py
+++ b/quantmind/flows/paper.py
@@ -13,7 +13,7 @@ flow, fork this file (Layer 3 — design doc §9).
 
 from typing import Any, TypeVar
 
-from agents import Agent, RunHooks, Tool
+from agents import Agent, AgentOutputSchema, RunHooks, Tool
 
 from quantmind.configs import PaperFlowCfg
 from quantmind.configs.paper import (
@@ -41,6 +41,12 @@ You are extracting a research paper into a structured QuantMind ``Paper``
 TreeKnowledge object. Build the section tree top-down: every node has a
 title and a short summary; leaf nodes additionally carry the section
 markdown content. Cite supporting passages on each node.
+
+CRITICAL: All id, node_id, root_node_id, parent_id, children_ids, and
+tree_id fields MUST be valid UUID4 strings (e.g.
+"550e8400-e29b-41d4-a716-446655440000"). Do NOT use human-readable names
+like "root" or "introduction". Generate a fresh UUID4 for each node and
+reference them consistently.
 
 Honour these flags from the run config:
 - extract_methodology={extract_methodology}: when true, every methodology
@@ -98,7 +104,7 @@ async def paper_flow(
         ),
         "model": cfg.model,
         "tools": list(extra_tools or []),
-        "output_type": out_type,
+        "output_type": AgentOutputSchema(out_type, strict_json_schema=False),
         "input_guardrails": list(extra_input_guardrails or []),
         "output_guardrails": list(extra_output_guardrails or []),
     }


### PR DESCRIPTION
## Summary

- Wrap `output_type` in `AgentOutputSchema(strict_json_schema=False)` to fix strict JSON schema rejection when using nested Pydantic models with `extra="forbid"` and `additionalProperties`
- Add explicit UUID4 format instructions to the agent prompt so the LLM generates valid UUIDs for `TreeKnowledge` node IDs instead of human-readable strings like `"root"` or `"introduction"`
- Import `AgentOutputSchema` from the `agents` package

## Context

`paper_flow` fails at runtime with OpenAI Agents SDK v0.17.x due to two independent issues:

1. **Schema error**: The SDK's strict mode requires all object types to omit `additionalProperties`, but QuantMind's `BaseKnowledge` and related models use `ConfigDict(extra="forbid")` which sets `additionalProperties: false`. The SDK rejects this at agent construction time.

2. **UUID validation error**: With strict mode disabled, the LLM returns the correct tree structure but uses descriptive strings as node IDs. Pydantic then rejects the response because `TreeNode.node_id`, `TreeKnowledge.root_node_id`, and related fields are typed as `UUID`.

Both fixes are minimal and localised to `paper.py`.

## Test plan

- [x] Verified `paper_flow` runs end-to-end on arXiv paper 2310.10688 (TimesFM) with `gpt-4o-mini`
- [x] Confirmed the extracted `Paper` object passes Pydantic validation with proper UUID node IDs
- [ ] Run existing test suite (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)