### PR TITLE
docs(contexts): prevent hard-wrapped GitHub prose

### DIFF
--- a/.agents/skills/quantmind-dev/SKILL.md
+++ b/.agents/skills/quantmind-dev/SKILL.md
@@ -17,7 +17,10 @@ Development workflow for contributing to the QuantMind codebase.
    operation or public-network source.
 4. When creating, updating, or triaging an issue or pull request, use the
    canonical [repository label guidance](../../../contexts/dev/labels.md).
-5. Pick exactly one workflow reference below; do not load the others.
+5. Before writing or editing any GitHub body, follow the canonical
+   [GitHub writing style](../../../contexts/dev/github-writing.md), including
+   its no-hard-wrap rule.
+6. Pick exactly one workflow reference below; do not load the others.
 
 ## Select Workflow
 

--- a/.agents/skills/quantmind-dev/references/pull-request.md
+++ b/.agents/skills/quantmind-dev/references/pull-request.md
@@ -34,7 +34,10 @@ batch input`, `docs(readme): update quick start`.
 
 Written in English (external audiences read it: contributors, search
 indexers, future maintainers). Follow `.github/PULL_REQUEST_TEMPLATE.md`
-and make sure the body covers:
+and the canonical
+[GitHub writing style](../../../../contexts/dev/github-writing.md). Do not
+hard-wrap body prose at 80 columns or another fixed width. Make sure the body
+covers:
 
 1. **What changed and why** — a short summary; link the design discussion
    if one exists.

--- a/.claude/skills/quantmind-dev/SKILL.md
+++ b/.claude/skills/quantmind-dev/SKILL.md
@@ -17,7 +17,10 @@ Development workflow for contributing to the QuantMind codebase.
    operation or public-network source.
 4. When creating, updating, or triaging an issue or pull request, use the
    canonical [repository label guidance](../../../contexts/dev/labels.md).
-5. Pick exactly one workflow reference below; do not load the others.
+5. Before writing or editing any GitHub body, follow the canonical
+   [GitHub writing style](../../../contexts/dev/github-writing.md), including
+   its no-hard-wrap rule.
+6. Pick exactly one workflow reference below; do not load the others.
 
 ## Select Workflow
 

--- a/.claude/skills/quantmind-dev/references/pull-request.md
+++ b/.claude/skills/quantmind-dev/references/pull-request.md
@@ -34,7 +34,10 @@ batch input`, `docs(readme): update quick start`.
 
 Written in English (external audiences read it: contributors, search
 indexers, future maintainers). Follow `.github/PULL_REQUEST_TEMPLATE.md`
-and make sure the body covers:
+and the canonical
+[GitHub writing style](../../../../contexts/dev/github-writing.md). Do not
+hard-wrap body prose at 80 columns or another fixed width. Make sure the body
+covers:
 
 1. **What changed and why** — a short summary; link the design discussion
    if one exists.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,8 @@ labels: ['type: bug']
 assignees: ''
 ---
 
+<!-- github-prose-style: Keep each logical paragraph/list item on one physical line; do not hard-wrap at 80 columns. -->
+
 ## 🐛 Bug Description
 
 <!-- A clear and concise description of what the bug is. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,8 @@ labels: ['type: feature']
 assignees: ''
 ---
 
+<!-- github-prose-style: Keep each logical paragraph/list item on one physical line; do not hard-wrap at 80 columns. -->
+
 ## ✨ Feature Summary
 
 <!-- A clear and concise description of the feature you'd like to see implemented. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- github-prose-style: Keep each logical paragraph/list item on one physical line; do not hard-wrap at 80 columns. -->
+
 ## Summary
 
 <!-- What changed and why? Keep this concise and link the design when useful. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,9 @@ A new feature ships with a unit test **and** a focused example:
 
 - Commit messages: English, Conventional Commits.
 - PR titles, PR bodies, and issue bodies: English.
+- GitHub Issue, Pull Request, Discussion, and comment body formatting follows
+  the [GitHub writing style](contexts/dev/github-writing.md); never hard-wrap
+  remote prose at 80 columns or another fixed width.
 - Code comments and docstrings: English, Google style.
 
 ## Development Workflows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,9 @@ A new feature ships with a unit test **and** a focused example:
 
 - Commit messages: English, Conventional Commits.
 - PR titles, PR bodies, and issue bodies: English.
