### PR TITLE
feat(preprocess): add PR Newswire ingestion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ We use [uv](https://github.com/astral-sh/uv) for fast and reliable Python packag
 
 ### 📚 Usage Examples
 
+Component-specific guides and architecture notes live under [`docs/`](docs/).
+
 #### Run a single paper through `paper_flow`
 
 ```python
@@ -174,40 +176,6 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
-
-#### Fetch PR Newswire releases
-
-```python
-import asyncio
-
-from quantmind.preprocess import (
-    PR_NEWSWIRE,
-    FetchPolicy,
-    WireFeedConfig,
-    fetch_wire_documents,
-)
-
-
-async def main() -> None:
-    result = await fetch_wire_documents(
-        WireFeedConfig(
-            provider=PR_NEWSWIRE,
-            feed_urls=(
-                "https://www.prnewswire.com/rss/news-releases-list.rss",
-            ),
-            fetch_policy=FetchPolicy(min_interval_seconds=0.25),
-        )
-    )
-    print(f"documents={result.success_count}")
-    print(f"failures={result.failure_count}")
-
-
-asyncio.run(main())
-```
-
-Each successful `WireDocument` retains the raw feed entry, raw article HTML,
-and cleaned Markdown. Feed and item failures are recorded in the result without
-stopping the remaining batch.
 
 #### Fan out a batch with `batch_run`
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,40 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+#### Fetch PR Newswire releases
+
+```python
+import asyncio
+
+from quantmind.preprocess import (
+    PR_NEWSWIRE,
+    FetchPolicy,
+    WireFeedConfig,
+    fetch_wire_documents,
+)
+
+
+async def main() -> None:
+    result = await fetch_wire_documents(
+        WireFeedConfig(
+            provider=PR_NEWSWIRE,
+            feed_urls=(
+                "https://www.prnewswire.com/rss/news-releases-list.rss",
+            ),
+            fetch_policy=FetchPolicy(min_interval_seconds=0.25),
+        )
+    )
+    print(f"documents={result.success_count}")
+    print(f"failures={result.failure_count}")
+
+
+asyncio.run(main())
+```
+
+Each successful `WireDocument` retains the raw feed entry, raw article HTML,
+and cleaned Markdown. Feed and item failures are recorded in the result without
+stopping the remaining batch.
+
 #### Fan out a batch with `batch_run`
 
 ```python

--- a/docs/NEWS_PIPELINE.md
+++ b/docs/NEWS_PIPELINE.md
@@ -1,0 +1,247 @@
+# News Pipeline
+
+QuantMind provides deterministic building blocks for fetching, parsing, and
+normalizing public financial news. The current wire-provider MVP supports PR
+Newswire. The provider contract is extensible, but other wire services are not
+built-in or verified yet.
+
+This guide describes the public OSS behavior implemented today. It does not
+assume private feeds, credentials, persistence infrastructure, or internal
+services.
+
+## What the Pipeline Can Do
+
+| Stage | Public API | Result |
+| --- | --- | --- |
+| HTTP acquisition | `fetch_url`, `HttpFetcher`, `FetchPolicy` | Bounded response bytes and fetch metadata |
+| Feed parsing | `fetch_rss_feed`, `parse_feed` | Typed RSS 2.x or Atom items |
+| Article acquisition | `feed_item_to_news_document` | Explicit feed-body or linked-article text |
+| Normalization | `preprocess_news_document`, `preprocess_feed_item` | Deterministic `NewsCandidate` |
+| Wire ingestion | `fetch_wire_documents` | PR Newswire documents plus non-fatal failures |
+
+The main wire path is:
+
+```text
+Public RSS/Atom feed
+  -> shared HTTP fetcher
+  -> typed feed items
+  -> provider mapping
+  -> linked article fetch
+  -> deterministic news normalization
+  -> WireDocument + optional WireFetchFailure records
+```
+
+### HTTP robustness
+
+`FetchPolicy` can opt a caller into:
+
+- bounded retries for transport errors, HTTP 408, HTTP 429, and HTTP 5xx;
+- exponential backoff with configurable jitter;
+- `Retry-After` handling for HTTP 429 and HTTP 503;
+- per-host concurrency limits and minimum request spacing.
+
+Calling `fetch_url` without a policy preserves its one-shot behavior. Reuse one
+`HttpFetcher` when several requests should share a connection pool and the same
+per-host rate state.
+
+### RSS and Atom parsing
+
+`fetch_rss_feed` and `parse_feed` support RSS 2.x and Atom. Each `FeedItem`
+retains normalized fields, selected source metadata, and the raw XML entry.
+
+### Explicit body acquisition
+
+News feed items use an explicit body-source decision:
+
+- `body_source="feed"` trusts the content included in the feed and performs no
+  article request;
+- `body_source="article"` always follows the item URL, even when the feed
+  contains a non-empty teaser.
+
+The default is `feed`. The built-in PR Newswire adapter uses `article` because
+its public feed descriptions may be teasers.
+
+### Deterministic normalization
+
+`NewsCandidate` normalization currently includes:
+
+- Unicode, whitespace, and duplicate-line cleanup;
+- canonical source URLs with common tracking parameters removed;
+- UTC publication timestamps;
+- stable content hashes and source deduplication keys;
+- exchange-qualified ticker hints such as `NASDAQ: NVDA` or `NYSE: IBM`.
+
+Ticker extraction only produces hints. Instrument resolution and validation
+remain downstream responsibilities.
+
+### Replayable wire documents
+
+Each successful `WireDocument` contains:
+
+- the raw feed entry;
+- raw article HTML when an article request was used;
+- source and fetch metadata;
+- cleaned Markdown;
+- provider identity, payload ID, canonical URL, title, publisher, publication
+  time, content hash, stable identity, and ticker hints.
+
+Individual feed or article failures do not fail the whole call. They are
+returned as lightweight `WireFetchFailure` values alongside successful
+documents.
+
+## Examples
+
+### Normalize an existing news document
+
+This path performs no network request and is useful when the caller already
+has the article text.
+
+```python
+from datetime import datetime, timezone
+
+from quantmind.preprocess import RawNewsDocument, preprocess_news_document
+
+raw = RawNewsDocument(
+    title="Example Corp Reports Results",
+    body_text=(
+        "Example Corp (NASDAQ: EXMPL) reported fictional quarterly revenue."
+    ),
+    source_url="https://example.com/releases/results?utm_source=rss",
+    publisher="Example Publisher",
+    published_at=datetime(2026, 7, 12, 12, 0, tzinfo=timezone.utc),
+    payload_id="release-123",
+)
+
+candidate = preprocess_news_document(raw)
+
+print(candidate.source_url)
+print(candidate.dedup_key)
+print([hint.symbol for hint in candidate.ticker_hints])
+```
+
+A runnable version lives at
+[`examples/preprocess/01_news_pr_wire.py`](../examples/preprocess/01_news_pr_wire.py).
+
+### Fetch and normalize a custom RSS or Atom feed
+
+Choose the body source based on the feed contract. Use `article` when entries
+only contain teasers.
+
+```python
+import asyncio
+
+from quantmind.preprocess import (
+    FetchPolicy,
+    HttpFetcher,
+    fetch_rss_feed,
+    preprocess_feed_item,
+)
+
+
+async def main() -> None:
+    policy = FetchPolicy(
+        max_attempts=3,
+        max_concurrency_per_host=2,
+        min_interval_seconds=0.25,
+    )
+    async with HttpFetcher(policy=policy) as fetcher:
+        feed = await fetch_rss_feed(
+            "https://example.com/news.xml",
+            fetcher=fetcher,
+        )
+        candidates = [
+            await preprocess_feed_item(
+                item,
+                publisher="Example Publisher",
+                body_source="article",
+                fetcher=fetcher,
+            )
+            for item in feed.items
+        ]
+
+    print(f"candidates={len(candidates)}")
+
+
+asyncio.run(main())
+```
+
+### Fetch the public PR Newswire feed
+
+`fetch_wire_documents` uses one shared fetcher for the feed and article
+requests. The result contains successful documents and recorded failures.
+
+```python
+import asyncio
+
+from quantmind.preprocess import (
+    PR_NEWSWIRE,
+    FetchPolicy,
+    WireFeedConfig,
+    fetch_wire_documents,
+)
+
+
+async def main() -> None:
+    result = await fetch_wire_documents(
+        WireFeedConfig(
+            provider=PR_NEWSWIRE,
+            feed_urls=(
+                "https://www.prnewswire.com/rss/news-releases-list.rss",
+            ),
+            fetch_policy=FetchPolicy(min_interval_seconds=0.25),
+        )
+    )
+
+    print(f"documents={result.success_count}")
+    print(f"failures={result.failure_count}")
+
+    if result.documents:
+        document = result.documents[0]
+        print(document.identity)
+        print(document.cleaned_markdown[:200])
+        print(document.raw_feed_entry.content_hash)
+        if document.raw_article is not None:
+            print(document.raw_article.content_hash)
+
+    for failure in result.failures:
+        print(failure.stage, failure.error_type, failure.source_url)
+
+
+asyncio.run(main())
+```
+
+A focused runnable version lives at
+[`examples/preprocess/02_wire_ingestion.py`](../examples/preprocess/02_wire_ingestion.py).
+
+## Verification
+
+The normal test suite is deterministic and does not require public network
+access:
+
+```bash
+python -m pytest --no-cov tests/preprocess
+bash scripts/verify.sh
+```
+
+The live smoke test is separate and performs real PR Newswire feed and article
+requests:
+
+```bash
+python scripts/smoke_wire.py
+```
+
+The smoke checklist verifies that the current public feed produces documents,
+raw feed entries, raw articles, cleaned Markdown, unique identities, and no
+recorded failures.
+
+## Current Non-Goals
+
+The current pipeline does not provide:
+
+- built-in GlobeNewswire or Business Wire adapters;
+- persistent cursors, watermarks, or time-window pagination;
+- scheduling or durable storage;
+- a shared batch-operation base class, hooks, monitoring, or metrics;
+- authenticated or private provider endpoints;
+- automatic company or instrument resolution;
+- downstream news-card generation.

--- a/examples/preprocess/01_news_pr_wire.py
+++ b/examples/preprocess/01_news_pr_wire.py
@@ -1,0 +1,24 @@
+"""Minimal PR-wire news preprocessing example."""
+
+from datetime import datetime, timezone
+
+from quantmind.preprocess.news import RawNewsDocument, preprocess_news_document
+
+raw = RawNewsDocument(
+    title="NVIDIA Announces Results",
+    body_text=(
+        "NVIDIA Corporation (NASDAQ: NVDA) today reported record quarterly "
+        "revenue and highlighted demand for accelerated computing."
+    ),
+    source_type="press_release",
+    source_url="https://example.com/news/nvidia-results",
+    publisher="Example Newswire",
+    published_at=datetime(2026, 7, 6, 12, 0, tzinfo=timezone.utc),
+    payload_id="example-wire-123",
+)
+
+candidate = preprocess_news_document(raw)
+
+print(candidate.dedup_key)
+print(candidate.content_hash)
+print([hint.symbol for hint in candidate.ticker_hints])

--- a/examples/preprocess/02_wire_ingestion.py
+++ b/examples/preprocess/02_wire_ingestion.py
@@ -1,0 +1,32 @@
+"""Fetch the public PR Newswire feed and print a compact summary."""
+
+import asyncio
+
+from quantmind.preprocess import (
+    PR_NEWSWIRE,
+    FetchPolicy,
+    WireFeedConfig,
+    fetch_wire_documents,
+)
+
+_PR_NEWSWIRE_FEED = "https://www.prnewswire.com/rss/news-releases-list.rss"
+
+
+async def main() -> None:
+    """Fetch PR Newswire and print a compact result summary."""
+    result = await fetch_wire_documents(
+        WireFeedConfig(
+            provider=PR_NEWSWIRE,
+            feed_urls=(_PR_NEWSWIRE_FEED,),
+            fetch_policy=FetchPolicy(min_interval_seconds=0.25),
+        )
+    )
+    print(f"documents={result.success_count} failures={result.failure_count}")
+    if result.documents:
+        first = result.documents[0]
+        print(first.title)
+        print(first.identity)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/quantmind/preprocess/__init__.py
+++ b/quantmind/preprocess/__init__.py
@@ -1,10 +1,4 @@
-"""Preprocess layer — fetch + format two-stage data prep.
-
-Imports are surfaced at the package root for the common path
-(``from quantmind.preprocess import fetch_arxiv, pdf_to_markdown``) but
-sub-modules remain available for callers that prefer the explicit path
-(``from quantmind.preprocess.fetch.arxiv import fetch_arxiv``).
-"""
+"""Preprocess layer for fetching, formatting, and source normalization."""
 
 from quantmind.preprocess.clean import (
     collapse_whitespace,
@@ -14,10 +8,17 @@ from quantmind.preprocess.clean import (
 from quantmind.preprocess.fetch import (
     ArxivIdParseError,
     CrossrefMetadata,
+    FeedItem,
+    FetchAttemptsExhausted,
     Fetched,
+    FetchPolicy,
+    HttpFetcher,
+    RawFeed,
     RawPaper,
     fetch_arxiv,
+    fetch_rss_feed,
     fetch_url,
+    parse_feed,
     read_local_file,
     resolve_doi,
 )
@@ -26,27 +27,92 @@ from quantmind.preprocess.format import (
     html_to_markdown,
     pdf_to_markdown,
 )
+from quantmind.preprocess.news import (
+    BodySource,
+    NewsCandidate,
+    NewsTickerHint,
+    RawNewsDocument,
+    build_news_dedup_key,
+    build_sec_news_dedup_key,
+    canonicalize_source_url,
+    extract_exchange_ticker_hints,
+    feed_item_to_news_document,
+    fetch_news_document,
+    news_content_hash,
+    news_document_from_fetched,
+    normalize_news_text,
+    preprocess_feed_item,
+    preprocess_news_document,
+    preprocess_news_url,
+)
 from quantmind.preprocess.time import (
     business_days_between,
     parse_filing_date,
+    parse_news_datetime,
     to_utc,
+)
+from quantmind.preprocess.wire import (
+    PR_NEWSWIRE,
+    RawWireArtifact,
+    WireDocument,
+    WireFeedConfig,
+    WireFetchFailure,
+    WireFetchResult,
+    WireItemMapping,
+    WireProvider,
+    build_wire_identity,
+    fetch_wire_documents,
 )
 
 __all__ = [
     "ArxivIdParseError",
+    "BodySource",
     "CrossrefMetadata",
+    "FeedItem",
+    "FetchAttemptsExhausted",
+    "FetchPolicy",
     "Fetched",
+    "HttpFetcher",
+    "NewsCandidate",
+    "NewsTickerHint",
+    "PR_NEWSWIRE",
     "PdfParseError",
+    "RawFeed",
+    "RawNewsDocument",
     "RawPaper",
+    "RawWireArtifact",
+    "WireDocument",
+    "WireFeedConfig",
+    "WireFetchFailure",
+    "WireFetchResult",
+    "WireItemMapping",
+    "WireProvider",
+    "build_news_dedup_key",
+    "build_sec_news_dedup_key",
+    "build_wire_identity",
     "business_days_between",
+    "canonicalize_source_url",
     "collapse_whitespace",
     "dedupe_lines",
+    "extract_exchange_ticker_hints",
+    "feed_item_to_news_document",
     "fetch_arxiv",
+    "fetch_news_document",
+    "fetch_rss_feed",
     "fetch_url",
+    "fetch_wire_documents",
     "html_to_markdown",
+    "news_content_hash",
+    "news_document_from_fetched",
+    "normalize_news_text",
     "normalize_unicode",
+    "parse_feed",
     "parse_filing_date",
+    "parse_news_datetime",
     "pdf_to_markdown",
+    "preprocess_feed_item",
+    "preprocess_news_document",
+    "preprocess_news_url",
     "read_local_file",
     "resolve_doi",
     "to_utc",

--- a/quantmind/preprocess/fetch/__init__.py
+++ b/quantmind/preprocess/fetch/__init__.py
@@ -15,18 +15,34 @@ from quantmind.preprocess.fetch.doi import (
 )
 from quantmind.preprocess.fetch.http import (
     DEFAULT_USER_AGENT,
+    FetchAttemptsExhausted,
+    FetchPolicy,
+    HttpFetcher,
     fetch_url,
 )
 from quantmind.preprocess.fetch.local import read_local_file
+from quantmind.preprocess.fetch.rss import (
+    FeedItem,
+    RawFeed,
+    fetch_rss_feed,
+    parse_feed,
+)
 
 __all__ = [
     "ArxivIdParseError",
     "CrossrefMetadata",
     "DEFAULT_USER_AGENT",
+    "FeedItem",
+    "FetchAttemptsExhausted",
+    "FetchPolicy",
     "Fetched",
+    "HttpFetcher",
+    "RawFeed",
     "RawPaper",
     "fetch_arxiv",
+    "fetch_rss_feed",
     "fetch_url",
+    "parse_feed",
     "read_local_file",
     "resolve_doi",
 ]

--- a/quantmind/preprocess/fetch/_types.py
+++ b/quantmind/preprocess/fetch/_types.py
@@ -29,6 +29,15 @@ class Fetched:
     headers: dict[str, str] = field(default_factory=dict)
     """Selected response headers (HTTP fetches only); empty dict otherwise."""
 
+    status_code: int | None = None
+    """HTTP status code when fetched over HTTP; otherwise ``None``."""
+
+    resolved_url: str | None = None
+    """Final URL after redirects; otherwise ``None``."""
+
+    fetched_at: datetime | None = None
+    """UTC capture time for HTTP evidence; otherwise ``None``."""
+
 
 @dataclass(frozen=True, slots=True)
 class RawPaper(Fetched):

--- a/quantmind/preprocess/fetch/http.py
+++ b/quantmind/preprocess/fetch/http.py
@@ -1,9 +1,12 @@
-"""HTTP fetch helper.
+"""Reusable HTTP fetching with optional retry and host politeness policy."""
 
-Pulls bytes from an arbitrary URL with a sane default User-Agent, a body
-size cap, and a request timeout. Returns ``Fetched`` so the format layer
-can dispatch on ``content_type`` without re-inspecting headers.
-"""
+import asyncio
+import random
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from types import TracebackType
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -20,43 +23,204 @@ _CAPTURED_HEADERS: tuple[str, ...] = (
     "etag",
     "last-modified",
     "content-disposition",
+    "retry-after",
 )
 
 
-async def fetch_url(
-    url: str,
-    *,
-    timeout: float = 30.0,
-    max_bytes: int = 50_000_000,
-    user_agent: str = DEFAULT_USER_AGENT,
-) -> Fetched:
-    """GET ``url`` and return the body as ``Fetched``.
+@dataclass(frozen=True, slots=True)
+class FetchPolicy:
+    """Generic retry and per-host politeness settings for HTTP requests."""
 
-    Streams the response so we can short-circuit on payloads larger than
-    ``max_bytes`` without buffering the whole thing into memory.
+    max_attempts: int = 3
+    backoff_base_seconds: float = 0.5
+    backoff_max_seconds: float = 30.0
+    jitter_seconds: float = 0.1
+    max_concurrency_per_host: int = 2
+    min_interval_seconds: float = 0.0
 
-    Args:
-        url: Absolute http(s) URL.
-        timeout: Per-request timeout in seconds.
-        max_bytes: Hard ceiling on response body size. Hitting it raises
-            ``ValueError``.
-        user_agent: Optional override; defaults to a QuantMind-branded UA.
+    def __post_init__(self) -> None:
+        """Validate policy values before requests start."""
+        if self.max_attempts < 1:
+            raise ValueError("max_attempts must be >= 1")
+        if self.backoff_base_seconds < 0:
+            raise ValueError("backoff_base_seconds must be >= 0")
+        if self.backoff_max_seconds < self.backoff_base_seconds:
+            raise ValueError(
+                "backoff_max_seconds must be >= backoff_base_seconds"
+            )
+        if self.jitter_seconds < 0:
+            raise ValueError("jitter_seconds must be >= 0")
+        if self.max_concurrency_per_host < 1:
+            raise ValueError("max_concurrency_per_host must be >= 1")
+        if self.min_interval_seconds < 0:
+            raise ValueError("min_interval_seconds must be >= 0")
 
-    Returns:
-        ``Fetched`` with body bytes, ``content_type`` (lower-cased,
-        parameter-stripped — e.g. ``"text/html"`` not
-        ``"text/html; charset=utf-8"``), and a curated subset of response
-        headers.
 
-    Raises:
-        ValueError: If the response body exceeds ``max_bytes``.
-        httpx.HTTPError: For network / status / timeout failures.
-    """
-    headers = {"User-Agent": user_agent}
-    async with httpx.AsyncClient(
-        timeout=timeout, follow_redirects=True
-    ) as client:
-        async with client.stream("GET", url, headers=headers) as response:
+class FetchAttemptsExhausted(httpx.HTTPError):
+    """A retryable HTTP failure that exhausted its configured attempts."""
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        attempts: int,
+        last_error: httpx.HTTPError,
+    ) -> None:
+        self.url = url
+        self.attempts = attempts
+        self.last_error = last_error
+        super().__init__(
+            f"request to {url!r} failed after {attempts} attempts: {last_error}"
+        )
+
+
+@dataclass(slots=True)
+class _HostState:
+    semaphore: asyncio.Semaphore
+    spacing_lock: asyncio.Lock
+    next_request_at: float = 0.0
+
+
+class HttpFetcher:
+    """Stateful HTTP fetcher sharing a client and per-host rate state."""
+
+    def __init__(
+        self,
+        *,
+        policy: FetchPolicy | None = None,
+        timeout: float = 30.0,
+        max_bytes: int = 50_000_000,
+        user_agent: str = DEFAULT_USER_AGENT,
+    ) -> None:
+        self.policy = policy
+        self.timeout = timeout
+        self.max_bytes = max_bytes
+        self.user_agent = user_agent
+        self._client: httpx.AsyncClient | None = None
+        self._host_states: dict[str, _HostState] = {}
+
+    async def __aenter__(self) -> "HttpFetcher":
+        self._client = httpx.AsyncClient(
+            timeout=self.timeout,
+            follow_redirects=True,
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def fetch_url(
+        self,
+        url: str,
+        *,
+        timeout: float | None = None,
+        max_bytes: int | None = None,
+        user_agent: str | None = None,
+    ) -> Fetched:
+        """GET one URL using this fetcher's shared policy and host state."""
+        if self._client is None:
+            raise RuntimeError("HttpFetcher must be used as an async context")
+
+        policy = self.policy
+        attempts = policy.max_attempts if policy is not None else 1
+        for attempt in range(1, attempts + 1):
+            try:
+                return await self._request_once(
+                    url,
+                    timeout=self.timeout if timeout is None else timeout,
+                    max_bytes=self.max_bytes
+                    if max_bytes is None
+                    else max_bytes,
+                    user_agent=user_agent or self.user_agent,
+                )
+            except httpx.HTTPError as exc:
+                if policy is None or not _is_retryable(exc):
+                    raise
+                if attempt == attempts:
+                    raise FetchAttemptsExhausted(
+                        url=url,
+                        attempts=attempts,
+                        last_error=exc,
+                    ) from exc
+                delay = min(
+                    policy.backoff_max_seconds,
+                    policy.backoff_base_seconds * (2 ** (attempt - 1)),
+                )
+                delay += random.uniform(0.0, policy.jitter_seconds)
+                retry_after = _retry_after_seconds(exc)
+                if retry_after is not None:
+                    delay = max(delay, retry_after)
+                await asyncio.sleep(delay)
+
+        raise AssertionError("unreachable retry loop")
+
+    async def _request_once(
+        self,
+        url: str,
+        *,
+        timeout: float,
+        max_bytes: int,
+        user_agent: str,
+    ) -> Fetched:
+        policy = self.policy
+        if policy is None:
+            return await self._stream_get(
+                url,
+                timeout=timeout,
+                max_bytes=max_bytes,
+                user_agent=user_agent,
+            )
+
+        host = urlsplit(url).netloc.lower()
+        state = self._host_states.get(host)
+        if state is None:
+            state = _HostState(
+                semaphore=asyncio.Semaphore(policy.max_concurrency_per_host),
+                spacing_lock=asyncio.Lock(),
+            )
+            self._host_states[host] = state
+
+        async with state.semaphore:
+            async with state.spacing_lock:
+                loop = asyncio.get_running_loop()
+                delay = state.next_request_at - loop.time()
+                if delay > 0:
+                    await asyncio.sleep(delay)
+                state.next_request_at = (
+                    loop.time() + policy.min_interval_seconds
+                )
+            return await self._stream_get(
+                url,
+                timeout=timeout,
+                max_bytes=max_bytes,
+                user_agent=user_agent,
+            )
+
+    async def _stream_get(
+        self,
+        url: str,
+        *,
+        timeout: float,
+        max_bytes: int,
+        user_agent: str,
+    ) -> Fetched:
+        if self._client is None:
+            raise RuntimeError("HttpFetcher must be used as an async context")
+
+        headers = {"User-Agent": user_agent}
+        async with self._client.stream(
+            "GET",
+            url,
+            headers=headers,
+            timeout=timeout,
+        ) as response:
             response.raise_for_status()
             chunks: list[bytes] = []
             received = 0
@@ -74,14 +238,75 @@ async def fetch_url(
             )
             content_type = raw_content_type.split(";", 1)[0].strip().lower()
             captured = {
-                k: v
-                for k, v in response.headers.items()
-                if k.lower() in _CAPTURED_HEADERS
+                key: value
+                for key, value in response.headers.items()
+                if key.lower() in _CAPTURED_HEADERS
             }
+            return Fetched(
+                bytes=b"".join(chunks),
+                content_type=content_type,
+                source_url=url,
+                headers=captured,
+                status_code=response.status_code,
+                resolved_url=str(response.url),
+                fetched_at=datetime.now(timezone.utc),
+            )
 
-    return Fetched(
-        bytes=b"".join(chunks),
-        content_type=content_type,
-        source_url=url,
-        headers=captured,
-    )
+
+async def fetch_url(
+    url: str,
+    *,
+    timeout: float = 30.0,
+    max_bytes: int = 50_000_000,
+    user_agent: str = DEFAULT_USER_AGENT,
+    fetch_policy: FetchPolicy | None = None,
+) -> Fetched:
+    """GET ``url`` with optional retry/backoff and host politeness policy.
+
+    Omitting ``fetch_policy`` preserves the original one-shot request
+    behavior. Reuse ``HttpFetcher`` directly when several calls must share
+    per-host rate state and one connection pool.
+    """
+    async with HttpFetcher(
+        policy=fetch_policy,
+        timeout=timeout,
+        max_bytes=max_bytes,
+        user_agent=user_agent,
+    ) as fetcher:
+        return await fetcher.fetch_url(url)
+
+
+def _is_retryable(error: httpx.HTTPError) -> bool:
+    if isinstance(error, httpx.TransportError):
+        return True
+    if isinstance(error, httpx.HTTPStatusError):
+        status = error.response.status_code
+        return status in {408, 429} or status >= 500
+    return False
+
+
+def _retry_after_seconds(error: httpx.HTTPError) -> float | None:
+    if not isinstance(error, httpx.HTTPStatusError):
+        return None
+    if error.response.status_code not in {429, 503}:
+        return None
+    value = error.response.headers.get("retry-after")
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        try:
+            parsed = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+        if parsed is None:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return max(
+            0.0,
+            (
+                parsed.astimezone(timezone.utc) - datetime.now(timezone.utc)
+            ).total_seconds(),
+        )

--- a/quantmind/preprocess/fetch/rss.py
+++ b/quantmind/preprocess/fetch/rss.py
@@ -1,0 +1,270 @@
+"""RSS/Atom feed fetch and parsing helpers for news ingestion.
+
+This module deliberately stays in the fetch layer: it downloads feed XML and
+turns it into typed feed-item metadata. Article-body extraction and source
+normalisation live in ``quantmind.preprocess.news``.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from xml.etree import ElementTree
+
+from quantmind.preprocess.fetch._types import Fetched
+from quantmind.preprocess.fetch.http import (
+    DEFAULT_USER_AGENT,
+    HttpFetcher,
+    fetch_url,
+)
+from quantmind.preprocess.time import parse_news_datetime
+
+
+@dataclass(frozen=True, slots=True)
+class FeedItem:
+    """One RSS/Atom entry discovered in a feed."""
+
+    title: str
+    url: str | None = None
+    id: str | None = None
+    published_at: datetime | None = None
+    summary_html: str | None = None
+    content_html: str | None = None
+    source_feed_url: str | None = None
+    raw: dict[str, str] = field(default_factory=dict)
+    raw_xml: bytes = b""
+
+
+@dataclass(frozen=True, slots=True)
+class RawFeed:
+    """Parsed RSS/Atom feed metadata and items."""
+
+    feed_url: str | None
+    title: str | None = None
+    items: tuple[FeedItem, ...] = ()
+    content_type: str = "application/xml"
+    headers: dict[str, str] = field(default_factory=dict)
+    fetched: Fetched | None = None
+
+
+async def fetch_rss_feed(
+    url: str,
+    *,
+    timeout: float = 30.0,
+    max_bytes: int = 5_000_000,
+    user_agent: str = DEFAULT_USER_AGENT,
+    fetcher: HttpFetcher | None = None,
+) -> RawFeed:
+    """Fetch an RSS/Atom feed and parse its entries.
+
+    Args:
+        url: Absolute RSS/Atom feed URL.
+        timeout: Per-request timeout in seconds.
+        max_bytes: Hard ceiling on response body size.
+        user_agent: Optional User-Agent override.
+        fetcher: Optional shared HTTP fetcher and host-rate state.
+
+    Returns:
+        Parsed feed metadata and entries.
+
+    Raises:
+        ValueError: If the feed XML is unsupported or malformed.
+        httpx.HTTPError: For network / status / timeout failures.
+    """
+    if fetcher is None:
+        raw = await fetch_url(
+            url,
+            timeout=timeout,
+            max_bytes=max_bytes,
+            user_agent=user_agent,
+        )
+    else:
+        raw = await fetcher.fetch_url(
+            url,
+            timeout=timeout,
+            max_bytes=max_bytes,
+            user_agent=user_agent,
+        )
+    return parse_feed(
+        raw.bytes,
+        feed_url=url,
+        content_type=raw.content_type,
+        headers=raw.headers,
+        fetched=raw,
+    )
+
+
+def parse_feed(
+    xml_bytes: bytes,
+    *,
+    feed_url: str | None = None,
+    content_type: str = "application/xml",
+    headers: dict[str, str] | None = None,
+    fetched: Fetched | None = None,
+) -> RawFeed:
+    """Parse RSS 2.x or Atom XML bytes into a ``RawFeed``.
+
+    Args:
+        xml_bytes: Raw XML payload.
+        feed_url: Origin feed URL, when known.
+        content_type: MIME type observed for the feed.
+        headers: Selected HTTP response headers.
+        fetched: Original fetched response metadata, when available.
+
+    Returns:
+        Parsed feed metadata and items.
+
+    Raises:
+        ValueError: If the XML is empty, malformed, or not RSS/Atom.
+    """
+    if not xml_bytes.strip():
+        raise ValueError("empty feed payload")
+    try:
+        root = ElementTree.fromstring(xml_bytes)
+    except ElementTree.ParseError as exc:
+        raise ValueError(f"malformed feed XML: {exc}") from exc
+
+    root_name = _local_name(root.tag)
+    if root_name == "rss":
+        title, items = _parse_rss(root, feed_url)
+    elif root_name == "feed":
+        title, items = _parse_atom(root, feed_url)
+    else:
+        raise ValueError(f"unsupported feed root: {root_name!r}")
+
+    return RawFeed(
+        feed_url=feed_url,
+        title=title,
+        items=tuple(items),
+        content_type=content_type,
+        headers=dict(headers or {}),
+        fetched=fetched,
+    )
+
+
+def _parse_rss(
+    root: ElementTree.Element,
+    feed_url: str | None,
+) -> tuple[str | None, list[FeedItem]]:
+    channel = _first_child(root, "channel") or root
+    title = _child_text(channel, "title")
+    items: list[FeedItem] = []
+    for item in _children(channel, "item"):
+        item_title = _child_text(item, "title") or ""
+        url = _child_text(item, "link")
+        item_id = _child_text(item, "guid") or url
+        published_at = _parse_datetime_or_none(
+            _child_text(item, "pubDate")
+            or _child_text(item, "date")
+            or _child_text(item, "published")
+        )
+        summary = _child_text(item, "description")
+        content = _child_text(item, "encoded") or _child_text(item, "content")
+        items.append(
+            FeedItem(
+                title=item_title,
+                url=url,
+                id=item_id,
+                published_at=published_at,
+                summary_html=summary,
+                content_html=content,
+                source_feed_url=feed_url,
+                raw={
+                    k: v
+                    for k, v in {
+                        "guid": item_id,
+                        "pubDate": _child_text(item, "pubDate"),
+                    }.items()
+                    if v
+                },
+                raw_xml=ElementTree.tostring(item, encoding="utf-8"),
+            )
+        )
+    return title, items
+
+
+def _parse_atom(
+    root: ElementTree.Element,
+    feed_url: str | None,
+) -> tuple[str | None, list[FeedItem]]:
+    title = _child_text(root, "title")
+    items: list[FeedItem] = []
+    for entry in _children(root, "entry"):
+        item_title = _child_text(entry, "title") or ""
+        url = _atom_link(entry)
+        item_id = _child_text(entry, "id") or url
+        published_at = _parse_datetime_or_none(
+            _child_text(entry, "published") or _child_text(entry, "updated")
+        )
+        summary = _child_text(entry, "summary")
+        content = _child_text(entry, "content")
+        items.append(
+            FeedItem(
+                title=item_title,
+                url=url,
+                id=item_id,
+                published_at=published_at,
+                summary_html=summary,
+                content_html=content,
+                source_feed_url=feed_url,
+                raw={
+                    k: v
+                    for k, v in {
+                        "id": item_id,
+                        "updated": _child_text(entry, "updated"),
+                    }.items()
+                    if v
+                },
+                raw_xml=ElementTree.tostring(entry, encoding="utf-8"),
+            )
+        )
+    return title, items
+
+
+def _atom_link(entry: ElementTree.Element) -> str | None:
+    fallback: str | None = None
+    for child in _children(entry, "link"):
+        href = child.attrib.get("href")
+        if not href:
+            continue
+        rel = child.attrib.get("rel", "alternate").strip().lower()
+        if rel == "alternate":
+            return href.strip()
+        fallback = fallback or href.strip()
+    return fallback
+
+
+def _parse_datetime_or_none(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return parse_news_datetime(value)
+    except ValueError:
+        return None
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _children(
+    element: ElementTree.Element,
+    name: str,
+) -> list[ElementTree.Element]:
+    return [child for child in list(element) if _local_name(child.tag) == name]
+
+
+def _first_child(
+    element: ElementTree.Element,
+    name: str,
+) -> ElementTree.Element | None:
+    for child in list(element):
+        if _local_name(child.tag) == name:
+            return child
+    return None
+
+
+def _child_text(element: ElementTree.Element, name: str) -> str | None:
+    child = _first_child(element, name)
+    if child is None:
+        return None
+    text = "".join(child.itertext()).strip()
+    return text or None

--- a/quantmind/preprocess/news.py
+++ b/quantmind/preprocess/news.py
@@ -1,0 +1,454 @@
+"""Source-agnostic news preprocessing and candidate normalization."""
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from quantmind.preprocess.clean import (
+    collapse_whitespace,
+    dedupe_lines,
+    normalize_unicode,
+)
+from quantmind.preprocess.fetch._types import Fetched
+from quantmind.preprocess.fetch.http import HttpFetcher, fetch_url
+from quantmind.preprocess.fetch.rss import FeedItem
+from quantmind.preprocess.format.html import html_to_markdown
+from quantmind.preprocess.time import to_utc
+
+NewsSourceType = Literal[
+    "company_8k",
+    "press_release",
+    "publisher_news",
+    "regulatory_news",
+]
+BodySource = Literal["feed", "article"]
+
+_SOURCE_PREFIX: dict[str, str] = {
+    "company_8k": "sec",
+    "press_release": "wire",
+    "publisher_news": "publisher",
+    "regulatory_news": "regulatory",
+}
+
+_TRACKING_QUERY_PARAMS = {
+    "fbclid",
+    "feedref",
+    "gclid",
+    "mc_cid",
+    "mc_eid",
+    "spm",
+}
+
+_EXCHANGE_TICKER_RE = re.compile(
+    r"(?:\(|\b)"
+    r"(NASDAQ|NYSE(?:\s+American|\s+MKT|\s+Arca)?|AMEX|OTCQX|OTCQB|OTC|CBOE)"
+    r"\s*:\s*"
+    r"([A-Z][A-Z0-9.-]{0,9})"
+    r"(?:\)|\b)",
+    re.IGNORECASE,
+)
+_EMAIL_PROTECTION_LINK_RE = re.compile(
+    r"\[\[email protected]\]\(/cdn-cgi/l/email-protection#[^)]+\)"
+)
+
+_EXCHANGE_NAMES: dict[str, str] = {
+    "NASDAQ": "NASDAQ",
+    "NYSE": "NYSE",
+    "NYSE AMERICAN": "NYSE American",
+    "NYSE MKT": "NYSE American",
+    "NYSE ARCA": "NYSE Arca",
+    "AMEX": "NYSE American",
+    "OTCQX": "OTCQX",
+    "OTCQB": "OTCQB",
+    "OTC": "OTC",
+    "CBOE": "CBOE",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class NewsTickerHint:
+    """Ticker hint extracted before instrument resolution."""
+
+    symbol: str
+    exchange: str | None = None
+    source: str = "exchange_code"
+    confidence: float = 1.0
+    raw: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RawNewsDocument:
+    """Raw news document ready for source-agnostic preprocessing."""
+
+    body_text: str
+    source_type: NewsSourceType = "press_release"
+    source_url: str | None = None
+    title: str | None = None
+    publisher: str | None = None
+    published_at: datetime | None = None
+    payload_id: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class NewsCandidate:
+    """Normalised candidate document consumed by a news processing flow."""
+
+    body_text: str
+    content_hash: str
+    source_type: NewsSourceType
+    dedup_key: str
+    source_url: str | None = None
+    title: str | None = None
+    publisher: str | None = None
+    published_at: datetime | None = None
+    ticker_hints: tuple[NewsTickerHint, ...] = ()
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+async def fetch_news_document(
+    url: str,
+    *,
+    source_type: NewsSourceType = "press_release",
+    title: str | None = None,
+    publisher: str | None = None,
+    published_at: datetime | None = None,
+    payload_id: str | None = None,
+    timeout: float = 30.0,
+    max_bytes: int = 10_000_000,
+    fetcher: HttpFetcher | None = None,
+) -> RawNewsDocument:
+    """Fetch one news/press-release URL and extract plain markdown text.
+
+    Args:
+        url: Article or press-release URL.
+        source_type: Normalised source family.
+        title: Optional title supplied by a feed or caller.
+        publisher: Optional source publisher.
+        published_at: Optional publication timestamp.
+        payload_id: Optional upstream feed/item id.
+        timeout: Per-request timeout in seconds.
+        max_bytes: Hard ceiling on response body size.
+        fetcher: Optional shared HTTP fetcher and host-rate state.
+
+    Returns:
+        Raw document with extracted markdown text and caller metadata.
+
+    Raises:
+        ValueError: If the content type cannot be converted to text.
+        httpx.HTTPError: For network / status / timeout failures.
+    """
+    if fetcher is None:
+        fetched = await fetch_url(url, timeout=timeout, max_bytes=max_bytes)
+    else:
+        fetched = await fetcher.fetch_url(
+            url,
+            timeout=timeout,
+            max_bytes=max_bytes,
+        )
+    return await news_document_from_fetched(
+        fetched,
+        source_type=source_type,
+        title=title,
+        publisher=publisher,
+        published_at=published_at,
+        payload_id=payload_id,
+    )
+
+
+async def news_document_from_fetched(
+    fetched: Fetched,
+    *,
+    source_type: NewsSourceType = "press_release",
+    title: str | None = None,
+    publisher: str | None = None,
+    published_at: datetime | None = None,
+    payload_id: str | None = None,
+) -> RawNewsDocument:
+    """Extract a raw news document from already-fetched evidence."""
+    body_text = await _text_from_fetched(fetched)
+    return RawNewsDocument(
+        body_text=body_text,
+        source_type=source_type,
+        source_url=fetched.resolved_url or fetched.source_url,
+        title=title,
+        publisher=publisher,
+        published_at=published_at,
+        payload_id=payload_id,
+        metadata={
+            "body_source": "article",
+            "content_type": fetched.content_type,
+        },
+    )
+
+
+async def preprocess_news_url(
+    url: str,
+    *,
+    source_type: NewsSourceType = "press_release",
+    title: str | None = None,
+    publisher: str | None = None,
+    published_at: datetime | None = None,
+    payload_id: str | None = None,
+    timeout: float = 30.0,
+    max_bytes: int = 10_000_000,
+) -> NewsCandidate:
+    """Fetch and normalise one news/press-release URL."""
+    raw = await fetch_news_document(
+        url,
+        source_type=source_type,
+        title=title,
+        publisher=publisher,
+        published_at=published_at,
+        payload_id=payload_id,
+        timeout=timeout,
+        max_bytes=max_bytes,
+    )
+    return preprocess_news_document(raw)
+
+
+async def feed_item_to_news_document(
+    item: FeedItem,
+    *,
+    source_type: NewsSourceType = "press_release",
+    publisher: str | None = None,
+    body_source: BodySource = "feed",
+    fetcher: HttpFetcher | None = None,
+) -> RawNewsDocument:
+    """Convert one parsed RSS/Atom item into a raw news document.
+
+    ``body_source="feed"`` trusts the RSS/Atom body. ``"article"`` always
+    follows the item URL, even when the feed contains a non-empty teaser.
+    """
+    if body_source == "article":
+        if not item.url:
+            raise ValueError("article body_source requires an item URL")
+        raw = await fetch_news_document(
+            item.url,
+            source_type=source_type,
+            title=item.title,
+            publisher=publisher,
+            published_at=item.published_at,
+            payload_id=item.id,
+            fetcher=fetcher,
+        )
+        return RawNewsDocument(
+            body_text=raw.body_text,
+            source_type=raw.source_type,
+            source_url=raw.source_url,
+            title=raw.title,
+            publisher=raw.publisher,
+            published_at=raw.published_at,
+            payload_id=raw.payload_id,
+            metadata={
+                **raw.metadata,
+                **{
+                    key: value
+                    for key, value in {
+                        "source_feed_url": item.source_feed_url,
+                        **item.raw,
+                    }.items()
+                    if value
+                },
+            },
+        )
+
+    body_text = await _html_or_text_to_markdown(
+        item.content_html or item.summary_html or ""
+    )
+    return RawNewsDocument(
+        body_text=body_text,
+        source_type=source_type,
+        source_url=item.url,
+        title=item.title,
+        publisher=publisher,
+        published_at=item.published_at,
+        payload_id=item.id,
+        metadata={
+            key: value
+            for key, value in {
+                "body_source": "feed",
+                "source_feed_url": item.source_feed_url,
+                **item.raw,
+            }.items()
+            if value
+        },
+    )
+
+
+async def preprocess_feed_item(
+    item: FeedItem,
+    *,
+    source_type: NewsSourceType = "press_release",
+    publisher: str | None = None,
+    body_source: BodySource = "feed",
+    fetcher: HttpFetcher | None = None,
+) -> NewsCandidate:
+    """Convert and normalise one parsed RSS/Atom item."""
+    raw = await feed_item_to_news_document(
+        item,
+        source_type=source_type,
+        publisher=publisher,
+        body_source=body_source,
+        fetcher=fetcher,
+    )
+    return preprocess_news_document(raw)
+
+
+def preprocess_news_document(raw: RawNewsDocument) -> NewsCandidate:
+    """Normalise a raw news document into the shared candidate contract.
+
+    The output carries stable source identity, cleaned body text, a content
+    hash, provenance, timestamp, and deterministic ticker hints.
+    """
+    body_text = normalize_news_text(raw.body_text)
+    if not body_text:
+        raise ValueError("news document body is empty after preprocessing")
+
+    source_url = (
+        canonicalize_source_url(raw.source_url) if raw.source_url else None
+    )
+    title = normalize_news_text(raw.title or "") or None
+    published_at = to_utc(raw.published_at) if raw.published_at else None
+    ticker_scan = "\n".join(part for part in (title, body_text) if part)
+
+    return NewsCandidate(
+        body_text=body_text,
+        content_hash=news_content_hash(body_text),
+        source_type=raw.source_type,
+        dedup_key=build_news_dedup_key(
+            source_type=raw.source_type,
+            source_url=source_url,
+            payload_id=raw.payload_id,
+        ),
+        source_url=source_url,
+        title=title,
+        publisher=raw.publisher,
+        published_at=published_at,
+        ticker_hints=extract_exchange_ticker_hints(ticker_scan),
+        metadata=dict(raw.metadata),
+    )
+
+
+def normalize_news_text(text: str) -> str:
+    """Apply QuantMind's canonical text cleanup order for news bodies."""
+    normalized = normalize_unicode(text)
+    normalized = _EMAIL_PROTECTION_LINK_RE.sub("[email protected]", normalized)
+    return collapse_whitespace(dedupe_lines(normalized))
+
+
+def news_content_hash(text: str) -> str:
+    """Return the sha256 hash for an already-normalised news body."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def build_news_dedup_key(
+    *,
+    source_type: NewsSourceType,
+    source_url: str | None = None,
+    payload_id: str | None = None,
+) -> str:
+    """Build a deterministic source-document dedup key.
+
+    Press-release/wire rows use the payload id when available and otherwise
+    fall back to the canonical source URL. The identity is hashed so callers do
+    not accidentally depend on upstream id formatting.
+    """
+    identity = (payload_id or "").strip()
+    if not identity and source_url:
+        identity = canonicalize_source_url(source_url)
+    if not identity:
+        raise ValueError("news dedup key requires payload_id or source_url")
+    prefix = _SOURCE_PREFIX[source_type]
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    return f"{prefix}:{digest}"
+
+
+def build_sec_news_dedup_key(
+    *,
+    accession_number: str,
+    section_key: str,
+) -> str:
+    """Build a stable 8-K EX-99.x news dedup key."""
+    accession = accession_number.strip()
+    section = section_key.strip().lower()
+    if not accession or not section:
+        raise ValueError("SEC news dedup key requires accession and section")
+    return f"sec:{accession}:{section}"
+
+
+def canonicalize_source_url(url: str) -> str:
+    """Normalise source URLs for stable dedup identity."""
+    parsed = urlsplit(url.strip())
+    query = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if not key.lower().startswith("utm_")
+        and key.lower() not in _TRACKING_QUERY_PARAMS
+    ]
+    path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/")
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            path,
+            urlencode(sorted(query), doseq=True),
+            "",
+        )
+    )
+
+
+def extract_exchange_ticker_hints(text: str) -> tuple[NewsTickerHint, ...]:
+    """Extract exchange-qualified ticker mentions from PR-style text.
+
+    Examples matched include ``(NASDAQ: NVDA)`` and ``NYSE: IBM``. The result is
+    only a hint; downstream instrument resolution should still validate it.
+    """
+    hints: list[NewsTickerHint] = []
+    seen: set[tuple[str, str | None]] = set()
+    for match in _EXCHANGE_TICKER_RE.finditer(text):
+        raw_exchange = " ".join(match.group(1).upper().split())
+        exchange = _EXCHANGE_NAMES.get(raw_exchange, raw_exchange)
+        symbol = match.group(2).upper()
+        key = (symbol, exchange)
+        if key in seen:
+            continue
+        seen.add(key)
+        hints.append(
+            NewsTickerHint(
+                symbol=symbol,
+                exchange=exchange,
+                raw=match.group(0).strip(),
+            )
+        )
+    return tuple(hints)
+
+
+async def _text_from_fetched(raw: Fetched) -> str:
+    ct = (raw.content_type or "").lower()
+    text = raw.bytes.decode("utf-8", errors="replace")
+    if ct.startswith("text/html") or ct.startswith("application/xhtml+xml"):
+        return await html_to_markdown(text)
+    if (
+        ct.startswith("text/plain")
+        or ct.startswith("text/markdown")
+        or ct.startswith("application/xml")
+        or ct.startswith("text/xml")
+    ):
+        return text
+    raise ValueError(f"Unsupported content-type for news input: {ct!r}")
+
+
+async def _html_or_text_to_markdown(value: str) -> str:
+    text = value.strip()
+    if not text:
+        return ""
+    if "<" not in text or ">" not in text:
+        return text
+    markdown = await html_to_markdown(text)
+    return markdown or text

--- a/quantmind/preprocess/time.py
+++ b/quantmind/preprocess/time.py
@@ -6,6 +6,7 @@ expected to be aware (tz-attached); naive ones are treated as UTC.
 """
 
 from datetime import date, datetime, timezone
+from email.utils import parsedate_to_datetime
 
 # ISO 8601 + the common journal/news layouts. Order matters: more specific
 # patterns first so ``2024-04-15T10:30:00Z`` doesn't get partial-matched
@@ -68,6 +69,38 @@ def parse_filing_date(value: str) -> datetime:
     raise ValueError(
         f"could not parse date {value!r}; tried {len(_DATE_FORMATS)} formats"
     ) from last_error
+
+
+def parse_news_datetime(value: str) -> datetime:
+    """Parse an RFC 822 or ISO-8601 news timestamp into UTC.
+
+    Args:
+        value: News timestamp string.
+
+    Returns:
+        A timezone-aware UTC datetime.
+
+    Raises:
+        ValueError: If the timestamp is empty or unsupported.
+    """
+    text = value.strip()
+    if not text:
+        raise ValueError("empty news datetime string")
+
+    try:
+        return parse_filing_date(text)
+    except ValueError as iso_error:
+        try:
+            parsed = parsedate_to_datetime(text)
+        except (TypeError, ValueError) as rfc_error:
+            raise ValueError(
+                f"could not parse news datetime {value!r}"
+            ) from rfc_error
+        if parsed is None:
+            raise ValueError(
+                f"could not parse news datetime {value!r}"
+            ) from iso_error
+        return to_utc(parsed)
 
 
 def business_days_between(a: date, b: date) -> int:

--- a/quantmind/preprocess/wire.py
+++ b/quantmind/preprocess/wire.py
@@ -1,0 +1,431 @@
+"""Provider-pluggable ingestion for public press-release wire feeds."""
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal, Protocol
+
+import httpx
+
+from quantmind.preprocess.fetch._types import Fetched
+from quantmind.preprocess.fetch.http import (
+    FetchAttemptsExhausted,
+    FetchPolicy,
+    HttpFetcher,
+)
+from quantmind.preprocess.fetch.rss import FeedItem, parse_feed
+from quantmind.preprocess.news import (
+    BodySource,
+    NewsTickerHint,
+    canonicalize_source_url,
+    feed_item_to_news_document,
+    news_document_from_fetched,
+    preprocess_news_document,
+)
+
+WireFailureStage = Literal[
+    "feed_fetch",
+    "feed_parse",
+    "article_fetch",
+    "article_parse",
+    "document_build",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class WireItemMapping:
+    """Provider-normalized identity and metadata for one feed item."""
+
+    payload_id: str | None
+    canonical_url: str | None
+    title: str
+    published_at: datetime | None
+
+
+class WireProvider(Protocol):
+    """Adapter contract for provider-specific feed item behavior."""
+
+    @property
+    def name(self) -> str:
+        """Stable provider identifier."""
+        ...
+
+    @property
+    def publisher(self) -> str:
+        """Human-readable publisher name."""
+        ...
+
+    @property
+    def body_source(self) -> BodySource:
+        """Whether cleaned body text comes from feed or article HTML."""
+        ...
+
+    def map_item(self, item: FeedItem) -> WireItemMapping:
+        """Map one provider feed item into common identity fields."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class _StandardWireProvider:
+    name: str
+    publisher: str
+    body_source: BodySource
+
+    def map_item(self, item: FeedItem) -> WireItemMapping:
+        url = canonicalize_source_url(item.url) if item.url else None
+        return WireItemMapping(
+            payload_id=(item.id or "").strip() or None,
+            canonical_url=url,
+            title=item.title,
+            published_at=item.published_at,
+        )
+
+
+PR_NEWSWIRE: WireProvider = _StandardWireProvider(
+    name="pr-newswire",
+    publisher="PR Newswire",
+    body_source="article",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WireFeedConfig:
+    """Public feed URLs, provider adapter, and shared HTTP policy."""
+
+    provider: WireProvider
+    feed_urls: tuple[str, ...]
+    fetch_policy: FetchPolicy = field(default_factory=FetchPolicy)
+
+    def __post_init__(self) -> None:
+        """Reject incomplete configs before network calls begin."""
+        if not self.feed_urls:
+            raise ValueError("WireFeedConfig requires at least one feed URL")
+        if any(not url.strip() for url in self.feed_urls):
+            raise ValueError("feed URLs must not be empty")
+
+
+@dataclass(frozen=True, slots=True)
+class RawWireArtifact:
+    """Raw bytes and fetch metadata retained for replay and re-cleaning."""
+
+    bytes: bytes
+    content_hash: str
+    content_type: str
+    source_url: str | None
+    resolved_url: str | None
+    status_code: int | None
+    headers: dict[str, str] = field(default_factory=dict)
+    fetched_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WireDocument:
+    """Replayable raw wire evidence paired with cleaned markdown."""
+
+    provider: str
+    identity: str
+    cleaned_markdown: str
+    content_hash: str
+    raw_feed_entry: RawWireArtifact
+    raw_article: RawWireArtifact | None = None
+    payload_id: str | None = None
+    canonical_url: str | None = None
+    title: str | None = None
+    publisher: str | None = None
+    published_at: datetime | None = None
+    ticker_hints: tuple[NewsTickerHint, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class WireFetchFailure:
+    """Lightweight record for one feed or item that could not be processed."""
+
+    provider: str
+    stage: WireFailureStage
+    source_url: str
+    item_id: str | None
+    error_type: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class WireFetchResult:
+    """Successful wire documents plus non-fatal per-item failures."""
+
+    documents: tuple[WireDocument, ...] = ()
+    failures: tuple[WireFetchFailure, ...] = ()
+
+    @property
+    def success_count(self) -> int:
+        """Number of documents produced by this call."""
+        return len(self.documents)
+
+    @property
+    def failure_count(self) -> int:
+        """Number of feed or item failures recorded by this call."""
+        return len(self.failures)
+
+
+async def fetch_wire_documents(config: WireFeedConfig) -> WireFetchResult:
+    """Fetch current feed items and convert them into wire documents.
+
+    Independent feed and item failures are recorded while remaining inputs
+    continue. Configuration errors still raise before any network request.
+    """
+    documents: list[WireDocument] = []
+    failures: list[WireFetchFailure] = []
+    seen: set[str] = set()
+    async with HttpFetcher(policy=config.fetch_policy) as fetcher:
+        for feed_url in config.feed_urls:
+            try:
+                fetched_feed = await fetcher.fetch_url(
+                    feed_url,
+                    max_bytes=5_000_000,
+                )
+            except Exception as exc:
+                failures.append(
+                    _failure(
+                        config.provider,
+                        "feed_fetch",
+                        feed_url,
+                        None,
+                        exc,
+                    )
+                )
+                continue
+
+            try:
+                feed = parse_feed(
+                    fetched_feed.bytes,
+                    feed_url=feed_url,
+                    content_type=fetched_feed.content_type,
+                    headers=fetched_feed.headers,
+                    fetched=fetched_feed,
+                )
+            except Exception as exc:
+                failures.append(
+                    _failure(
+                        config.provider,
+                        "feed_parse",
+                        feed_url,
+                        None,
+                        exc,
+                    )
+                )
+                continue
+
+            for item in feed.items:
+                try:
+                    mapping = config.provider.map_item(item)
+                    identity = build_wire_identity(
+                        provider=config.provider.name,
+                        payload_id=mapping.payload_id,
+                        canonical_url=mapping.canonical_url,
+                    )
+                except Exception as exc:
+                    failures.append(
+                        _failure(
+                            config.provider,
+                            "document_build",
+                            item.url or feed_url,
+                            item.id,
+                            exc,
+                        )
+                    )
+                    continue
+
+                if identity in seen:
+                    continue
+                seen.add(identity)
+
+                document = await _build_document(
+                    provider=config.provider,
+                    item=item,
+                    mapping=mapping,
+                    identity=identity,
+                    fetched_feed=fetched_feed,
+                    fetcher=fetcher,
+                    failures=failures,
+                )
+                if document is not None:
+                    documents.append(document)
+
+    return WireFetchResult(
+        documents=tuple(documents),
+        failures=tuple(failures),
+    )
+
+
+def build_wire_identity(
+    *,
+    provider: str,
+    payload_id: str | None,
+    canonical_url: str | None,
+) -> str:
+    """Build stable identity from provider, payload ID, and canonical URL."""
+    normalized_provider = provider.strip().lower()
+    normalized_payload = (payload_id or "").strip()
+    normalized_url = (
+        canonicalize_source_url(canonical_url) if canonical_url else ""
+    )
+    if not normalized_provider:
+        raise ValueError("wire identity requires a provider")
+    if not normalized_payload and not normalized_url:
+        raise ValueError("wire identity requires a payload ID or URL")
+    raw_identity = "\x1f".join(
+        (normalized_provider, normalized_payload, normalized_url)
+    )
+    digest = hashlib.sha256(raw_identity.encode("utf-8")).hexdigest()
+    return f"wire:{normalized_provider}:{digest}"
+
+
+async def _build_document(
+    *,
+    provider: WireProvider,
+    item: FeedItem,
+    mapping: WireItemMapping,
+    identity: str,
+    fetched_feed: Fetched,
+    fetcher: HttpFetcher,
+    failures: list[WireFetchFailure],
+) -> WireDocument | None:
+    raw_article: Fetched | None = None
+    if provider.body_source == "article":
+        article_url = mapping.canonical_url
+        if not article_url:
+            failures.append(
+                _failure(
+                    provider,
+                    "article_fetch",
+                    item.source_feed_url or "",
+                    item.id,
+                    ValueError("article body source requires an item URL"),
+                )
+            )
+            return None
+        try:
+            raw_article = await fetcher.fetch_url(
+                article_url,
+                max_bytes=10_000_000,
+            )
+        except Exception as exc:
+            failures.append(
+                _failure(
+                    provider,
+                    "article_fetch",
+                    article_url,
+                    item.id,
+                    exc,
+                )
+            )
+            return None
+
+    try:
+        if raw_article is None:
+            raw_news = await feed_item_to_news_document(
+                item,
+                publisher=provider.publisher,
+                body_source="feed",
+            )
+        else:
+            raw_news = await news_document_from_fetched(
+                raw_article,
+                title=mapping.title,
+                publisher=provider.publisher,
+                published_at=mapping.published_at,
+                payload_id=mapping.payload_id,
+            )
+        candidate = preprocess_news_document(raw_news)
+    except Exception as exc:
+        failures.append(
+            _failure(
+                provider,
+                "article_parse"
+                if raw_article is not None
+                else "document_build",
+                item.url or item.source_feed_url or "",
+                item.id,
+                exc,
+            )
+        )
+        return None
+
+    return WireDocument(
+        provider=provider.name,
+        identity=identity,
+        cleaned_markdown=candidate.body_text,
+        content_hash=candidate.content_hash,
+        raw_feed_entry=_feed_entry_artifact(item, fetched_feed),
+        raw_article=(
+            _artifact_from_fetched(raw_article)
+            if raw_article is not None
+            else None
+        ),
+        payload_id=mapping.payload_id,
+        canonical_url=mapping.canonical_url,
+        title=candidate.title,
+        publisher=candidate.publisher,
+        published_at=candidate.published_at,
+        ticker_hints=candidate.ticker_hints,
+    )
+
+
+def _feed_entry_artifact(
+    item: FeedItem,
+    fetched_feed: Fetched,
+) -> RawWireArtifact:
+    raw_xml = item.raw_xml
+    return RawWireArtifact(
+        bytes=raw_xml,
+        content_hash=hashlib.sha256(raw_xml).hexdigest(),
+        content_type="application/xml",
+        source_url=fetched_feed.source_url,
+        resolved_url=fetched_feed.resolved_url,
+        status_code=fetched_feed.status_code,
+        headers=dict(fetched_feed.headers),
+        fetched_at=fetched_feed.fetched_at,
+    )
+
+
+def _artifact_from_fetched(fetched: Fetched) -> RawWireArtifact:
+    return RawWireArtifact(
+        bytes=fetched.bytes,
+        content_hash=hashlib.sha256(fetched.bytes).hexdigest(),
+        content_type=fetched.content_type,
+        source_url=fetched.source_url,
+        resolved_url=fetched.resolved_url,
+        status_code=fetched.status_code,
+        headers=dict(fetched.headers),
+        fetched_at=fetched.fetched_at,
+    )
+
+
+def _failure(
+    provider: WireProvider,
+    stage: WireFailureStage,
+    source_url: str,
+    item_id: str | None,
+    error: Exception,
+) -> WireFetchFailure:
+    return WireFetchFailure(
+        provider=provider.name,
+        stage=stage,
+        source_url=source_url,
+        item_id=item_id,
+        error_type=_error_type(error),
+        message=str(error),
+    )
+
+
+def _error_type(error: Exception) -> str:
+    if isinstance(error, FetchAttemptsExhausted):
+        return "retry_exhausted"
+    if isinstance(error, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(error, httpx.TransportError):
+        return "network"
+    if isinstance(error, httpx.HTTPStatusError):
+        return "http_status"
+    if isinstance(error, ValueError):
+        return "invalid_content"
+    return "unexpected"

--- a/scripts/smoke_wire.py
+++ b/scripts/smoke_wire.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Run the manual live-network checklist for PR Newswire."""
+
+import asyncio
+
+from quantmind.preprocess import (
+    PR_NEWSWIRE,
+    FetchPolicy,
+    WireFeedConfig,
+    fetch_wire_documents,
+)
+
+_PUBLIC_FEED = "https://www.prnewswire.com/rss/news-releases-list.rss"
+
+
+async def _check_pr_newswire() -> bool:
+    provider_name = PR_NEWSWIRE.name
+    try:
+        result = await asyncio.wait_for(
+            fetch_wire_documents(
+                WireFeedConfig(
+                    provider=PR_NEWSWIRE,
+                    feed_urls=(_PUBLIC_FEED,),
+                    fetch_policy=FetchPolicy(
+                        max_attempts=2,
+                        min_interval_seconds=0.25,
+                    ),
+                )
+            ),
+            timeout=120,
+        )
+    except Exception as exc:
+        print(f"[FAIL] {provider_name}: {type(exc).__name__}: {exc}")
+        return False
+
+    documents = result.documents
+    checks = {
+        "documents": bool(documents),
+        "no_failures": not result.failures,
+        "raw_feed_entry": bool(documents)
+        and all(document.raw_feed_entry.bytes for document in documents),
+        "raw_article": bool(documents)
+        and all(
+            document.raw_article is not None
+            and bool(document.raw_article.bytes)
+            for document in documents
+        ),
+        "cleaned_markdown": bool(documents)
+        and all(document.cleaned_markdown.strip() for document in documents),
+        "unique_identity": len({document.identity for document in documents})
+        == len(documents),
+    }
+    for check, passed in checks.items():
+        state = "PASS" if passed else "FAIL"
+        print(f"[{state}] {provider_name}: {check}")
+    print(
+        f"       documents={result.success_count} "
+        f"failures={result.failure_count}"
+    )
+    for failure in result.failures[:3]:
+        print(
+            f"       {failure.stage} {failure.error_type} {failure.source_url}"
+        )
+    return all(checks.values())
+
+
+async def main() -> int:
+    """Run the PR Newswire checklist and return a process exit code."""
+    return 0 if await _check_pr_newswire() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/preprocess/fetch/test_http.py
+++ b/tests/preprocess/fetch/test_http.py
@@ -1,11 +1,18 @@
-"""Tests for preprocess.fetch.http — fetch_url."""
+"""Tests for preprocess.fetch.http."""
 
+import asyncio
 import unittest
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import respx
 
-from quantmind.preprocess.fetch.http import fetch_url
+from quantmind.preprocess.fetch.http import (
+    FetchAttemptsExhausted,
+    FetchPolicy,
+    HttpFetcher,
+    fetch_url,
+)
 
 
 class FetchUrlTests(unittest.IsolatedAsyncioTestCase):
@@ -27,6 +34,9 @@ class FetchUrlTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.bytes, b"hello world")
         self.assertEqual(result.content_type, "text/plain")
         self.assertEqual(result.source_url, "https://example.com/data")
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.resolved_url, "https://example.com/data")
+        self.assertIsNotNone(result.fetched_at)
         self.assertEqual(result.headers.get("etag"), "abc123")
         self.assertNotIn("x-ignored", result.headers)
 
@@ -64,3 +74,189 @@ class FetchUrlTests(unittest.IsolatedAsyncioTestCase):
             result = await fetch_url("https://example.com")
 
         self.assertEqual(result.content_type, "application/octet-stream")
+
+
+class FetchPolicyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_retries_transient_status_with_backoff(self):
+        policy = FetchPolicy(
+            max_attempts=3,
+            backoff_base_seconds=0.25,
+            backoff_max_seconds=1.0,
+            jitter_seconds=0.0,
+        )
+        with (
+            respx.mock(assert_all_called=True) as router,
+            patch(
+                "quantmind.preprocess.fetch.http.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as sleep,
+        ):
+            route = router.get("https://example.com/transient").mock(
+                side_effect=[
+                    httpx.Response(503),
+                    httpx.Response(200, content=b"ok"),
+                ]
+            )
+            result = await fetch_url(
+                "https://example.com/transient",
+                fetch_policy=policy,
+            )
+
+        self.assertEqual(result.bytes, b"ok")
+        self.assertEqual(route.call_count, 2)
+        sleep.assert_awaited_once_with(0.25)
+
+    async def test_retry_after_overrides_backoff(self):
+        policy = FetchPolicy(
+            max_attempts=2,
+            backoff_base_seconds=0.1,
+            backoff_max_seconds=1.0,
+            jitter_seconds=0.0,
+        )
+        with (
+            respx.mock(assert_all_called=True) as router,
+            patch(
+                "quantmind.preprocess.fetch.http.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as sleep,
+        ):
+            router.get("https://example.com/rate-limited").mock(
+                side_effect=[
+                    httpx.Response(429, headers={"Retry-After": "2"}),
+                    httpx.Response(200, content=b"ok"),
+                ]
+            )
+            await fetch_url(
+                "https://example.com/rate-limited",
+                fetch_policy=policy,
+            )
+
+        sleep.assert_awaited_once_with(2.0)
+
+    async def test_retries_transport_failure(self):
+        policy = FetchPolicy(
+            max_attempts=2,
+            backoff_base_seconds=0.0,
+            backoff_max_seconds=0.0,
+            jitter_seconds=0.0,
+        )
+        with (
+            respx.mock(assert_all_called=True) as router,
+            patch(
+                "quantmind.preprocess.fetch.http.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            route = router.get("https://example.com/network").mock(
+                side_effect=[
+                    httpx.ConnectError("connection reset"),
+                    httpx.Response(200, content=b"recovered"),
+                ]
+            )
+            result = await fetch_url(
+                "https://example.com/network",
+                fetch_policy=policy,
+            )
+
+        self.assertEqual(route.call_count, 2)
+        self.assertEqual(result.bytes, b"recovered")
+
+    async def test_retry_exhaustion_has_stable_error(self):
+        policy = FetchPolicy(
+            max_attempts=3,
+            backoff_base_seconds=0.0,
+            backoff_max_seconds=0.0,
+            jitter_seconds=0.0,
+        )
+        with (
+            respx.mock(assert_all_called=True) as router,
+            patch(
+                "quantmind.preprocess.fetch.http.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            route = router.get("https://example.com/down").mock(
+                return_value=httpx.Response(500)
+            )
+            with self.assertRaises(FetchAttemptsExhausted) as context:
+                await fetch_url(
+                    "https://example.com/down",
+                    fetch_policy=policy,
+                )
+
+        self.assertEqual(route.call_count, 3)
+        self.assertEqual(context.exception.attempts, 3)
+        self.assertIsInstance(
+            context.exception.last_error,
+            httpx.HTTPStatusError,
+        )
+
+    async def test_non_retryable_status_is_one_shot(self):
+        with respx.mock(assert_all_called=True) as router:
+            route = router.get("https://example.com/not-found").mock(
+                return_value=httpx.Response(404)
+            )
+            with self.assertRaises(httpx.HTTPStatusError):
+                await fetch_url(
+                    "https://example.com/not-found",
+                    fetch_policy=FetchPolicy(),
+                )
+
+        self.assertEqual(route.call_count, 1)
+
+    async def test_shared_fetcher_spaces_same_host_requests(self):
+        policy = FetchPolicy(
+            max_attempts=1,
+            jitter_seconds=0.0,
+            min_interval_seconds=0.5,
+        )
+        with (
+            respx.mock(assert_all_called=True) as router,
+            patch(
+                "quantmind.preprocess.fetch.http.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as sleep,
+        ):
+            router.get(url__regex=r"https://example\.com/.*").mock(
+                return_value=httpx.Response(200)
+            )
+            async with HttpFetcher(policy=policy) as fetcher:
+                await fetcher.fetch_url("https://example.com/one")
+                await fetcher.fetch_url("https://example.com/two")
+
+        self.assertEqual(sleep.await_count, 1)
+        self.assertGreater(sleep.await_args.args[0], 0.4)
+
+    async def test_shared_fetcher_caps_same_host_concurrency(self):
+        in_flight = 0
+        peak = 0
+
+        async def respond(request: httpx.Request) -> httpx.Response:
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return httpx.Response(200, request=request)
+
+        policy = FetchPolicy(
+            max_attempts=1,
+            max_concurrency_per_host=1,
+        )
+        with respx.mock(assert_all_called=True) as router:
+            router.get(url__regex=r"https://example\.com/.*").mock(
+                side_effect=respond
+            )
+            async with HttpFetcher(policy=policy) as fetcher:
+                await asyncio.gather(
+                    fetcher.fetch_url("https://example.com/one"),
+                    fetcher.fetch_url("https://example.com/two"),
+                )
+
+        self.assertEqual(peak, 1)
+
+
+class FetchPolicyValidationTests(unittest.TestCase):
+    def test_rejects_invalid_attempt_count(self):
+        with self.assertRaises(ValueError):
+            FetchPolicy(max_attempts=0)

--- a/tests/preprocess/fetch/test_rss.py
+++ b/tests/preprocess/fetch/test_rss.py
@@ -1,0 +1,98 @@
+"""Tests for preprocess.fetch.rss — RSS/Atom feed parsing."""
+
+import unittest
+from datetime import timezone
+
+import httpx
+import respx
+
+from quantmind.preprocess.fetch.rss import fetch_rss_feed, parse_feed
+
+_RSS = b"""\
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Press releases</title>
+    <item>
+      <title>NVIDIA Announces Results</title>
+      <link>https://example.com/pr/nvidia-results?utm_source=x</link>
+      <guid>gnw-123</guid>
+      <pubDate>Mon, 15 Apr 2024 10:30:00 GMT</pubDate>
+      <description><![CDATA[<p>Short summary</p>]]></description>
+      <content:encoded><![CDATA[<article><p>Full release body</p></article>]]></content:encoded>
+    </item>
+  </channel>
+</rss>
+"""
+
+_ATOM = b"""\
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom press releases</title>
+  <entry>
+    <title>Microsoft Announces Cloud Update</title>
+    <id>tag:example.com,2024:msft-cloud</id>
+    <updated>2024-04-15T10:30:00Z</updated>
+    <link rel="alternate" href="https://example.com/pr/msft-cloud" />
+    <summary type="html">&lt;p&gt;Cloud update summary&lt;/p&gt;</summary>
+  </entry>
+</feed>
+"""
+
+
+class ParseFeedTests(unittest.TestCase):
+    def test_parse_rss_item_metadata(self):
+        feed = parse_feed(
+            _RSS,
+            feed_url="https://example.com/rss",
+            content_type="application/rss+xml",
+            headers={"etag": "abc"},
+        )
+
+        self.assertEqual(feed.title, "Press releases")
+        self.assertEqual(feed.feed_url, "https://example.com/rss")
+        self.assertEqual(feed.content_type, "application/rss+xml")
+        self.assertEqual(feed.headers["etag"], "abc")
+        self.assertEqual(len(feed.items), 1)
+        item = feed.items[0]
+        self.assertEqual(item.title, "NVIDIA Announces Results")
+        self.assertEqual(item.id, "gnw-123")
+        self.assertEqual(
+            item.url, "https://example.com/pr/nvidia-results?utm_source=x"
+        )
+        self.assertEqual(item.published_at.tzinfo, timezone.utc)
+        self.assertEqual(item.published_at.hour, 10)
+        self.assertIn("Full release body", item.content_html or "")
+
+    def test_parse_atom_entry_metadata(self):
+        feed = parse_feed(_ATOM, feed_url="https://example.com/atom")
+
+        self.assertEqual(feed.title, "Atom press releases")
+        self.assertEqual(len(feed.items), 1)
+        item = feed.items[0]
+        self.assertEqual(item.title, "Microsoft Announces Cloud Update")
+        self.assertEqual(item.id, "tag:example.com,2024:msft-cloud")
+        self.assertEqual(item.url, "https://example.com/pr/msft-cloud")
+        self.assertEqual(item.published_at.tzinfo, timezone.utc)
+
+    def test_unsupported_root_raises(self):
+        with self.assertRaises(ValueError):
+            parse_feed(b"<html></html>")
+
+
+class FetchRssFeedTests(unittest.IsolatedAsyncioTestCase):
+    async def test_fetches_and_parses_feed(self):
+        with respx.mock(assert_all_called=True) as router:
+            router.get("https://example.com/rss").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "application/rss+xml"},
+                    content=_RSS,
+                )
+            )
+            feed = await fetch_rss_feed("https://example.com/rss")
+
+        self.assertEqual(feed.title, "Press releases")
+        self.assertEqual(len(feed.items), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/preprocess/fixtures/wire/pr_news_wire.xml
+++ b/tests/preprocess/fixtures/wire/pr_news_wire.xml
@@ -1,0 +1,12 @@
+<rss version="2.0">
+  <channel>
+    <title>Sanitized PR Newswire feed</title>
+    <item>
+      <title>Example Energy Shares an Operations Update</title>
+      <link>https://example.test/prn/releases/operations-update</link>
+      <guid>prn-example-001</guid>
+      <pubDate>Wed, 17 Apr 2024 12:00:00 GMT</pubDate>
+      <description><![CDATA[<p>Example Energy shared a short operations teaser.</p>]]></description>
+    </item>
+  </channel>
+</rss>

--- a/tests/preprocess/fixtures/wire/pr_news_wire_article.html
+++ b/tests/preprocess/fixtures/wire/pr_news_wire_article.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <article>
+      <h1>Example Energy Shares an Operations Update</h1>
+      <p>Example Energy (NYSE: EXEN) supplied fictional operating details for a sanitized provider fixture.</p>
+      <p>This full article is the source of the cleaned markdown body.</p>
+    </article>
+  </body>
+</html>

--- a/tests/preprocess/test_news.py
+++ b/tests/preprocess/test_news.py
@@ -1,0 +1,288 @@
+"""Tests for preprocess.news — PR/wire candidate normalisation."""
+
+import hashlib
+import unittest
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import respx
+
+from quantmind.preprocess.fetch.rss import FeedItem
+from quantmind.preprocess.news import (
+    RawNewsDocument,
+    build_news_dedup_key,
+    build_sec_news_dedup_key,
+    canonicalize_source_url,
+    extract_exchange_ticker_hints,
+    feed_item_to_news_document,
+    fetch_news_document,
+    news_content_hash,
+    normalize_news_text,
+    preprocess_feed_item,
+    preprocess_news_document,
+)
+from quantmind.preprocess.time import parse_news_datetime
+
+
+class NewsTimeTests(unittest.TestCase):
+    def test_parse_rfc822_news_datetime(self):
+        result = parse_news_datetime("Mon, 15 Apr 2024 10:30:00 GMT")
+
+        self.assertEqual(result.tzinfo, timezone.utc)
+        self.assertEqual(result.year, 2024)
+        self.assertEqual(result.hour, 10)
+
+    def test_parse_news_datetime_with_offset(self):
+        result = parse_news_datetime("Mon, 15 Apr 2024 10:30:00 -0400")
+
+        self.assertEqual(result.tzinfo, timezone.utc)
+        self.assertEqual(result.hour, 14)
+
+
+class NewsPreprocessTests(unittest.TestCase):
+    def test_normalize_news_text_and_hash(self):
+        text = (
+            "NVIDIA\u2014reported   revenue\n\n\nNVIDIA\u2014reported   revenue"
+        )
+        normalized = normalize_news_text(text)
+
+        self.assertEqual(
+            normalized,
+            "NVIDIA-reported revenue\n\nNVIDIA-reported revenue",
+        )
+        self.assertEqual(
+            news_content_hash(normalized),
+            hashlib.sha256(normalized.encode("utf-8")).hexdigest(),
+        )
+
+    def test_normalize_news_text_stabilizes_email_protection_links(self):
+        text_a = (
+            "Contact [[email protected]](/cdn-cgi/l/email-protection#abc123)"
+        )
+        text_b = (
+            "Contact [[email protected]](/cdn-cgi/l/email-protection#def456)"
+        )
+
+        self.assertEqual(
+            normalize_news_text(text_a), normalize_news_text(text_b)
+        )
+
+    def test_canonicalize_source_url_drops_tracking(self):
+        result = canonicalize_source_url(
+            "HTTPS://Example.COM/path/?b=2&utm_source=x&a=1#frag"
+        )
+
+        self.assertEqual(result, "https://example.com/path?a=1&b=2")
+
+    def test_exchange_ticker_hints_are_deduped(self):
+        hints = extract_exchange_ticker_hints(
+            "NVIDIA Corporation (NASDAQ: NVDA) and IBM NYSE: IBM. "
+            "Again (NASDAQ: NVDA)."
+        )
+
+        self.assertEqual([h.symbol for h in hints], ["NVDA", "IBM"])
+        self.assertEqual(hints[0].exchange, "NASDAQ")
+        self.assertEqual(hints[1].exchange, "NYSE")
+
+    def test_build_sec_news_dedup_key(self):
+        self.assertEqual(
+            build_sec_news_dedup_key(
+                accession_number="0001045810-26-000123",
+                section_key="EX99.1",
+            ),
+            "sec:0001045810-26-000123:ex99.1",
+        )
+
+    def test_build_news_dedup_key_requires_identity(self):
+        with self.assertRaises(ValueError):
+            build_news_dedup_key(source_type="press_release")
+
+    def test_preprocess_news_document_builds_candidate_contract(self):
+        published = datetime(
+            2024, 4, 15, 10, 30, tzinfo=timezone(timedelta(hours=-4))
+        )
+        raw = RawNewsDocument(
+            body_text=(
+                "NVIDIA Corporation (NASDAQ: NVDA) today reported "
+                "record quarterly revenue."
+            ),
+            source_url="https://example.com/pr/nvidia-results?utm_source=feed",
+            title="NVIDIA Announces Results",
+            publisher="PR Newswire",
+            published_at=published,
+            payload_id="gnw-123",
+        )
+
+        candidate = preprocess_news_document(raw)
+
+        self.assertEqual(candidate.source_type, "press_release")
+        self.assertTrue(candidate.dedup_key.startswith("wire:"))
+        self.assertEqual(
+            candidate.source_url, "https://example.com/pr/nvidia-results"
+        )
+        self.assertEqual(candidate.published_at.tzinfo, timezone.utc)
+        self.assertEqual(candidate.published_at.hour, 14)
+        self.assertEqual(candidate.ticker_hints[0].symbol, "NVDA")
+        self.assertEqual(
+            candidate.content_hash,
+            hashlib.sha256(candidate.body_text.encode("utf-8")).hexdigest(),
+        )
+
+    def test_preprocess_news_document_rejects_empty_body(self):
+        raw = RawNewsDocument(
+            body_text="  ",
+            source_url="https://example.com/pr/empty",
+        )
+
+        with self.assertRaises(ValueError):
+            preprocess_news_document(raw)
+
+
+class NewsFeedItemTests(unittest.IsolatedAsyncioTestCase):
+    async def test_feed_item_to_news_document_uses_inline_content(self):
+        item = FeedItem(
+            title="NVIDIA Announces Results",
+            url="https://example.com/pr/nvidia-results",
+            id="gnw-123",
+            published_at=datetime(2024, 4, 15, tzinfo=timezone.utc),
+            content_html=(
+                "<html><body><article><p>NVIDIA Corporation "
+                "(NASDAQ: NVDA) reported results.</p></article></body></html>"
+            ),
+            source_feed_url="https://example.com/rss",
+        )
+
+        raw = await feed_item_to_news_document(item, publisher="PR Newswire")
+
+        self.assertEqual(raw.payload_id, "gnw-123")
+        self.assertEqual(raw.publisher, "PR Newswire")
+        self.assertIn("NVIDIA", raw.body_text)
+        self.assertEqual(
+            raw.metadata["source_feed_url"], "https://example.com/rss"
+        )
+        self.assertEqual(raw.metadata["body_source"], "feed")
+
+    async def test_article_source_fetches_despite_nonempty_teaser(self):
+        item = FeedItem(
+            title="NVIDIA Announces Results",
+            url="https://example.com/pr/nvidia-results",
+            id="wire-123",
+            summary_html="<p>This non-empty teaser is not the full body.</p>",
+            source_feed_url="https://example.com/rss",
+        )
+        html = """
+        <html><body><article>
+          <h1>NVIDIA Announces Results</h1>
+          <p>The complete release contains full financial details.</p>
+        </article></body></html>
+        """
+        with respx.mock(assert_all_called=True) as router:
+            router.get(item.url).mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "text/html"},
+                    text=html,
+                )
+            )
+            raw = await feed_item_to_news_document(
+                item,
+                body_source="article",
+            )
+
+        self.assertIn("complete release", raw.body_text)
+        self.assertNotIn("non-empty teaser", raw.body_text)
+        self.assertEqual(raw.metadata["body_source"], "article")
+
+    async def test_feed_source_does_not_fetch_item_url(self):
+        item = FeedItem(
+            title="NVIDIA Announces Results",
+            url="https://example.com/pr/nvidia-results",
+            summary_html="<p>Feed body stays local.</p>",
+        )
+
+        with respx.mock(assert_all_called=True):
+            raw = await feed_item_to_news_document(
+                item,
+                body_source="feed",
+            )
+
+        self.assertIn("Feed body", raw.body_text)
+
+    async def test_article_source_requires_item_url(self):
+        item = FeedItem(title="Missing URL", summary_html="A teaser")
+
+        with self.assertRaisesRegex(ValueError, "requires an item URL"):
+            await feed_item_to_news_document(
+                item,
+                body_source="article",
+            )
+
+    async def test_article_extraction_failure_is_explicit(self):
+        item = FeedItem(
+            title="Unsupported body",
+            url="https://example.com/release.pdf",
+            summary_html="A teaser",
+        )
+        with respx.mock(assert_all_called=True) as router:
+            router.get(item.url).mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "application/pdf"},
+                    content=b"not html",
+                )
+            )
+            with self.assertRaisesRegex(ValueError, "Unsupported"):
+                await feed_item_to_news_document(
+                    item,
+                    body_source="article",
+                )
+
+    async def test_preprocess_feed_item_returns_candidate(self):
+        item = FeedItem(
+            title="NVIDIA Announces Results",
+            url="https://example.com/pr/nvidia-results",
+            id="gnw-123",
+            summary_html="<p>NVIDIA Corporation (NASDAQ: NVDA) reported results.</p>",
+        )
+
+        candidate = await preprocess_feed_item(item, publisher="PR Newswire")
+
+        self.assertEqual(candidate.publisher, "PR Newswire")
+        self.assertEqual(candidate.ticker_hints[0].symbol, "NVDA")
+
+
+class FetchNewsDocumentTests(unittest.IsolatedAsyncioTestCase):
+    async def test_fetch_news_document_extracts_html(self):
+        html = """
+        <html>
+          <body>
+            <article>
+              <h1>NVIDIA Announces Results</h1>
+              <p>NVIDIA Corporation (NASDAQ: NVDA) reported record revenue.</p>
+            </article>
+          </body>
+        </html>
+        """
+        with respx.mock(assert_all_called=True) as router:
+            router.get("https://example.com/pr/nvidia-results").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "text/html; charset=utf-8"},
+                    content=html.encode(),
+                )
+            )
+            raw = await fetch_news_document(
+                "https://example.com/pr/nvidia-results",
+                title="NVIDIA Announces Results",
+                payload_id="gnw-123",
+            )
+
+        self.assertEqual(
+            raw.source_url, "https://example.com/pr/nvidia-results"
+        )
+        self.assertEqual(raw.metadata["content_type"], "text/html")
+        self.assertIn("record revenue", raw.body_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/preprocess/test_wire.py
+++ b/tests/preprocess/test_wire.py
@@ -1,0 +1,276 @@
+"""Tests for provider-pluggable wire ingestion."""
+
+import unittest
+from pathlib import Path
+
+import httpx
+import respx
+
+from quantmind.preprocess.fetch.http import FetchPolicy
+from quantmind.preprocess.wire import (
+    PR_NEWSWIRE,
+    WireFeedConfig,
+    WireItemMapping,
+    build_wire_identity,
+    fetch_wire_documents,
+)
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "wire"
+
+
+def _fixture(name: str) -> bytes:
+    return (_FIXTURES / name).read_bytes()
+
+
+class _FeedBodyProvider:
+    name = "full-content-test-wire"
+    publisher = "Full Content Test Wire"
+    body_source = "feed"
+
+    def map_item(self, item):
+        return WireItemMapping(
+            payload_id=item.id,
+            canonical_url=item.url,
+            title=item.title,
+            published_at=item.published_at,
+        )
+
+
+class WireProviderConfigTests(unittest.TestCase):
+    def test_builtin_body_sources_are_explicit(self):
+        self.assertEqual(PR_NEWSWIRE.body_source, "article")
+
+    def test_config_requires_a_feed_url(self):
+        with self.assertRaises(ValueError):
+            WireFeedConfig(provider=PR_NEWSWIRE, feed_urls=())
+
+    def test_identity_uses_all_available_components(self):
+        base = build_wire_identity(
+            provider="provider-a",
+            payload_id="item-1",
+            canonical_url="https://example.test/release",
+        )
+
+        self.assertNotEqual(
+            base,
+            build_wire_identity(
+                provider="provider-b",
+                payload_id="item-1",
+                canonical_url="https://example.test/release",
+            ),
+        )
+        self.assertNotEqual(
+            base,
+            build_wire_identity(
+                provider="provider-a",
+                payload_id="item-2",
+                canonical_url="https://example.test/release",
+            ),
+        )
+        self.assertNotEqual(
+            base,
+            build_wire_identity(
+                provider="provider-a",
+                payload_id="item-1",
+                canonical_url="https://example.test/other",
+            ),
+        )
+
+
+class FetchWireDocumentsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_feed_body_mode_remains_available_for_custom_provider(self):
+        feed_url = "https://example.test/custom/rss"
+        feed = b"""
+        <rss><channel><item>
+          <title>Example quarterly results</title>
+          <link>https://example.test/releases/results</link>
+          <guid>custom-example-001</guid>
+          <description><![CDATA[
+            <p>Example Corp reported fictional quarterly revenue.</p>
+            <p>NASDAQ: EXMPL</p>
+          ]]></description>
+        </item></channel></rss>
+        """
+        with respx.mock(assert_all_called=True) as router:
+            router.get(feed_url).mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "application/rss+xml"},
+                    content=feed,
+                )
+            )
+            result = await fetch_wire_documents(
+                WireFeedConfig(
+                    provider=_FeedBodyProvider(),
+                    feed_urls=(feed_url,),
+                )
+            )
+
+        self.assertEqual(result.success_count, 1)
+        self.assertEqual(result.failure_count, 0)
+        document = result.documents[0]
+        self.assertIn("fictional quarterly revenue", document.cleaned_markdown)
+        self.assertIsNone(document.raw_article)
+        self.assertIn(b"custom-example-001", document.raw_feed_entry.bytes)
+        self.assertEqual(document.raw_feed_entry.status_code, 200)
+        self.assertIsNotNone(document.raw_feed_entry.fetched_at)
+        self.assertEqual(document.ticker_hints[0].symbol, "EXMPL")
+
+    async def test_pr_newswire_returns_both_raw_artifacts(self):
+        feed_url = "https://example.test/prn/rss"
+        article_url = "https://example.test/prn/releases/operations-update"
+        article = _fixture("pr_news_wire_article.html")
+        with respx.mock(assert_all_called=True) as router:
+            router.get(feed_url).mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "application/rss+xml"},
+                    content=_fixture("pr_news_wire.xml"),
+                )
+            )
+            router.get(article_url).mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "text/html"},
+                    content=article,
+                )
+            )
+            result = await fetch_wire_documents(
+                WireFeedConfig(
+                    provider=PR_NEWSWIRE,
+                    feed_urls=(feed_url,),
+                )
+            )
+
+        self.assertEqual(result.success_count, 1)
+        self.assertEqual(result.failure_count, 0)
+        document = result.documents[0]
+        self.assertIn("full article", document.cleaned_markdown)
+        self.assertIsNotNone(document.raw_article)
+        assert document.raw_article is not None
+        self.assertEqual(document.raw_article.bytes, article)
+        self.assertTrue(document.raw_feed_entry.bytes)
+
+    async def test_duplicate_identity_is_processed_once(self):
+        feed_url = "https://example.test/duplicate/rss"
+        item = """
+        <item>
+          <title>Duplicate release</title>
+          <link>https://example.test/releases/duplicate</link>
+          <guid>duplicate-1</guid>
+          <description><![CDATA[<p>A complete duplicate body.</p>]]></description>
+        </item>
+        """
+        feed = f"<rss><channel>{item}{item}</channel></rss>".encode()
+        with respx.mock(assert_all_called=True) as router:
+            router.get(feed_url).mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "application/rss+xml"},
+                    content=feed,
+                )
+            )
+            result = await fetch_wire_documents(
+                WireFeedConfig(
+                    provider=_FeedBodyProvider(),
+                    feed_urls=(feed_url,),
+                )
+            )
+
+        self.assertEqual(result.success_count, 1)
+        self.assertEqual(result.failure_count, 0)
+
+    async def test_extraction_failure_is_recorded_and_batch_continues(self):
+        feed_url = "https://example.test/partial/rss"
+        bad_url = "https://example.test/releases/bad"
+        good_url = "https://example.test/releases/good"
+        feed = f"""
+        <rss><channel>
+          <item>
+            <title>Bad release</title><link>{bad_url}</link>
+            <guid>bad-1</guid><description>Short teaser</description>
+          </item>
+          <item>
+            <title>Good release</title><link>{good_url}</link>
+            <guid>good-1</guid><description>Short teaser</description>
+          </item>
+        </channel></rss>
+        """.encode()
+        good_article = b"""
+        <html><body><article>
+          <h1>Good release</h1><p>The complete good article body.</p>
+        </article></body></html>
+        """
+        with respx.mock(assert_all_called=True) as router:
+            router.get(feed_url).mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "application/rss+xml"},
+                    content=feed,
+                )
+            )
+            router.get(bad_url).mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "application/pdf"},
+                    content=b"not html",
+                )
+            )
+            router.get(good_url).mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "text/html"},
+                    content=good_article,
+                )
+            )
+            result = await fetch_wire_documents(
+                WireFeedConfig(
+                    provider=PR_NEWSWIRE,
+                    feed_urls=(feed_url,),
+                    fetch_policy=FetchPolicy(max_attempts=1),
+                )
+            )
+
+        self.assertEqual(result.success_count, 1)
+        self.assertEqual(result.failure_count, 1)
+        self.assertEqual(result.documents[0].payload_id, "good-1")
+        failure = result.failures[0]
+        self.assertEqual(failure.item_id, "bad-1")
+        self.assertEqual(failure.stage, "article_parse")
+        self.assertEqual(failure.error_type, "invalid_content")
+
+    async def test_feed_failure_does_not_discard_other_feed(self):
+        bad_feed = "https://example.test/feed/bad"
+        good_feed = "https://example.test/feed/good"
+        with respx.mock(assert_all_called=True) as router:
+            router.get(bad_feed).mock(return_value=httpx.Response(404))
+            router.get(good_feed).mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"Content-Type": "application/rss+xml"},
+                    content=b"""
+                    <rss><channel><item>
+                      <title>Good feed item</title>
+                      <link>https://example.test/releases/good-feed</link>
+                      <guid>good-feed-1</guid>
+                      <description>A complete feed body.</description>
+                    </item></channel></rss>
+                    """,
+                )
+            )
+            result = await fetch_wire_documents(
+                WireFeedConfig(
+                    provider=_FeedBodyProvider(),
+                    feed_urls=(bad_feed, good_feed),
+                    fetch_policy=FetchPolicy(max_attempts=1),
+                )
+            )
+
+        self.assertEqual(result.success_count, 1)
+        self.assertEqual(result.failure_count, 1)
+        self.assertEqual(result.failures[0].stage, "feed_fetch")
+        self.assertEqual(result.failures[0].error_type, "http_status")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds a provider-pluggable public wire ingestion pipeline with PR Newswire as the only built-in MVP provider.

