### PR TITLE
fix(knowledge): use string ids in TreeKnowledge/BaseKnowledge, not UUID

### DIFF
--- a/quantmind/flows/paper.py
+++ b/quantmind/flows/paper.py
@@ -13,7 +13,7 @@ flow, fork this file (Layer 3 — design doc §9).
 
 from typing import Any, TypeVar
 
-from agents import Agent, RunHooks, Tool
+from agents import Agent, AgentOutputSchema, RunHooks, Tool
 
 from quantmind.configs import PaperFlowCfg
 from quantmind.configs.paper import (
@@ -98,7 +98,10 @@ async def paper_flow(
         ),
         "model": cfg.model,
         "tools": list(extra_tools or []),
-        "output_type": out_type,
+        # `Paper.nodes` is a dict-typed field; strict-mode structured output
+        # (the Agents SDK default) cannot represent dict types at all, so
+        # this flow always runs non-strict.
+        "output_type": AgentOutputSchema(out_type, strict_json_schema=False),
         "input_guardrails": list(extra_input_guardrails or []),
         "output_guardrails": list(extra_output_guardrails or []),
     }

--- a/quantmind/knowledge/_base.py
+++ b/quantmind/knowledge/_base.py
@@ -74,7 +74,12 @@ class BaseKnowledge(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     # Identity
-    id: UUID = Field(default_factory=uuid4)
+    #
+    # `str` rather than `UUID`: this field is part of every knowledge type's
+    # LLM-facing structured-output schema, and an extractor agent naturally
+    # sets it to a domain identifier (e.g. an arXiv id) rather than leaving
+    # the default UUID4. `str` accepts both; `UUID` rejects the former.
+    id: str = Field(default_factory=lambda: str(uuid4()))
     item_type: str
     schema_version: str = "1.0"
 

--- a/quantmind/knowledge/_tree.py
+++ b/quantmind/knowledge/_tree.py
@@ -12,11 +12,23 @@ a coarse pre-filter, never as a replacement for that reasoning.
 """
 
 from collections.abc import Iterator
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from quantmind.knowledge._base import BaseKnowledge, Citation
+
+
+def _new_node_id() -> str:
+    """Default node id: a UUID4 rendered as a string.
+
+    Plain ``str`` rather than ``UUID`` because ``nodes`` below is a dict
+    keyed by node id, and OpenAI's strict-mode structured output does not
+    support dict-typed fields at all -- so the extractor agent runs with
+    ``strict_json_schema=False`` and is free to choose readable slugs
+    ("introduction", "methodology") instead of UUIDs. ``str`` accepts both.
+    """
+    return str(uuid4())
 
 
 class TreeNode(BaseModel):
@@ -30,14 +42,14 @@ class TreeNode(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    node_id: UUID = Field(default_factory=uuid4)
-    parent_id: UUID | None = None
+    node_id: str = Field(default_factory=_new_node_id)
+    parent_id: str | None = None
     position: int = 0
     title: str
     summary: str
     content: str | None = None
     citations: list[Citation] = Field(default_factory=list)
-    children_ids: list[UUID] = Field(default_factory=list)
+    children_ids: list[str] = Field(default_factory=list)
 
     def embedding_text(self) -> str:
         """Default: title + summary. Override per domain if needed."""
@@ -53,19 +65,19 @@ class TreeKnowledge(BaseKnowledge):
     complete tree.
     """
 
-    root_node_id: UUID
-    nodes: dict[UUID, TreeNode]
+    root_node_id: str
+    nodes: dict[str, TreeNode]
 
     def root(self) -> TreeNode:
         return self.nodes[self.root_node_id]
 
-    def children_of(self, node_id: UUID) -> list[TreeNode]:
+    def children_of(self, node_id: str) -> list[TreeNode]:
         node = self.nodes[node_id]
         return [self.nodes[c] for c in node.children_ids]
 
     def walk_dfs(self) -> Iterator[TreeNode]:
         """Depth-first traversal starting at the root."""
-        stack: list[UUID] = [self.root_node_id]
+        stack: list[str] = [self.root_node_id]
         while stack:
             node_id = stack.pop()
             node = self.nodes[node_id]
@@ -73,12 +85,12 @@ class TreeKnowledge(BaseKnowledge):
             # Reverse so children are visited in declared order.
             stack.extend(reversed(node.children_ids))
 
-    def find_path(self, node_id: UUID) -> list[TreeNode]:
+    def find_path(self, node_id: str) -> list[TreeNode]:
         """Root-to-node path. Empty if `node_id` is not in the tree."""
         if node_id not in self.nodes:
             return []
         path: list[TreeNode] = []
-        cursor: UUID | None = node_id
+        cursor: str | None = node_id
         while cursor is not None:
             node = self.nodes[cursor]
             path.append(node)

--- a/quantmind/knowledge/paper.py
+++ b/quantmind/knowledge/paper.py
@@ -9,7 +9,6 @@ summarisation), then a `PaperKnowledgeCard` derived from the root summary.
 """
 
 from typing import Literal
-from uuid import UUID
 
 from pydantic import Field
 
@@ -41,7 +40,7 @@ class PaperKnowledgeCard(FlattenKnowledge):
 
     item_type: Literal["paper_card"] = "paper_card"
 
-    paper_id: UUID
+    paper_id: str
     summary: str
     methodology: str | None = None
     key_findings: list[str] = Field(default_factory=list)

--- a/tests/flows/test_paper.py
+++ b/tests/flows/test_paper.py
@@ -30,7 +30,7 @@ from quantmind.preprocess.fetch import Fetched, RawPaper
 
 
 def _stub_paper() -> Paper:
-    root_id = uuid4()
+    root_id = str(uuid4())
     root = TreeNode(node_id=root_id, title="root", summary="stub")
     return Paper(
         as_of=datetime(2026, 5, 7, tzinfo=timezone.utc),
@@ -273,7 +273,11 @@ class PaperFlowTests(unittest.IsolatedAsyncioTestCase):
             _patch_runner(_stub_paper()),
         ):
             await paper_flow(RawText(text="x"), output_type=MyPaper)
-        self.assertIs(seen["output_type"], MyPaper)
+        # `output_type` is wrapped in a non-strict `AgentOutputSchema` because
+        # `Paper.nodes` is a dict-typed field, which strict-mode structured
+        # output cannot represent.
+        self.assertIs(seen["output_type"].output_type, MyPaper)
+        self.assertFalse(seen["output_type"].is_strict_json_schema())
 
     async def test_extra_tools_and_guardrails_forwarded(self) -> None:
         seen: dict[str, Any] = {}

--- a/tests/knowledge/test_paper.py
+++ b/tests/knowledge/test_paper.py
@@ -18,7 +18,7 @@ def _src() -> SourceRef:
 
 
 def _single_node_paper(**overrides) -> Paper:
-    root_id = uuid4()
+    root_id = str(uuid4())
     root = TreeNode(
         node_id=root_id,
         parent_id=None,
@@ -65,7 +65,7 @@ class PaperTreeTests(unittest.TestCase):
 
 class PaperKnowledgeCardTests(unittest.TestCase):
     def test_minimal(self):
-        paper_id = uuid4()
+        paper_id = str(uuid4())
         card = PaperKnowledgeCard(
             as_of=_now(),
             source=_src(),
@@ -81,7 +81,7 @@ class PaperKnowledgeCardTests(unittest.TestCase):
         card = PaperKnowledgeCard(
             as_of=_now(),
             source=_src(),
-            paper_id=uuid4(),
+            paper_id=str(uuid4()),
             summary="s",
             methodology="m",
             key_findings=["f1", "f2"],
@@ -95,7 +95,7 @@ class PaperKnowledgeCardTests(unittest.TestCase):
         card = PaperKnowledgeCard(
             as_of=_now(),
             source=_src(),
-            paper_id=uuid4(),
+            paper_id=str(uuid4()),
             summary="momentum study",
             key_findings=["beats SPX", "robust to costs"],
         )

--- a/tests/knowledge/test_roundtrip.py
+++ b/tests/knowledge/test_roundtrip.py
@@ -3,7 +3,7 @@
 These tests guard the contract that powers ``Agent(output_type=...)``: the
 LLM returns JSON, the Agents SDK calls ``model_validate_json`` on it, and
 the result must equal what we would have produced via ``model_dump_json``.
-Tree schemas are the trickiest because of ``dict[UUID, TreeNode]`` keys.
+Tree schemas are the trickiest because of ``dict[str, TreeNode]`` keys.
 """
 
 import unittest