+- GitHub Issue, Pull Request, Discussion, and comment body formatting follows
+  the [GitHub writing style](contexts/dev/github-writing.md); never hard-wrap
+  remote prose at 80 columns or another fixed width.
 - Code comments and docstrings: English, Google style.
 
 ## Development Workflows

--- a/contexts/dev/README.md
+++ b/contexts/dev/README.md
@@ -8,6 +8,7 @@ canonical source instead of treating this page as a replacement for it.
 | Architecture constraints and module ownership | [`AGENTS.md`](../../AGENTS.md) or [`CLAUDE.md`](../../CLAUDE.md) |
 | Component-development workflow | [`quantmind-dev` component workflow](../../.agents/skills/quantmind-dev/references/develop-components.md) |
 | Issue and pull-request labels | [Repository label guidance](labels.md) |
+| Issue and pull-request body formatting | [GitHub writing style](github-writing.md) |
 | Public operation and source catalog | [`docs/README.md`](../../docs/README.md) |
 | Public operation naming | [Operation naming contract](../../docs/design/en/operations.md) |
 | Component designs | [`docs/design/`](../../docs/design/) |

--- a/contexts/dev/github-writing.md
+++ b/contexts/dev/github-writing.md
@@ -1,0 +1,46 @@
+# GitHub Writing Style
+
+This guide is the canonical source-format contract for QuantMind Issue, Pull
+Request, Discussion, and comment bodies. It applies to text submitted to
+GitHub, not to Markdown files stored in the repository.
+
+## No Hard-wrapped Prose
+
+GitHub wraps rendered prose for the viewer. Do not insert source newlines at a
+fixed width, including 80 columns.
+
+- Keep each logical paragraph on one physical source line.
+- Keep each list or checklist item on one physical source line.
+- Keep each blockquote paragraph on one physical source line after `>`.
+- Keep each Markdown table row on one physical source line.
+- Preserve line structure inside fenced code blocks.
+- Use blank lines, headings, lists, code fences, tables, or an intentional
+  Markdown hard break only when they express real structure.
+
+Repository formatters and code line-length settings do not apply to GitHub
+body prose. In particular, do not run Issue or Pull Request bodies through
+`textwrap.fill`, an 80-column editor wrap, or a Markdown formatter configured
+to wrap prose.
+
+## Write Workflow
+
+1. Draft the complete body with one logical prose unit per source line.
+2. Preserve the selected Issue or Pull Request template and its checklist.
+3. Submit the body as written, preferably with `--body-file` when using `gh`.
+4. Read the raw body back after creation or editing and check that prose was
+   not hard-wrapped before considering the write complete.
+
+When Prettier is already available, use its no-wrap mode as a preflight on the
+temporary body file:
+
+```bash
+prettier --write --parser markdown --prose-wrap never /tmp/github-body.md
+prettier --check --parser markdown --prose-wrap never /tmp/github-body.md
+```
+
+Do not introduce a repository-wide Markdown formatter or change Python's
+80-column setting for this purpose. The preflight applies only to the temporary
+GitHub body.
+
+When updating an existing hard-wrapped body, normalize the complete body while
+preserving its meaning, headings, lists, code blocks, links, and checkboxes.

--- a/contexts/dev/labels.md
+++ b/contexts/dev/labels.md
@@ -69,6 +69,9 @@ type, area, and impact dimensions.
 
 ## Issues and Pull Requests
 
+Body source formatting follows the [GitHub writing style](github-writing.md),
+including its no-hard-wrap rule.
+
 - Label an issue from the intended problem and accepted scope.
 - Label a pull request from its actual diff.
 - A pull request that closes an issue should normally align with the issue's

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -9,6 +9,7 @@ class TestContextEntryPoints(unittest.TestCase):
         context_indexes = (
             "contexts/README.md",
             "contexts/dev/README.md",
+            "contexts/dev/github-writing.md",
             "contexts/dev/labels.md",
             "contexts/usage/README.md",
         )
@@ -118,9 +119,72 @@ class TestContextEntryPoints(unittest.TestCase):
             with self.subTest(dimension=dimension):
                 self.assertEqual(found, expected)
 
