### PR TITLE
docs(contexts): define repository label taxonomy

### DIFF
--- a/.agents/skills/quantmind-dev/SKILL.md
+++ b/.agents/skills/quantmind-dev/SKILL.md
@@ -15,7 +15,9 @@ Development workflow for contributing to the QuantMind codebase.
    architecture constraints and the module map.
 3. Read `docs/README.md` when the task adds, changes, or uses a public
    operation or public-network source.
-4. Pick exactly one workflow reference below; do not load the others.
+4. When creating, updating, or triaging an issue or pull request, use the
+   canonical [repository label guidance](../../../contexts/dev/labels.md).
+5. Pick exactly one workflow reference below; do not load the others.
 
 ## Select Workflow
 

--- a/.claude/skills/quantmind-dev/SKILL.md
+++ b/.claude/skills/quantmind-dev/SKILL.md
@@ -15,7 +15,9 @@ Development workflow for contributing to the QuantMind codebase.
    architecture constraints and the module map.
 3. Read `docs/README.md` when the task adds, changes, or uses a public
    operation or public-network source.
-4. Pick exactly one workflow reference below; do not load the others.
+4. When creating, updating, or triaging an issue or pull request, use the
+   canonical [repository label guidance](../../../contexts/dev/labels.md).
+5. Pick exactly one workflow reference below; do not load the others.
 
 ## Select Workflow
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: 🐛 Bug Report
 about: Report a bug to help us improve QuantMind
 title: 'bug: [brief description of the bug]'
-labels: ['bug', 'needs-triage']
+labels: ['type: bug']
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: ✨ Feature Request
 about: Suggest a new feature or enhancement for QuantMind
 title: 'feat: [brief description of the feature]'
-labels: ['enhancement', 'needs-triage']
+labels: ['type: feature']
 assignees: ''
 ---
 

--- a/contexts/dev/README.md
+++ b/contexts/dev/README.md
@@ -7,6 +7,7 @@ canonical source instead of treating this page as a replacement for it.
 |---|---|
 | Architecture constraints and module ownership | [`AGENTS.md`](../../AGENTS.md) or [`CLAUDE.md`](../../CLAUDE.md) |
 | Component-development workflow | [`quantmind-dev` component workflow](../../.agents/skills/quantmind-dev/references/develop-components.md) |
+| Issue and pull-request labels | [Repository label guidance](labels.md) |
 | Public operation and source catalog | [`docs/README.md`](../../docs/README.md) |
 | Public operation naming | [Operation naming contract](../../docs/design/en/operations.md) |
 | Component designs | [`docs/design/`](../../docs/design/) |

