### PR TITLE
docs(contexts): establish repository context framework

### DIFF
--- a/.agents/skills/quantmind-dev/SKILL.md
+++ b/.agents/skills/quantmind-dev/SKILL.md
@@ -9,11 +9,13 @@ Development workflow for contributing to the QuantMind codebase.
 
 ## Start Here
 
-1. Read the repository root `AGENTS.md` or `CLAUDE.md` for the stable
+1. Use the repository [`contexts/README.md`](../../../contexts/README.md) to
+   select the development context for this contribution.
+2. Read the repository root `AGENTS.md` or `CLAUDE.md` for the stable
    architecture constraints and the module map.
-2. Read `docs/README.md` when the task adds, changes, or uses a public
+3. Read `docs/README.md` when the task adds, changes, or uses a public
    operation or public-network source.
-3. Pick exactly one workflow reference below; do not load the others.
+4. Pick exactly one workflow reference below; do not load the others.
 
 ## Select Workflow
 

--- a/.claude/skills/quantmind-dev/SKILL.md
+++ b/.claude/skills/quantmind-dev/SKILL.md
@@ -9,11 +9,13 @@ Development workflow for contributing to the QuantMind codebase.
 
 ## Start Here
 
-1. Read the repository root `AGENTS.md` or `CLAUDE.md` for the stable
+1. Use the repository [`contexts/README.md`](../../../contexts/README.md) to
+   select the development context for this contribution.
+2. Read the repository root `AGENTS.md` or `CLAUDE.md` for the stable
    architecture constraints and the module map.
-2. Read `docs/README.md` when the task adds, changes, or uses a public
+3. Read `docs/README.md` when the task adds, changes, or uses a public
    operation or public-network source.
-3. Pick exactly one workflow reference below; do not load the others.
+4. Pick exactly one workflow reference below; do not load the others.
 
 ## Select Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,9 @@
 Guidance for coding agents contributing to this repository. Keep this file
 aligned with `CLAUDE.md` (same core rules); update both in the same change.
 
+Use [`contexts/README.md`](contexts/README.md) as the repository information
+entry point for either development or library-usage work.
+
 ## What This Is
 
 QuantMind is a knowledge extraction and retrieval library for quantitative

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working in
 this repository. Keep this file aligned with `AGENTS.md` (same core rules);
 update both in the same change.
 
+Use [`contexts/README.md`](contexts/README.md) as the repository information
+entry point for either development or library-usage work.
+
 ## What This Is
 
 QuantMind is a knowledge extraction and retrieval library for quantitative

--- a/contexts/README.md
+++ b/contexts/README.md
@@ -1,0 +1,22 @@
+# QuantMind Repository Context
+
+This directory is the public repository routing layer for coding agents. Start
+with the index that matches the work you are doing:
+
+- [Develop QuantMind](dev/README.md) for architecture, contribution, testing,
+  and verification guidance.
+- [Use QuantMind](usage/README.md) for public operations, examples, and usage
+  documentation.
+
+## Source of Truth and Ownership
+
+- Context pages curate links and route readers; they do not copy full guidance.
+- Code, public contracts, design documents, `AGENTS.md` / `CLAUDE.md`, and
+  workflow skills remain canonical for their stated domains.
+- Update a component's context index only when its discoverable entry points
+  change, not for every implementation change.
+- Repository maintainers own this shared structure. Component contributors own
+  the links for the components they change.
+
+Keep this layer limited to public repository information. Private,
+deployment-specific, and internal-only guidance does not belong here.

--- a/contexts/dev/README.md
+++ b/contexts/dev/README.md
@@ -1,0 +1,18 @@
+# Develop QuantMind
+
+Use this index when extending or maintaining the repository. Follow the linked
+canonical source instead of treating this page as a replacement for it.
+
+| Need | Canonical source |
+|---|---|
+| Architecture constraints and module ownership | [`AGENTS.md`](../../AGENTS.md) or [`CLAUDE.md`](../../CLAUDE.md) |
+| Component-development workflow | [`quantmind-dev` component workflow](../../.agents/skills/quantmind-dev/references/develop-components.md) |
+| Public operation and source catalog | [`docs/README.md`](../../docs/README.md) |
+| Public operation naming | [Operation naming contract](../../docs/design/en/operations.md) |
+| Component designs | [`docs/design/`](../../docs/design/) |
+| Test patterns and coverage | [`tests/`](../../tests/) |
+| Focused runnable examples | [`examples/`](../../examples/) |
+| Deterministic verification | [`scripts/verify.sh`](../../scripts/verify.sh) |
+
+Run `bash scripts/verify.sh` for every change. For a public-network component,
+also run the bounded live verifier listed in the public component catalog.