@@ -66,7 +66,7 @@ class FlattenRoundTripTests(unittest.TestCase):
         card = PaperKnowledgeCard(
             as_of=_now(),
             source=_src("arxiv"),
-            paper_id=uuid4(),
+            paper_id=str(uuid4()),
             summary="momentum study",
             methodology="cross-sectional",
             key_findings=["beats SPX"],
@@ -93,8 +93,8 @@ class FlattenRoundTripTests(unittest.TestCase):
 
 class TreeRoundTripTests(unittest.TestCase):
     def _build_paper(self) -> Paper:
-        leaf_id = uuid4()
-        root_id = uuid4()
+        leaf_id = str(uuid4())
+        root_id = str(uuid4())
         leaf = TreeNode(
             node_id=leaf_id,
             parent_id=root_id,
@@ -122,11 +122,11 @@ class TreeRoundTripTests(unittest.TestCase):
             nodes={root_id: root, leaf_id: leaf},
         )
 
-    def test_paper_dict_uuid_keys_round_trip(self):
+    def test_paper_dict_str_keys_round_trip(self):
         p = self._build_paper()
         revived = Paper.model_validate_json(p.model_dump_json())
         self.assertEqual(p, revived)
-        # UUID keys are preserved through the JSON detour.
+        # String keys are preserved through the JSON detour.
         self.assertEqual(set(revived.nodes.keys()), set(p.nodes.keys()))
         # Helper still works on the revived instance.
         self.assertEqual(revived.root().title, "Cross-Sectional Momentum")

--- a/tests/knowledge/test_tree.py
+++ b/tests/knowledge/test_tree.py
@@ -3,7 +3,7 @@
 import unittest
 from datetime import datetime, timezone
 from typing import Literal
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from pydantic import ValidationError
 
@@ -32,10 +32,10 @@ def _make_tree() -> _SampleTree:
     │   └── a2
     └── b
     """
-    a1_id, a2_id = uuid4(), uuid4()
-    a_id = uuid4()
-    b_id = uuid4()
-    root_id = uuid4()
+    a1_id, a2_id = str(uuid4()), str(uuid4())
+    a_id = str(uuid4())
+    b_id = str(uuid4())
+    root_id = str(uuid4())
     a1 = TreeNode(
         node_id=a1_id,
         parent_id=a_id,
@@ -88,7 +88,7 @@ class TreeNodeTests(unittest.TestCase):
         self.assertEqual(n.summary, "s")
         self.assertIsNone(n.content)
         self.assertEqual(n.children_ids, [])
-        self.assertIsInstance(n.node_id, UUID)
+        self.assertIsInstance(n.node_id, str)
 
     def test_default_node_id_unique(self):
         a = TreeNode(title="t", summary="s")
@@ -141,7 +141,7 @@ class TreeKnowledgeTests(unittest.TestCase):
 
     def test_find_path_unknown(self):
         tree = _make_tree()
-        self.assertEqual(tree.find_path(uuid4()), [])
+        self.assertEqual(tree.find_path(str(uuid4())), [])
 
     def test_embedding_text_uses_root(self):
         tree = _make_tree()


### PR DESCRIPTION
Fixes #91.

## Problem

`paper_flow()` fails on its own README example against the currently resolved `openai-agents` version. Two bugs stack:

1. `TreeKnowledge.nodes` is `dict[UUID, TreeNode]`. Strict-mode structured output (the Agents SDK default) cannot represent dict-typed fields at all, so `Agent(output_type=Paper)` raises before any LLM call happens.
2. Passing `AgentOutputSchema(Paper, strict_json_schema=False)` gets past that, but non-strict mode drops the UUID format constraint, and the extraction agent naturally fills `node_id`/`parent_id`/`children_ids`/`id` with readable identifiers ("root", "introduction", the arXiv id) instead of UUIDs. Validation then fails with dozens of `uuid_parsing` errors.

Full repro and tracebacks in #91.

## Fix

- `TreeNode.node_id`/`parent_id`/`children_ids` and `TreeKnowledge.root_node_id`/`nodes`: `UUID` → `str`. Accepts both real UUIDs and the readable slugs the model prefers.
- `BaseKnowledge.id` and `PaperKnowledgeCard.paper_id`: same change, same reason — `id` is part of every knowledge type's LLM-facing schema, and this is the only remaining validation failure once the `nodes` fix is in.
- `paper_flow`: passes `AgentOutputSchema(out_type, strict_json_schema=False)` instead of a bare type. Required regardless of key type, since dict-typed fields are strict-mode-incompatible either way.

## Testing

- Ran the unmodified `paper_flow()` call from the README against a real paper (arXiv `2404.11584`, `gpt-4o-mini`). Before this change: fails on both bugs above. After: completes end-to-end with zero validation errors, produces a 27-node tree matching the paper's actual structure.
- `pytest tests/ -q`: 232/233 pass. The one failure (`FetchAndFormatTests::test_local_file_branch`) is pre-existing and unrelated — a Windows path-separator assertion (`\tmp\p.md` vs `/tmp/p.md`), reproduces on `master` without this change.
- Updated the five test files that constructed `TreeNode`/`TreeKnowledge`/`PaperKnowledgeCard` with raw `uuid4()` `UUID` objects to use `str(uuid4())` instead, and the one assertion that checked `node_id`'s runtime type.

## Not in scope

`Citation.tree_id`/`node_id` and `ExtractionRef.run_id` remain `UUID`. They're optional (default `None`) and the extraction agent never populated them in the verification run, so there's no observed failure to fix — happy to also convert them for consistency if maintainers would rather have one convention throughout.