--- a/contexts/dev/labels.md
+++ b/contexts/dev/labels.md
@@ -1,0 +1,107 @@
+# Repository Label Guidance
+
+This file is the canonical decision guide for labeling QuantMind issues and
+pull requests. Labels describe three independent dimensions:
+
+- `type:` answers what kind of change is proposed or delivered.
+- `area:` answers which repository ownership surface is affected.
+- `impact:` identifies special compatibility or live-network risk.
+
+Choose labels from the work's intent and accepted scope, not only from the
+files it happens to touch.
+
+## Cardinality
+
+Every issue and pull request must have **exactly one** `type:` label.
+
+Normally choose **one** `area:` label. Use two only when the work genuinely
+spans two ownership surfaces; never use more than two.
+
+`impact:` labels are optional and additive. Resolution and community labels
+do not count toward these limits.
+
+## Type Labels
+
+| Label | Use when |
+|---|---|
+| `type: bug` | Existing behavior does not meet its contract or documented expectation. |
+| `type: feature` | The work adds a new capability or observable behavior. |
+| `type: refactor` | Existing implementation is reorganized without intentionally changing public behavior. |
+| `type: docs` | The primary deliverable is documentation, guidance, or explanatory example text. |
+| `type: maintenance` | The work performs specific repository upkeep, such as dependency, configuration, release, or housekeeping changes. |
+| `type: design` | The primary deliverable is an architecture decision, RFC, or design that precedes implementation. |
+
+`type: maintenance` is not a miscellaneous bucket. If the intended outcome is
+unclear, clarify the work before labeling it.
+
+## Area Labels
+
+| Label | Ownership surface |
+|---|---|
+| `area: contexts` | Repository information routing and discovery under `contexts/`. This does not mean all documentation. |
+| `area: harness` | Contributor and agent controls: `AGENTS.md`, `CLAUDE.md`, skills, CI, verification scripts, hooks, templates, and rulesets. |
+| `area: knowledge` | Knowledge models, schemas, serialization, and representation under `quantmind/knowledge/`. |
+| `area: configs` | Typed inputs and configuration contracts under `quantmind/configs/`. |
+| `area: preprocess` | Deterministic acquisition, parsing, cleaning, formatting, and source handling under `quantmind/preprocess/`. |
+| `area: flows` | Public operation implementations under `quantmind/flows/`. It is not a generic synonym for pipeline or orchestration. |
+| `area: mind` | Memory, tools, MCP integration, and the cognitive layer under `quantmind/mind/`. |
+| `area: utils` | The narrowly owned utilities surface under `quantmind/utils/`. |
+| `area: examples` | Examples are the primary deliverable, rather than supporting files for another area. |
+| `area: packaging` | Installation, builds, dependencies, releases, and package metadata. |
+
+Area labels describe ownership, not every touched path. For example, a news
+design-document-only change is `type: docs` + `area: preprocess`, while a
+skill-only guidance change is `type: docs` + `area: harness`.
+
+## Impact Labels
+
+| Label | Use when |
+|---|---|
+| `impact: breaking` | The accepted change can break a public API, serialized contract, or supported compatibility boundary. |
+| `impact: live-network` | The work depends on or changes real public-network behavior, external availability, or a live smoke test. |
+
+## Resolution and Community Labels
+
+Keep these standard GitHub labels when applicable: `duplicate`,
+`good first issue`, `help wanted`, `invalid`, `question`, and `wontfix`.
+They describe resolution or collaboration state and are independent of the
+type, area, and impact dimensions.
+
+## Issues and Pull Requests
+
+- Label an issue from the intended problem and accepted scope.
+- Label a pull request from its actual diff.
+- A pull request that closes an issue should normally align with the issue's
+  type and area. If implementation differs, label the pull request accurately
+  and update the issue when its accepted scope changed.
+- Re-evaluate labels when scope changes; do not preserve a stale label merely
+  because it was applied first.
+
+## Examples
+
+| Work | Labels | Reason |
+|---|---|---|
+| Context framework in [#101](https://github.com/LLMQuant/quant-mind/issues/101) | `type: feature`, `area: contexts` | It added a new routing capability. |
+| CI/E2E consolidation in [#102](https://github.com/LLMQuant/quant-mind/issues/102) | `type: refactor`, `area: harness`, `impact: live-network` | It restructures repository verification, including live smoke tests. |
+| This label-system issue and its PR | `type: docs`, `area: contexts`, `area: harness` | The canonical deliverable is context guidance routed through contributor controls. |
+| Fix `paper_flow` contract behavior | `type: bug`, `area: flows` | An existing public operation is broken. |
+| Update only the news design document | `type: docs`, `area: preprocess` | The document belongs to the news preprocessing surface, not contexts. |
+| Add a public news source | `type: feature`, `area: preprocess`, `impact: live-network` | It adds acquisition behavior backed by a real external source. |
+
+## Existing Label Migration
+
+Rename labels instead of deleting and recreating them so GitHub preserves
+history and current assignments:
+
+| Existing | Rename to |
+|---|---|
+| `bug` | `type: bug` |
+| `enhancement` | `type: feature` |
+| `documentation` | `type: docs` |
+| `refactor` | `type: refactor` |
+| `example` | `area: examples` |
+| `harness` | `area: harness` |
+
+After renaming, create the missing taxonomy labels and audit open issues and
+pull requests. Remove accidental multiple `type:` labels, choose one or two
+areas from accepted scope, and leave resolution/community labels intact.

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -9,6 +9,7 @@ class TestContextEntryPoints(unittest.TestCase):
         context_indexes = (
             "contexts/README.md",
             "contexts/dev/README.md",
+            "contexts/dev/labels.md",
             "contexts/usage/README.md",
         )
         markdown_link = re.compile(r"\[[^]]+]\(([^)]+)\)")
@@ -54,3 +55,72 @@ class TestContextEntryPoints(unittest.TestCase):
                     (source.parent / target).resolve().is_file(),
                     f"broken context entry link from {source_path}: {target}",
                 )
+
+    def test_label_guide_has_required_routes(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        required_links = {
+            "contexts/dev/README.md": "labels.md",
+            ".agents/skills/quantmind-dev/SKILL.md": (
+                "../../../contexts/dev/labels.md"
+            ),
+            ".claude/skills/quantmind-dev/SKILL.md": (
+                "../../../contexts/dev/labels.md"
+            ),
+        }
+
+        for source_path, target in required_links.items():
+            source = repo_root / source_path
+            with self.subTest(source=source_path):
+                self.assertIn(
+                    f"]({target})",
+                    source.read_text(encoding="utf-8"),
+                    f"{source_path} must route to the canonical label guide",
+                )
+                self.assertTrue(
+                    (source.parent / target).resolve().is_file(),
+                    f"broken label guide link from {source_path}: {target}",
+                )
+
+    def test_label_guide_has_complete_taxonomy(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        guide = (repo_root / "contexts/dev/labels.md").read_text(
+            encoding="utf-8"
+        )
+        expected_labels = {
+            "type": {
+                "type: bug",
+                "type: feature",
+                "type: refactor",
+                "type: docs",
+                "type: maintenance",
+                "type: design",
+            },
+            "area": {
+                "area: contexts",
+                "area: harness",
+                "area: knowledge",
+                "area: configs",
+                "area: preprocess",
+                "area: flows",
+                "area: mind",
+                "area: utils",
+                "area: examples",
+                "area: packaging",
+            },
+            "impact": {
+                "impact: breaking",
+                "impact: live-network",
+            },
+        }
+
+        for dimension, expected in expected_labels.items():
+            found = set(re.findall(rf"`({dimension}: [a-z-]+)`", guide))
+            with self.subTest(dimension=dimension):
+                self.assertEqual(found, expected)
+
+    def test_quantmind_dev_skill_mirrors_match(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        agents_skill = repo_root / ".agents/skills/quantmind-dev/SKILL.md"
+        claude_skill = repo_root / ".claude/skills/quantmind-dev/SKILL.md"
+
+        self.assertEqual(agents_skill.read_bytes(), claude_skill.read_bytes())


### PR DESCRIPTION
## Summary

- define one canonical `type:` / `area:` / `impact:` label decision guide
- route the development context index and mirrored `quantmind-dev` skills to that guide without copying rules
- update issue-template defaults from legacy labels to the new type labels
- extend deterministic context tests to lock taxonomy completeness, routing, and mirrored skill parity

## Related Issue

Closes #105

## Verification

- `PATH=/Users/wenkeli/work/LLMQuant/quant-mind/.venv/bin:$PATH pytest -q --no-cov tests/test_contexts.py` (5 passed, 32 subtests)
- `PATH=/Users/wenkeli/work/LLMQuant/quant-mind/.venv/bin:$PATH pre-commit run --all-files`
- `PATH=/Users/wenkeli/work/LLMQuant/quant-mind/.venv/bin:$PATH bash scripts/verify.sh` (287 passed, 88.42% coverage)
- `cmp -s .agents/skills/quantmind-dev/SKILL.md .claude/skills/quantmind-dev/SKILL.md`

No live component gate applies because this change does not modify a public-network integration.

## Checklist

- [x] The title uses English Conventional Commit format: `type(scope): summary`.
- [x] The related issue or design discussion is linked when applicable.
- [x] `bash scripts/verify.sh` passes.
- [x] Every applicable live component gate passes, or this PR states why none applies.
- [x] Public behavior has focused tests, an example, and documentation where applicable.
- [x] The PR is complete, small, and contains no unrelated changes.