--- a/contexts/usage/README.md
+++ b/contexts/usage/README.md
@@ -1,0 +1,17 @@
+# Use QuantMind
+
+Use this index when calling QuantMind as a library. These links point to the
+current public API, focused examples, and component-specific guidance.
+
+| Need | Canonical source |
+|---|---|
+| Current operations, inputs, results, and sources | [Public component catalog](../../docs/README.md) |
+| Installation and common usage | [Root README usage](../../README.md#-usage-examples) |
+| Paper extraction | [Paper guide](../../docs/papers.md) |
+| News collection | [News design and behavior](../../docs/design/en/news.md) |
+| Runnable operation examples | [`examples/flows/`](../../examples/flows/) |
+| Focused preprocessing examples | [`examples/preprocess/`](../../examples/preprocess/) |
+
+Import public inputs and configs from `quantmind.configs`, public operations
+from `quantmind.flows`, and result contracts from the owning layer identified
+by the component catalog.

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -1,0 +1,56 @@
+import re
+import unittest
+from pathlib import Path
+
+
+class TestContextEntryPoints(unittest.TestCase):
+    def test_context_index_targets_exist(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        context_indexes = (
+            "contexts/README.md",
+            "contexts/dev/README.md",
+            "contexts/usage/README.md",
+        )
+        markdown_link = re.compile(r"\[[^]]+]\(([^)]+)\)")
+
+        for index_path in context_indexes:
+            with self.subTest(index=index_path):
+                index = repo_root / index_path
+                self.assertTrue(
+                    index.is_file(), f"missing context index: {index_path}"
+                )
+
+            for target in markdown_link.findall(
+                index.read_text(encoding="utf-8")
+            ):
+                path = target.split("#", maxsplit=1)[0]
+                if not path or path.startswith(("http://", "https://")):
+                    continue
+                resolved = (index.parent / path).resolve()
+                with self.subTest(index=index_path, target=target):
+                    self.assertTrue(
+                        resolved.exists(),
+                        f"missing context target from {index_path}: {target}",
+                    )
+
+    def test_required_files_link_to_context_entry_point(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        required_links = {
+            "AGENTS.md": "contexts/README.md",
+            "CLAUDE.md": "contexts/README.md",
+            ".agents/skills/quantmind-dev/SKILL.md": "../../../contexts/README.md",
+            ".claude/skills/quantmind-dev/SKILL.md": "../../../contexts/README.md",
+        }
+
+        for source_path, target in required_links.items():
+            source = repo_root / source_path
+            with self.subTest(source=source_path):
+                self.assertIn(
+                    f"]({target})",
+                    source.read_text(encoding="utf-8"),
+                    f"{source_path} must link to contexts/README.md",
+                )
+                self.assertTrue(
+                    (source.parent / target).resolve().is_file(),
+                    f"broken context entry link from {source_path}: {target}",
+                )


### PR DESCRIPTION
## Summary

- add separate development and library-usage context indexes
- define source-of-truth and ownership rules for the routing layer
- link the context entry point from both agent guides and mirrored `quantmind-dev` skills
- add a focused deterministic test for context targets and required entry links

## Related Issue

Closes #101

## Verification

- `PATH=/Users/wenkeli/work/LLMQuant/quant-mind/.venv/bin:$PATH pytest -q --no-cov tests/test_contexts.py` (2 passed, 24 subtests)
- `PATH=/Users/wenkeli/work/LLMQuant/quant-mind/.venv/bin:$PATH pre-commit run --all-files`
- `PATH=/Users/wenkeli/work/LLMQuant/quant-mind/.venv/bin:$PATH bash scripts/verify.sh` (284 passed, 88.42% coverage)
- `cmp -s .agents/skills/quantmind-dev/SKILL.md .claude/skills/quantmind-dev/SKILL.md`

No live component gate applies because this change does not modify a public-network integration.

## Checklist

- [x] The title uses English Conventional Commit format: `type(scope): summary`.
- [x] The related issue or design discussion is linked when applicable.
- [x] `bash scripts/verify.sh` passes.
- [x] Every applicable live component gate passes, or this PR states why none applies.
- [x] Public behavior has focused tests, an example, and documentation where applicable.
- [x] The PR is complete, small, and contains no unrelated changes.