- adds explicit `body_source="feed" | "article"` acquisition so a non-empty RSS teaser no longer suppresses a required article fetch
- adds reusable opt-in HTTP retry/backoff, `Retry-After` handling, and shared per-host concurrency/spacing
- adds `fetch_wire_documents` with replayable raw feed/article evidence, cleaned Markdown, stable identity, and lightweight non-fatal failure records
- adds sanitized PR Newswire fixtures, offline unit tests, focused runnable examples, an English News Pipeline guide under `docs/`, and a live component smoke checklist
- leaves GlobeNewswire, Business Wire, persistent polling, and generic batch hooks/monitoring outside this MVP

The root cause of #96 was an implicit emptiness heuristic: any non-empty feed description was treated as the complete body. Provider configuration now selects the acquisition source explicitly.

Closes #96
Closes #97
Closes #98

## Verification

### Unit and repository checks

- `bash scripts/verify.sh`
  - 270 tests passed
  - 88.08% coverage
  - ruff format/check passed
  - basedpyright passed
  - import contracts passed
- `python -m pytest --no-cov tests/preprocess`
  - 123 tests passed

### Live smoke

- `python scripts/smoke_wire.py`
  - 20 PR Newswire documents
  - 0 failures
  - PASS: documents
  - PASS: raw feed entry
  - PASS: raw article
  - PASS: cleaned Markdown
  - PASS: unique identity

## Checklist

- [x] The PR title uses Conventional Commit format.
- [x] Related issues are referred to in this PR.
- [x] The Markdown is rendered correctly.
- [x] The code is documented.
- [x] The PR is focused on the PR Newswire ingestion MVP and its direct dependencies.