+    def test_github_writing_guide_has_required_routes(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        required_links = {
+            "contexts/dev/README.md": "github-writing.md",
+            "contexts/dev/labels.md": "github-writing.md",
+            "AGENTS.md": "contexts/dev/github-writing.md",
+            "CLAUDE.md": "contexts/dev/github-writing.md",
+            ".agents/skills/quantmind-dev/SKILL.md": (
+                "../../../contexts/dev/github-writing.md"
+            ),
+            ".claude/skills/quantmind-dev/SKILL.md": (
+                "../../../contexts/dev/github-writing.md"
+            ),
+            ".agents/skills/quantmind-dev/references/pull-request.md": (
+                "../../../../contexts/dev/github-writing.md"
+            ),
+            ".claude/skills/quantmind-dev/references/pull-request.md": (
+                "../../../../contexts/dev/github-writing.md"
+            ),
+        }
+
+        for source_path, target in required_links.items():
+            source = repo_root / source_path
+            with self.subTest(source=source_path):
+                self.assertIn(
+                    f"]({target})",
+                    source.read_text(encoding="utf-8"),
+                    f"{source_path} must route to the GitHub writing guide",
+                )
+                self.assertTrue(
+                    (source.parent / target).resolve().is_file(),
+                    f"broken GitHub writing guide link: {target}",
+                )
+
+        marker = "<!-- github-prose-style:"
+        templates = (
+            ".github/ISSUE_TEMPLATE/bug_report.md",
+            ".github/ISSUE_TEMPLATE/feature_request.md",
+            ".github/PULL_REQUEST_TEMPLATE.md",
+        )
+        for template_path in templates:
+            with self.subTest(template=template_path):
+                template = repo_root / template_path
+                self.assertIn(
+                    marker,
+                    template.read_text(encoding="utf-8"),
+                    f"{template_path} must remind authors not to hard-wrap",
+                )
+
     def test_quantmind_dev_skill_mirrors_match(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]
-        agents_skill = repo_root / ".agents/skills/quantmind-dev/SKILL.md"
-        claude_skill = repo_root / ".claude/skills/quantmind-dev/SKILL.md"
+        mirror_paths = (
+            "SKILL.md",
+            "references/commit.md",
+            "references/develop-components.md",
+            "references/pull-request.md",
+        )
 
-        self.assertEqual(agents_skill.read_bytes(), claude_skill.read_bytes())
+        for relative_path in mirror_paths:
+            agents_skill = (
+                repo_root / ".agents/skills/quantmind-dev" / relative_path
+            )
+            claude_skill = (
+                repo_root / ".claude/skills/quantmind-dev" / relative_path
+            )
+            with self.subTest(path=relative_path):
+                self.assertEqual(
+                    agents_skill.read_bytes(), claude_skill.read_bytes()
+                )


### PR DESCRIPTION
<!-- github-prose-style: Keep each logical paragraph/list item on one physical line; do not hard-wrap at 80 columns. -->

## Summary

Add a canonical source-format contract for GitHub Issue, Pull Request, Discussion, and comment bodies so future contributors and agents do not hard-wrap remote prose at 80 columns.

Route the contract through `AGENTS.md`, `CLAUDE.md`, both `quantmind-dev` skill copies, the pull-request workflow, the development-context index, label guidance, and the Issue/PR templates. Add regression coverage for every route, template marker, and mirrored skill reference.

The root cause was generation-side prose wrapping, not Ruff or another repository lint rule. This keeps Python's 80-column configuration and repository Markdown formatting unchanged while applying no-wrap normalization only to GitHub bodies.

## Related Issue

No issue applies; this is a focused contributor-governance fix requested during Issue maintenance.

## Verification

- `python -m pytest --no-cov -q tests/test_contexts.py` — 6 passed, 50 subtests passed.
- `bash scripts/verify.sh` — Ruff, BasedPyright, 5 import contracts, and 292 tests passed; total coverage 88.55%.
- Commit and pre-push hooks passed without bypassing verification.

## Checklist

- [x] The title uses English Conventional Commit format: `type(scope): summary`.
- [x] The related issue or design discussion is linked when applicable.
- [x] `bash scripts/verify.sh` passes.
- [x] Every applicable live-network component smoke test passes, or this PR states why none applies.
- [x] Public behavior has focused tests, an example, and documentation where applicable.
- [x] The PR is complete, small, and contains no unrelated changes.

No live-network component or runtime public behavior changes; live smoke tests and a usage example are not applicable.
