### PR TITLE
docs(design): page-preserving structure tree and reasoning-based retrieval

### DIFF
--- a/contexts/design/README.md
+++ b/contexts/design/README.md
@@ -30,7 +30,7 @@ implementation must preserve.
 | Preprocess | [Page-aware multimodal PDF parsing](preprocess/pdf.md) |
 | RAG | [Page-aware document chunking and retrieval](rag/document.md) |
 | Library | [Local knowledge storage and meaning-based search](library/local.md) |
-| Mind | [Build and navigate page-preserving knowledge trees](mind/navigation.md) |
+| Mind | [Build and navigate a page-preserving paper tree](mind/navigation.md) |
 | Operations | [Public operation naming](operations/naming.md) |
 | Operations | [Orchestration and construction altitude](operations/orchestration.md) |
 

--- a/contexts/design/README.md
+++ b/contexts/design/README.md
@@ -30,7 +30,7 @@ implementation must preserve.
 | Preprocess | [Page-aware multimodal PDF parsing](preprocess/pdf.md) |
 | RAG | [Page-aware document chunking and retrieval](rag/document.md) |
 | Library | [Local knowledge storage and meaning-based search](library/local.md) |
-| Mind | [Build and navigate a page-preserving paper tree](mind/navigation.md) |
+| Mind | [Build and navigate a page-preserving structure tree](mind/navigation.md) |
 | Operations | [Public operation naming](operations/naming.md) |
 | Operations | [Orchestration and construction altitude](operations/orchestration.md) |
 

--- a/contexts/design/README.md
+++ b/contexts/design/README.md
@@ -30,7 +30,7 @@ implementation must preserve.
 | Preprocess | [Page-aware multimodal PDF parsing](preprocess/pdf.md) |
 | RAG | [Page-aware document chunking and retrieval](rag/document.md) |
 | Library | [Local knowledge storage and meaning-based search](library/local.md) |
-| Mind | [Build and navigate a page-preserving structure tree](mind/navigation.md) |
+| Mind | [Build and retrieve from a page-preserving structure tree](mind/retrieval.md) |
 | Operations | [Public operation naming](operations/naming.md) |
 | Operations | [Orchestration and construction altitude](operations/orchestration.md) |
 

--- a/contexts/design/README.md
+++ b/contexts/design/README.md
@@ -30,6 +30,7 @@ implementation must preserve.
 | Preprocess | [Page-aware multimodal PDF parsing](preprocess/pdf.md) |
 | RAG | [Page-aware document chunking and retrieval](rag/document.md) |
 | Library | [Local knowledge storage and meaning-based search](library/local.md) |
+| Mind | [Build and navigate page-preserving knowledge trees](mind/navigation.md) |
 | Operations | [Public operation naming](operations/naming.md) |
 | Operations | [Orchestration and construction altitude](operations/orchestration.md) |
 

--- a/contexts/design/knowledge/paper.md
+++ b/contexts/design/knowledge/paper.md
@@ -92,4 +92,4 @@ Canonical paper models do not implement `embedding_text()` and do not select ret
 
 `LegacyPaper` retains the pre-V1 `TreeKnowledge` shape only so existing version-2 databases and the bundled legacy example can be opened. It is not exported as `Paper`, is not produced by `paper_flow`, and is not part of the V1 paper contract.
 
-There is no `PaperTree` in V1. A future tree or PageIndex artifact must be independently versioned, linked to an exact source and inputs, and added only with a real retrieval use case and migration plan. The accepted plan for that artifact is `PaperStructureTree`, a paper-artifact binding of a shared `StructureTree` base; see [Build and navigate a page-preserving structure tree](../mind/navigation.md).
+There is no `PaperTree` in V1. A future tree or PageIndex artifact must be independently versioned, linked to an exact source and inputs, and added only with a real retrieval use case and migration plan. The accepted plan for that artifact is `PaperStructureTree`, a paper-artifact binding of a shared `StructureTree` base; see [Build and retrieve from a page-preserving structure tree](../mind/retrieval.md).

--- a/contexts/design/knowledge/paper.md
+++ b/contexts/design/knowledge/paper.md
@@ -92,4 +92,4 @@ Canonical paper models do not implement `embedding_text()` and do not select ret
 
 `LegacyPaper` retains the pre-V1 `TreeKnowledge` shape only so existing version-2 databases and the bundled legacy example can be opened. It is not exported as `Paper`, is not produced by `paper_flow`, and is not part of the V1 paper contract.
 
-There is no `PaperTree` in V1. A future tree or PageIndex artifact must be independently versioned, linked to an exact source and inputs, and added only with a real retrieval use case and migration plan. The accepted plan for that artifact is `PaperNavigationTree`, a paper-artifact binding of a shared `NavigationTree` base; see [Build and navigate a page-preserving paper tree](../mind/navigation.md).
+There is no `PaperTree` in V1. A future tree or PageIndex artifact must be independently versioned, linked to an exact source and inputs, and added only with a real retrieval use case and migration plan. The accepted plan for that artifact is `PaperStructureTree`, a paper-artifact binding of a shared `StructureTree` base; see [Build and navigate a page-preserving structure tree](../mind/navigation.md).

--- a/contexts/design/knowledge/paper.md
+++ b/contexts/design/knowledge/paper.md
@@ -92,4 +92,4 @@ Canonical paper models do not implement `embedding_text()` and do not select ret
 
 `LegacyPaper` retains the pre-V1 `TreeKnowledge` shape only so existing version-2 databases and the bundled legacy example can be opened. It is not exported as `Paper`, is not produced by `paper_flow`, and is not part of the V1 paper contract.
 
-There is no `PaperTree` in V1. A future tree or PageIndex artifact must be independently versioned, linked to an exact source and inputs, and added only with a real retrieval use case and migration plan.
+There is no `PaperTree` in V1. A future tree or PageIndex artifact must be independently versioned, linked to an exact source and inputs, and added only with a real retrieval use case and migration plan. The accepted plan for that artifact is `PaperNavigationTree`, a paper-artifact binding of a shared `NavigationTree` base; see [Build and navigate a page-preserving paper tree](../mind/navigation.md).

--- a/contexts/design/library/local.md
+++ b/contexts/design/library/local.md
@@ -129,7 +129,7 @@ Reads fail closed when canonical hashes, counts, IDs, membership, lineage, sourc
 
 The library is canonical storage plus collection-wide semantic search, not a vector database abstraction. A future PageIndex path may first select candidate nodes through `search()` and then navigate a separate, independently versioned tree artifact. That agentic, library-backed navigation is owned by `quantmind.mind`, not `quantmind.rag`; only a stateless document-local draft helper may live under `rag`. See [Build and navigate page-preserving knowledge trees](../mind/navigation.md).
 
-PageIndex is not required to use `LocalKnowledgeLibrary.search()` or private LlamaIndex vector ranking. Paper Flow V1 deliberately stores chunks and a cited summary without defining a paper tree. When a navigation tree is stored as a `TreeKnowledge`, its per-node projections make hybrid semantic-plus-agentic navigation available without a second index.
+PageIndex is not required to use `LocalKnowledgeLibrary.search()` or private LlamaIndex vector ranking. Paper Flow V1 deliberately stores chunks and a cited summary without defining a paper tree. A navigation tree is stored as a source-linked paper artifact whose canonical persistence needs no embeddings; building per-node projections is an explicit later step that then enables hybrid semantic-plus-agentic navigation without a second index.
 
 ## Out of Scope
 

--- a/contexts/design/library/local.md
+++ b/contexts/design/library/local.md
@@ -127,9 +127,9 @@ Reads fail closed when canonical hashes, counts, IDs, membership, lineage, sourc
 
 ## PageIndex Boundary
 
-The library is canonical storage plus collection-wide semantic search, not a vector database abstraction. A future PageIndex path may first select candidate nodes through `search()` and then navigate a separate paper navigation-tree artifact. That agentic, library-backed navigation is owned by `quantmind.mind`, and `resolve()` is extended to the navigation-tree kind. See [Build and navigate a page-preserving paper tree](../mind/navigation.md).
+The library is canonical storage plus collection-wide semantic search, not a vector database abstraction. A future PageIndex path may first select candidate nodes through `search()` and then navigate a separate paper structure-tree artifact. That agentic, library-backed navigation is owned by `quantmind.mind`, and `resolve()` is extended to the structure-tree kind. See [Build and navigate a page-preserving structure tree](../mind/navigation.md).
 
-PageIndex is not required to use `LocalKnowledgeLibrary.search()` or private LlamaIndex vector ranking. Paper Flow V1 deliberately stores chunks and a cited summary without defining a paper tree. A navigation tree is stored as a source-linked paper artifact whose canonical persistence needs no embeddings; building per-node projections is an explicit later step that then enables hybrid semantic-plus-agentic navigation without a second index.
+PageIndex is not required to use `LocalKnowledgeLibrary.search()` or private LlamaIndex vector ranking. Paper Flow V1 deliberately stores chunks and a cited summary without defining a paper tree. A structure tree is stored as a source-linked paper artifact whose canonical persistence needs no embeddings; building per-node projections is an explicit later step that then enables hybrid semantic-plus-agentic navigation without a second index.
 
 ## Out of Scope
 

--- a/contexts/design/library/local.md
+++ b/contexts/design/library/local.md
@@ -127,7 +127,7 @@ Reads fail closed when canonical hashes, counts, IDs, membership, lineage, sourc
 
 ## PageIndex Boundary
 
-The library is canonical storage plus collection-wide semantic search, not a vector database abstraction. A future PageIndex path may first select candidate nodes through `search()` and then navigate a separate, independently versioned tree artifact. That agentic, library-backed navigation is owned by `quantmind.mind`, not `quantmind.rag`; only a stateless document-local draft helper may live under `rag`. See [Build and navigate page-preserving knowledge trees](../mind/navigation.md).
+The library is canonical storage plus collection-wide semantic search, not a vector database abstraction. A future PageIndex path may first select candidate nodes through `search()` and then navigate a separate paper navigation-tree artifact. That agentic, library-backed navigation is owned by `quantmind.mind`, and `resolve()` is extended to the navigation-tree kind. See [Build and navigate a page-preserving paper tree](../mind/navigation.md).
 
 PageIndex is not required to use `LocalKnowledgeLibrary.search()` or private LlamaIndex vector ranking. Paper Flow V1 deliberately stores chunks and a cited summary without defining a paper tree. A navigation tree is stored as a source-linked paper artifact whose canonical persistence needs no embeddings; building per-node projections is an explicit later step that then enables hybrid semantic-plus-agentic navigation without a second index.
 

--- a/contexts/design/library/local.md
+++ b/contexts/design/library/local.md
@@ -127,9 +127,9 @@ Reads fail closed when canonical hashes, counts, IDs, membership, lineage, sourc
 
 ## PageIndex Boundary
 
-The library is canonical storage plus collection-wide semantic search, not a vector database abstraction. A future PageIndex path may first select a paper through `search()` and then navigate a separate, independently versioned tree artifact through an opinionated operation under `quantmind.rag`.
+The library is canonical storage plus collection-wide semantic search, not a vector database abstraction. A future PageIndex path may first select candidate nodes through `search()` and then navigate a separate, independently versioned tree artifact. That agentic, library-backed navigation is owned by `quantmind.mind`, not `quantmind.rag`; only a stateless document-local draft helper may live under `rag`. See [Build and navigate page-preserving knowledge trees](../mind/navigation.md).
 
-PageIndex is not required to use `LocalKnowledgeLibrary.search()` or private LlamaIndex vector ranking. Paper Flow V1 deliberately stores chunks and a cited summary without defining a paper tree.
+PageIndex is not required to use `LocalKnowledgeLibrary.search()` or private LlamaIndex vector ranking. Paper Flow V1 deliberately stores chunks and a cited summary without defining a paper tree. When a navigation tree is stored as a `TreeKnowledge`, its per-node projections make hybrid semantic-plus-agentic navigation available without a second index.
 
 ## Out of Scope
 

--- a/contexts/design/library/local.md
+++ b/contexts/design/library/local.md
@@ -127,9 +127,9 @@ Reads fail closed when canonical hashes, counts, IDs, membership, lineage, sourc
 
 ## PageIndex Boundary
 
-The library is canonical storage plus collection-wide semantic search, not a vector database abstraction. A future PageIndex path may first select candidate nodes through `search()` and then navigate a separate paper structure-tree artifact. That agentic, library-backed navigation is owned by `quantmind.mind`, and `resolve()` is extended to the structure-tree kind. See [Build and navigate a page-preserving structure tree](../mind/navigation.md).
+The library is canonical storage plus collection-wide semantic search, not a vector database abstraction. A future PageIndex path may first select candidate nodes through `search()` and then retrieve over a separate paper structure-tree artifact. That agentic, library-backed retrieval is owned by `quantmind.mind`, and `resolve()` is extended to the structure-tree kind. See [Build and retrieve from a page-preserving structure tree](../mind/retrieval.md).
 
-PageIndex is not required to use `LocalKnowledgeLibrary.search()` or private LlamaIndex vector ranking. Paper Flow V1 deliberately stores chunks and a cited summary without defining a paper tree. A structure tree is stored as a source-linked paper artifact whose canonical persistence needs no embeddings; building per-node projections is an explicit later step that then enables hybrid semantic-plus-agentic navigation without a second index.
+PageIndex is not required to use `LocalKnowledgeLibrary.search()` or private LlamaIndex vector ranking. Paper Flow V1 deliberately stores chunks and a cited summary without defining a paper tree. A structure tree is stored as a source-linked paper artifact whose canonical persistence needs no embeddings; building per-node projections is an explicit later step that then enables hybrid semantic-plus-agentic retrieval without a second index.
 
 ## Out of Scope
 
@@ -137,5 +137,5 @@ PageIndex is not required to use `LocalKnowledgeLibrary.search()` or private Lla
 - implicit persistence inside flows;
 - answer synthesis or agent memory;
 - merging distinct canonical identities;
-- a V1 paper tree or PageIndex navigation API;
+- a V1 paper tree or PageIndex retrieval API;
 - treating rebuildable projections as canonical knowledge.

--- a/contexts/design/mind/navigation.md
+++ b/contexts/design/mind/navigation.md
@@ -1,17 +1,17 @@
-# Build and navigate a page-preserving paper tree
+# Build and navigate a page-preserving structure tree
 
 ## Quick Summary
 
-- **Purpose**: Define how a source-first paper gains a validated navigation tree
+- **Purpose**: Define how a source-first paper gains a validated structure tree
   and how a reasoning agent traverses it, without embeddings replacing reasoning.
 - **Read when**: Designing or changing PageIndex-style tree construction, the
   `mind` navigation package, or hybrid semantic-plus-agentic retrieval.
 - **Status**: Planned. No implementation exists on `master`. This page records
   the accepted design and refines issue #95 for the source-first Paper Flow V1
   model shipped in #120; the `quantmind.mind` package does not exist yet.
-- **Core rule**: One tree implementation. A shared `NavigationTree` base carries
+- **Core rule**: One tree implementation. A shared `StructureTree` base carries
   structure, navigation, and the integrity gate; each document type subclasses it
-  for identity. The paper tree is a derived, source-linked artifact whose model
+  for identity. The paper structure tree is a derived, source-linked artifact whose model
   returns only a draft while code validates every node. Navigation reasons over
   titles and summaries; embeddings are a coarse pre-filter added later, never a
   replacement.
@@ -25,7 +25,7 @@
 - [Motivation](#motivation)
 - [Design at a Glance](#design-at-a-glance)
 - [Ownership](#ownership)
-- [Navigation Tree Base and Paper Binding](#navigation-tree-base-and-paper-binding)
+- [Structure Tree Base and Paper Binding](#structure-tree-base-and-paper-binding)
 - [Build Pipeline](#build-pipeline)
 - [Navigation Retrieval](#navigation-retrieval)
 - [Multi-Model Compatibility](#multi-model-compatibility)
@@ -66,7 +66,7 @@ flowchart TD
         DRAFT["draft structuring agent (model, private draft)"]
     end
     subgraph KNW["knowledge"]
-        FD["PaperNavigationTree.from_draft() (code): mint ids, links, citations + validate() gate"]
+        FD["PaperStructureTree.from_draft() (code): mint ids, links, citations + validate() gate"]
     end
     subgraph LIB["library"]
         PUT["put artifact: paper_artifacts (no embeddings)"]
@@ -75,7 +75,7 @@ flowchart TD
         RES["resolve(locator): page-cited content"]
     end
     subgraph MND["mind"]
-        NAV["navigate(tree, question): single-pass / agentic"]
+        NAV["navigate(structure, question): single-pass / agentic"]
     end
     PD --> OUT
     OUT --> DRAFT
@@ -96,7 +96,7 @@ a new owner, `mind`. No shared runtime is moved and no second store is added.
 | Owner | Responsibility |
 |---|---|
 | `quantmind.preprocess` | Emit deterministic outline signals (heading candidates, table-of-contents pages, printed-to-physical page offset) from a parsed document. No LLM calls. |
-| `quantmind.knowledge` | Add the `NavigationTree` structural base (reused by a refactored `TreeKnowledge`) plus a `PaperNavigationTree(NavigationTree)` artifact whose `from_draft` constructor mints identity and runs the shared integrity gate. |
+| `quantmind.knowledge` | Add the `StructureTree` structural base (reused by a refactored `TreeKnowledge`) plus a `PaperStructureTree(StructureTree)` artifact whose `from_draft` constructor mints identity and runs the shared integrity gate. |
 | `quantmind.flows` | Run one draft-structuring agent and call the knowledge constructor. Reuses `flows._runner` unchanged. Persistence stays explicit. |
 | `quantmind.library` | Persist the artifact through the existing paper artifact tables and extend `resolve()` to the new kind. Per-node projections are a separate later step. |
 | `quantmind.mind` | Traverse the tree with the Agents SDK and return node evidence. May request a semantic shortlist from `library`. |
@@ -104,14 +104,14 @@ a new owner, `mind`. No shared runtime is moved and no second store is added.
 `quantmind.rag` is unchanged: it stays deterministic chunking and BM25 with no
 LLM dependency and hosts no PageIndex draft producer.
 
-## Navigation Tree Base and Paper Binding
+## Structure Tree Base and Paper Binding
 
 The tree structure is shared across document types; the identity binding is not.
 The design factors the two apart so the codebase keeps exactly one tree, not two.
 
 ```mermaid
 classDiagram
-    class NavigationTree {
+    class StructureTree {
         <<structural base>>
         +UUID root_node_id
         +Map nodes
@@ -135,7 +135,7 @@ classDiagram
         <<canonical identity>>
     }
     class TreeKnowledge
-    class PaperNavigationTree {
+    class PaperStructureTree {
         +PaperArtifactKind artifact_kind
         +UUID source_revision_id
         +str producer_config_hash
@@ -147,30 +147,30 @@ classDiagram
     }
     class PaperChunkSet
 
-    NavigationTree <|-- TreeKnowledge
+    StructureTree <|-- TreeKnowledge
     BaseKnowledge <|-- TreeKnowledge
-    NavigationTree <|-- PaperNavigationTree
-    NavigationTree *-- TreeNode : nodes
+    StructureTree <|-- PaperStructureTree
+    StructureTree *-- TreeNode : nodes
     TreeNode *-- Citation : citations
-    PaperNavigationTree ..> PaperSourceRevision : source_revision_id
-    PaperNavigationTree ..> PaperChunkSet : lineage
+    PaperStructureTree ..> PaperSourceRevision : source_revision_id
+    PaperStructureTree ..> PaperChunkSet : lineage
 ```
 
-`NavigationTree` is a structural base — a plain `BaseModel` with no
+`StructureTree` is a structural base — a plain `BaseModel` with no
 `BaseKnowledge` identity: `root_node_id: UUID`, `nodes: dict[UUID, TreeNode]`, the
 navigation surface (`root()`, `children_of()`, `walk_dfs()`, `find_path()`), and
 the `validate()` integrity gate. It carries no `id`, `as_of`, or `source`, so a
 subclass adds whatever identity its storage model needs without a second
 competing identity. The existing `TreeKnowledge` is refactored to
-`TreeKnowledge(BaseKnowledge, NavigationTree)` and reuses the same nodes,
+`TreeKnowledge(BaseKnowledge, StructureTree)` and reuses the same nodes,
 helpers, and gate instead of defining its own.
 
-A navigation tree is a derived artifact — rebuildable from a source plus a
+A structure tree is a derived artifact — rebuildable from a source plus a
 producer configuration, like `PaperChunkSet` — not canonical knowledge, so the
 paper binding is a paper artifact rather than a `TreeKnowledge` stored as a
-knowledge item. `PaperNavigationTree(NavigationTree)` adds:
+knowledge item. `PaperStructureTree(StructureTree)` adds:
 
-- `artifact_kind = PaperArtifactKind.NAVIGATION_TREE` and `schema_version`;
+- `artifact_kind = PaperArtifactKind.STRUCTURE_TREE` and `schema_version`;
 - `source_revision_id` binding it to an exact `PaperSourceRevision`;
 - a `producer` config (model, prompt version, input chunk-set id, instructions
   hash, structuring bounds) and its `producer_config_hash`;
@@ -179,7 +179,7 @@ knowledge item. `PaperNavigationTree(NavigationTree)` adds:
 
 A stable, source-and-producer-derived id makes an unchanged re-run idempotent and
 versions a changed configuration rather than overwriting it, exactly as the other
-paper artifacts behave. A future document type adds its own `NavigationTree`
+paper artifacts behave. A future document type adds its own `StructureTree`
 subclass with its own source binding; nothing paper-specific leaks into the base.
 
 Page ranges reuse `Citation`: a node spanning pages 5-8 carries four
@@ -202,9 +202,9 @@ call for the draft, and code-owned identity and validation.
    draft summaries, and candidate chunk indices per node. The draft chooses no
    ids, links, or canonical citations, exactly like the summary draft.
 3. **Canonicalization and integrity gate (`knowledge`).**
-   `PaperNavigationTree.from_draft(chunk_set, *, producer, draft)` mints node
+   `PaperStructureTree.from_draft(chunk_set, *, producer, draft)` mints node
    ids, builds parent/child links, and resolves each node's `Citation` entries
-   from the chunk set, then runs the shared `NavigationTree.validate()` gate. The
+   from the chunk set, then runs the shared `StructureTree.validate()` gate. The
    gate rejects any tree that is not single-rooted and acyclic with every node
    reachable, bidirectional parent/child consistency, unique sibling positions,
    no orphan, every cited page within the source, and every child's cited pages
@@ -221,11 +221,11 @@ Navigation lives in `quantmind.mind.navigation` and returns node evidence, never
 a synthesized answer:
 
 ```text
-navigate(tree, question, *, library, cfg, seed_locators=None)
+navigate(structure, question, *, library, cfg, seed_locators=None)
   -> list[NavigationEvidence]
 ```
 
-`tree` is any `NavigationTree` — a `PaperNavigationTree` today. Navigation is
+`structure` is any `StructureTree` — a `PaperStructureTree` today. Navigation is
 written against the base, so a future document type reuses it unchanged. Leaf
 content is resolved through the existing `LocalKnowledgeLibrary.resolve()`,
 extended to the new artifact kind, so no parallel page-resolver concept is added.
@@ -297,7 +297,7 @@ orphaned, and out-of-page-range trees; stable ids and idempotent re-runs; citati
 resolution to correct pages; reopen behavior; and, once projections exist, seeded
 hybrid navigation with locator validation.
 
-A bounded live slice builds a navigation tree over one exact arXiv revision with a
+A bounded live slice builds a structure tree over one exact arXiv revision with a
 real model, traverses it single-pass and agentically, and prints the selected
 titles, resolved page-cited content, and citation pages. It runs at least one
 non-OpenAI model to exercise the capability requirement.

--- a/contexts/design/mind/navigation.md
+++ b/contexts/design/mind/navigation.md
@@ -2,34 +2,38 @@
 
 ## Quick Summary
 
-- **Purpose**: Define how QuantMind builds a page-preserving, independently
-  versioned knowledge tree from a source-first paper and how a reasoning agent
-  navigates it, without embeddings replacing that reasoning.
+- **Purpose**: Define how QuantMind builds a page-preserving, source-linked
+  navigation tree from a source-first paper and how a reasoning agent navigates
+  it, without embeddings replacing that reasoning.
 - **Read when**: Designing or changing PageIndex-style tree construction, the
-  `mind` navigation package, hybrid semantic-plus-agentic retrieval, or the
-  multi-provider model seam these use.
+  `mind` navigation package, the shared agent runtime seam, hybrid
+  semantic-plus-agentic retrieval, or the multi-provider model matrix.
 - **Status**: Planned. No implementation exists on `master`. This page records
   the accepted design and refines issue #95 for the source-first Paper Flow V1
   model shipped in #120; the `quantmind.mind` package does not exist yet.
-- **Core rule**: Navigation reasons over titles and summaries; embeddings are a
-  coarse pre-filter, never a replacement. The tree is a rebuildable derived
-  artifact linked to an exact source, never a second canonical identity.
-- **Related work**: issues #95 (feature request), #71 (`mind` scaffold), #111
-  (`LocalKnowledgeLibrary`, closed), #120 (source-first Paper Flow V1);
-  prior art `VectifyAI/PageIndex` (MIT).
+- **Core rule**: A navigation tree is a source-linked, independently versioned
+  artifact with code-owned identity, links, and citations. The model proposes a
+  draft; code validates every node. Navigation reasons over titles and
+  summaries; embeddings are a coarse pre-filter, never a replacement.
+- **Related work**: issues #122 (context), #95 (feature request), #71 (`mind`
+  scaffold), #111 (`LocalKnowledgeLibrary`, closed), #120 (source-first Paper
+  Flow V1); prior art `VectifyAI/PageIndex` (MIT).
 
 ## Contents
 
 - [Motivation](#motivation)
 - [Non-Goals](#non-goals)
 - [Ownership](#ownership)
+- [Artifact Identity](#artifact-identity)
 - [Tree Model](#tree-model)
 - [Build Pipeline](#build-pipeline)
 - [Navigation Retrieval](#navigation-retrieval)
+- [Shared Agent Runtime](#shared-agent-runtime)
 - [Multi-Model Compatibility](#multi-model-compatibility)
 - [Hybrid Search Compatibility](#hybrid-search-compatibility)
 - [Boundaries and Import Contracts](#boundaries-and-import-contracts)
 - [Phasing](#phasing)
+- [Acceptance and Evaluation](#acceptance-and-evaluation)
 - [Relationship to Prior Art](#relationship-to-prior-art)
 - [Out of Scope](#out-of-scope)
 
@@ -44,13 +48,13 @@ fixed-size chunking fragments a table or a clause; a cross-reference such as
 retriever cannot use prior reasoning or conversation to decide where to look.
 
 Reasoning-based navigation reframes retrieval as relevance classification
-performed by the model over a document's real structure. The agent reads a
-tree of section titles and summaries, picks a branch, drills down, and lazily
-loads leaf text with exact page provenance. `quantmind.knowledge` already
-records this as the purpose of `TreeKnowledge`: "an agent reads the root
-summary plus children summaries, picks the most likely branch, drills down, and
-lazy-loads leaf content. Embeddings (when available) act as a coarse pre-filter,
-never as a replacement for that reasoning."
+performed by the model over a document's real structure. The agent reads a tree
+of section titles and summaries, picks a branch, drills down, and lazily loads
+leaf text with exact page provenance. `quantmind.knowledge` already records this
+as the purpose of `TreeKnowledge`: "an agent reads the root summary plus
+children summaries, picks the most likely branch, drills down, and lazy-loads
+leaf content. Embeddings (when available) act as a coarse pre-filter, never as a
+replacement for that reasoning."
 
 This page defines how that capability is built and owned across packages so the
 pieces compose without a new framework.
@@ -61,197 +65,264 @@ Carried from issue #95 and the existing library and RAG boundaries:
 
 - A general-purpose RAG or PageIndex framework, provider registry, or retriever
   hierarchy.
-- A second tree schema (`PageIndexNode`) or a generic `Document` model. The
-  design reuses `TreeKnowledge`, `TreeNode`, and `Citation`.
+- A second tree schema (`PageIndexNode`) or a generic `Document` model. The tree
+  payload reuses `TreeKnowledge`, `TreeNode`, and `Citation`.
 - A second persistence layer or semantic index. Persistence and semantic
   candidates stay in `LocalKnowledgeLibrary`.
 - Answer synthesis inside the navigation primitive. Navigation returns node
   evidence; a caller composes an answer.
 - Making `Paper` a `TreeKnowledge` again. Paper Flow V1 deliberately has no
-  paper tree; a navigation tree is a separate, independently versioned artifact.
+  paper tree; a navigation tree is a separate, source-linked artifact.
 
 ## Ownership
 
 The feature is cross-cutting. Each existing package keeps its current
-responsibility; only the agentic traversal introduces a new owner, `mind`.
+responsibility; the agentic traversal introduces a new owner, `mind`, and the
+shared agent runtime moves below `flows`.
 
 | Owner | Responsibility |
 |---|---|
 | `quantmind.preprocess` | Preserve page boundaries and emit deterministic outline signals (heading candidates, table-of-contents pages, printed-to-physical page offset). No LLM calls. |
-| `quantmind.rag` | Optional stateless helper: propose a draft outline or navigation evidence from one `ParsedDocument`. Returns a bounded draft, never canonical identity. Imports only `preprocess`. |
-| `quantmind.knowledge` | Provide the canonical `TreeKnowledge` / `TreeNode` / `Citation` models and page provenance. No I/O, no retrieval-text choice. |
-| `quantmind.flows` | Build and enrich the canonical tree with the Agents SDK, linking it to an exact `PaperSourceRevision`. Persistence stays explicit. |
-| `quantmind.library` | Persist the canonical tree and provide semantic candidates through existing per-node projections. Adds no second store or index. |
-| `quantmind.mind` | Perform agentic traversal over titles and summaries and return node evidence. May request a semantic shortlist from `library`. |
+| `quantmind.rag` | Optional stateless helper: propose a draft outline from one `ParsedDocument`. Returns a bounded draft, never canonical identity. Imports only `preprocess`. |
+| `quantmind.knowledge` | Provide the `TreeKnowledge` / `TreeNode` / `Citation` payload models and the `PaperNavigationArtifact` envelope with its validation rules. No I/O, no retrieval-text choice. |
+| `quantmind.flows` | Turn a model draft into a validated canonical artifact linked to an exact `PaperSourceRevision` and chunk set. Persistence stays explicit. |
+| `quantmind.library` | Persist the canonical artifact through the paper artifact tables and, as an explicit later step, build per-node projections. Adds no second store or index. |
+| `quantmind.mind` | Own the shared agent runtime seam and perform agentic traversal, returning node evidence. May request a semantic shortlist from `library`. |
 
 This resolves a prior tension. `contexts/design/library/local.md` and
 `contexts/design/rag/document.md` say a future PageIndex operation "may live
-under `quantmind.rag`". That remains true only for the stateless,
-document-local draft producer, because `rag` may import only `preprocess`. The
-stateful parts — building a persisted canonical tree and running hybrid,
-library-backed agentic navigation — sit above `library` and therefore belong to
-`flows` (build) and `mind` (navigate).
+under `quantmind.rag`". That holds only for the stateless, document-local draft
+producer, because `rag` may import only `preprocess`. Building a persisted
+canonical artifact and running hybrid, library-backed navigation sit above
+`library` and belong to `flows` (build) and `mind` (navigate).
+
+## Artifact Identity
+
+A navigation tree is a source-first artifact, not a bare `TreeKnowledge`. A
+plain `TreeKnowledge` cannot carry the identity the paper design requires: its
+`id` defaults to a random UUID, `ExtractionRef` records no producer
+configuration or input artifact, and `knowledge_items` has no link to
+`paper_sources` or `paper_artifact_lineage`. Persisting it with the conventional
+`put()` would make re-runs non-idempotent, allow a deleted source to orphan a
+tree, and hide the tree from `get_paper()`.
+
+The design therefore adds a `PaperNavigationArtifact` envelope, mirroring
+`PaperChunkSet` and `PaperGlobalSummary`:
+
+- a new `PaperArtifactKind` value (for example `paper_navigation_tree`);
+- `source_revision_id` binding it to an exact `PaperSourceRevision`;
+- a `producer` config (model, prompt version, input chunk-set id, instructions
+  hash, structuring bounds) and a `producer_config_hash`;
+- a `content_hash` over the canonical tree;
+- lineage to the input `PaperChunkSet` via `paper_artifact_lineage`;
+- a stable, content-derived artifact id, so an unchanged re-run is idempotent and
+  a changed producer configuration versions rather than overwrites.
+
+The envelope reuses `TreeKnowledge` / `TreeNode` as its payload; it does not
+introduce a second tree schema. It is persisted through the existing
+`paper_artifacts` / `paper_artifact_members` / `paper_artifact_lineage` tables
+(nodes as members), never `knowledge_items`, so identity, lineage, and
+fail-closed rehydration match every other paper artifact.
 
 ## Tree Model
-
-The navigation tree is a canonical `TreeKnowledge` value, not a new schema.
 
 - `TreeNode` already carries `node_id`, `parent_id`, `position`, `title`,
   `summary`, optional `content`, `citations`, and `children_ids`. A section maps
   to a node; the ordered PDF pages it spans map to node `citations`.
-- Page provenance uses `Citation`. `Citation.page` is the 1-based inclusive
-  start. Add an optional `Citation.end_page`: an omitted end means one page, and
-  a present end must satisfy `end_page >= page`. This is the only canonical-model
-  change and matches issue #95.
-- The tree is a derived artifact, not a second identity. It sets `source` to the
-  same `SourceRef` as the paper it describes, sets `extraction` to the
-  building flow and model, and links every node's leaf text back to exact source
-  pages. It is independently versioned by its producer configuration, exactly as
-  `PaperChunkSet` and `PaperGlobalSummary` are.
-- `TreeKnowledge` navigation helpers (`root()`, `children_of()`, `walk_dfs()`,
-  `find_path()`) are the traversal surface; the navigation package adds no
-  parallel tree structure.
-
-A navigation tree is built from a `PaperSourceRevision` and its `PaperChunkSet`
-so that a node's `content` and page citations reuse already-validated chunk text
-and spans rather than re-parsing the PDF.
+- Page provenance uses `Citation`. Add an optional `Citation.end_page`:
+  `Citation.page` is the 1-based inclusive start (constrained `>= 1`), an omitted
+  end means one page, a present end must satisfy `end_page >= page`, an end with
+  no start is rejected, and both must fall within the source page count.
+- A node's `content` and page citations reuse already-validated `PaperChunk`
+  text and `PaperSourceSpan` page numbers rather than re-parsing the PDF, so a
+  leaf never invents text or a page.
 
 ## Build Pipeline
 
-Construction separates deterministic work from model work so page and outline
-facts stay reproducible and free of LLM cost.
+Construction separates deterministic work from model work, and keeps canonical
+identity, links, and content in code rather than in model output.
 
 1. **Outline signals (`preprocess`, deterministic).** From the page-aware
    `ParsedDocument`, detect table-of-contents pages, heading candidates, and the
    printed-to-physical page offset. Emit ordered, page-anchored signals; make no
    LLM call and no ranking decision.
-2. **Structuring (`flows`, Agents SDK).** An agent turns outline signals and
-   chunk text into a `TreeKnowledge`: section titles, hierarchy, per-node
-   summaries, and page-range citations. When no usable table of contents exists,
-   the agent proposes a hierarchy directly from content. Oversized sections are
-   split by bounded page and token budgets, mirroring PageIndex's recursive node
-   subdivision.
-3. **Verification (`flows`, deterministic guardrail).** Sample node titles and
-   confirm each claimed section actually begins on its cited page against
-   `ParsedDocument` evidence. Below an accuracy floor, fall back to a weaker
-   structuring mode or a flat single-level tree rather than emit an unverified
-   hierarchy.
-4. **Persistence (`library`).** `put()` stores the canonical `TreeKnowledge`
-   using existing `knowledge_items` / `knowledge_nodes` rows and produces one
-   aggregate projection plus one projection for every non-root node. No new
-   table is required for the MVP.
+2. **Draft structuring (`flows`, Agents SDK).** An agent proposes a *private
+   draft* hierarchy from outline signals and chunk text: titles, nesting, and
+   per-node draft summaries with candidate page ranges. The model output is never
+   canonical; it is the equivalent of `PaperCitationDraft`.
+3. **Canonicalization (`flows`, code-owned).** Code assigns node ids, builds
+   parent/child links, resolves each leaf's `content` and `citations` from the
+   `PaperChunkSet`, and assembles the `PaperNavigationArtifact` with its producer
+   identity and lineage.
+4. **Full integrity validation (`knowledge` + `flows`, deterministic).** Reject
+   any artifact that is not a single-rooted, acyclic tree with: every node
+   reachable from the root; bidirectional parent/child consistency; unique
+   sibling positions; no orphan or unreachable node; every citation range inside
+   the source page count; and every child page span contained in its parent's
+   span. This is the integrity gate. Title-appearance sampling is retained only
+   as a quality signal, not as the gate, and a low quality score falls back to a
+   flat single-level tree rather than emitting an unverified hierarchy.
+5. **Persistence (`library`).** Store the canonical `PaperNavigationArtifact`
+   through the paper artifact tables. Persistence does not require embeddings;
+   projections are a separate, explicit step (see
+   [Phasing](#phasing)).
 
-Steps 1 and 3 hold no model dependency, so page and outline correctness are
-testable without a network. Step 2 is the only provider-dependent stage.
+Steps 1, 3, and 4 hold no model dependency, so page, link, and content
+correctness are testable without a network. Step 2 is the only stage that calls
+a model.
 
 ## Navigation Retrieval
 
 Navigation lives in `quantmind.mind.navigation` and returns node evidence
-(locators, titles, page-cited content), never a synthesized answer. Two grains
-are supported, matching the two paths in the reference implementation.
+(locators, titles, page-cited content), never a synthesized answer. Its inputs
+are explicit, so every tool it exposes is implementable:
 
-- **Single-pass classification.** Serialize the tree with node text stripped
-  (ids, titles, summaries, hierarchy only), ask the model once for the relevant
-  node ids, then load exact page-cited content for those nodes. Cheap and
-  bounded: two model calls independent of tree depth.
-- **Agentic traversal.** Expose SDK `@function_tool` functions over the tree —
-  `get_document_structure()` (tree without leaf text) and
-  `get_page_content(pages)` (exact page-cited leaf text) — and let an Agent
-  decide, turn by turn, which branch to open and when it has enough evidence.
-  This path can follow cross-references and use conversation state, at variable
-  model cost.
+```text
+navigate(artifact, question, *, page_resolver, seed_locators=None)
+  -> list[NavigationEvidence]
+```
 
-Both run through the shared `flows._runner` observability wrapper so tracing,
-turn limits, and the memory hook behave as they do for every other agent. The
-navigation primitive takes a tree, a question, and an optional set of seed node
-ids (see [Hybrid Search Compatibility](#hybrid-search-compatibility)); it does
-not own persistence, embedding, or answer generation.
+- `artifact` is the `PaperNavigationArtifact` (tree payload plus identity, so
+  seed locators can be validated against it).
+- `page_resolver` resolves node or page content from the exact
+  `PaperSourceRevision` / `PaperChunkSet`. The tree is not page storage; leaf
+  text comes from the resolver, matching how the reference implementation reads
+  cached pages rather than reconstructing them from the tree.
+
+Two grains are supported:
+
+- **Single-pass selection.** Serialize the tree with node text stripped (ids,
+  titles, summaries, hierarchy only), make **one** model call for the relevant
+  node ids, then load exact page-cited content for those nodes through the
+  resolver in code. Cheap and predictable.
+- **Agentic traversal.** Expose SDK `@function_tool` functions —
+  `get_document_structure()` (tree without leaf text), `get_children(node_id)`
+  (progressive expansion for large trees), and `get_node_content(node_ids)`
+  (exact page-cited leaf text via the resolver) — and let an Agent decide, turn
+  by turn, which branch to open and when it has enough evidence. This path can
+  follow cross-references and use conversation state, at variable model cost.
+
+Serializing the whole structure is bounded by node count, not depth, so large
+trees use a structure token budget plus `get_children()` progressive expansion
+rather than one giant blob. Both grains run through the shared runtime seam (see
+below) for tracing and turn limits.
+
+## Shared Agent Runtime
+
+Navigation must reuse the observability run wrapper and the model seam that
+`flows` uses, but `mind` may not import `flows`. The shared runtime therefore
+does not live in `flows`.
+
+Decision: place the run wrapper and model resolution in a shared module that both
+layers import downward — `quantmind.mind.runtime` (with `flows` depending on
+`mind`, which the contracts already permit) or a neutral `quantmind.runtime`
+module. The existing `flows._runner` moves there. `flows` and `mind.navigation`
+both call the shared runner; neither owns a private copy. This choice couples
+with the #71 `mind` scaffold and is a prerequisite for P1.
 
 ## Multi-Model Compatibility
 
-The design must not hard-lock to one provider for either generation or
-embeddings. On `master` today `cfg.model` is a plain string passed straight to
-`agents.Agent(model=...)`, there is no provider-detection helper, and the only
-embedding provider is OpenAI. The design commits to two seams.
+The design must not hard-lock to one provider for generation or embeddings. On
+`master` today `cfg.model` is a plain string passed straight to
+`agents.Agent(model=...)`, and the only embedding provider is OpenAI.
 
-- **One model-resolution seam for generation.** Structuring, single-pass
-  classification, and agentic traversal all take their model from
-  `BaseFlowCfg.model`. Provider resolution is centralized in one helper that maps
-  a model string to an SDK model, using the Agents SDK LiteLLM integration
-  (`agents.extensions.models.litellm_model.LitellmModel`, and the
-  `litellm/<provider>/<model>` convention) for non-OpenAI providers. `litellm`
-  is already a pinned dependency. No call site constructs a provider inline and
-  no per-flow model registry is added.
-- **Provider-agnostic embeddings for the hybrid pre-filter.** The library
-  already isolates embeddings behind the private `_EmbeddingProvider` Protocol
-  (`embed(texts, *, model, dimensions)` / `close()`). Hybrid navigation depends
-  only on that seam and on `SemanticQuery`/`SemanticHit`, never on a specific
-  embedding vendor. Promoting the seam to a supported swap point is a library
-  decision tracked separately; navigation must not assume OpenAI.
-
-Multi-model support is therefore a property of these two seams, not a provider
-registry or a retriever hierarchy — both explicit non-goals.
+- **Rely on the SDK, do not wrap it.** The Agents SDK already routes a
+  `litellm/<provider>/<model>` model string through its multi-provider support,
+  so the design adds no bespoke provider-resolution wrapper. `cfg.model` flows
+  unchanged into the shared runtime seam.
+- **Define a capability contract instead.** Each stage states what it needs from
+  a model: draft structuring needs reliable structured output; agentic traversal
+  needs tool-calling; all stages need usage reporting for the cost caps in
+  `BaseFlowCfg`. A provider that cannot meet a stage's contract is unsupported
+  for that stage, and this is covered by a provider test matrix (at least one
+  OpenAI and one non-OpenAI model across structuring and traversal), not by a
+  runtime abstraction.
+- **Provider-agnostic embeddings.** The library isolates embeddings behind the
+  private `_EmbeddingProvider` Protocol. Hybrid navigation depends only on that
+  seam and on `SemanticQuery` / `SemanticHit`, never on a specific vendor.
 
 ## Hybrid Search Compatibility
 
 Hybrid retrieval — use semantic search to shortlist nodes, then let the agent
-reason over that shortlist — is a first-class future mode, and the current
-storage model already makes it nearly free.
+reason over that shortlist — is a first-class later mode. It reuses locator
+identity end to end.
 
-- When a navigation `TreeKnowledge` is stored, `library` produces one projection
-  for every non-root node. `search(SemanticQuery(...))` over those projections
-  returns `SemanticHit` values whose `node_id` identifies candidate nodes in the
-  same tree.
-- The navigation primitive accepts optional seed node ids. Hybrid mode is the
-  composition: run `library.search()`, map the hits' `node_id` values to seeds,
-  and start agentic traversal from those nodes instead of the root; the agent
-  still expands, drills down, and follows cross-references from there.
+- After a navigation artifact's nodes are projected (the explicit P2 step),
+  `search(SemanticQuery(...))` over those projections returns `SemanticHit`
+  values. Each hit already carries a full `ArtifactLocator` (source revision,
+  artifact id, artifact kind, member id); the design keeps the locator and does
+  not collapse a hit to a bare `node_id`.
+- Seeds are locators, not node ids: `navigate(..., seed_locators=hits.locator)`.
+  Single-tree mode constrains the query with
+  `SemanticQuery(tree_id=artifact.id, artifact_kinds=[paper_navigation_tree])`
+  and rejects any seed whose artifact id does not match the artifact under
+  navigation, so a hit from another tree, a flat item, or a chunk cannot leak in.
+- Corpus mode (P3) navigates across artifacts and therefore keys seeds by the
+  full `(artifact_id, node_id)` locator, not node id alone.
 - Embeddings stay a coarse pre-filter. The agent may leave the seeded subtree,
-  and a hit never becomes an answer without the reasoning step. This is the
-  `TreeKnowledge` contract restated, not a new one.
-- The candidate source is pluggable. Pure-agentic navigation passes no seeds;
-  hybrid passes library seeds; a future corpus-level policy could pass seeds from
-  a different index without changing the navigation signature.
+  and a hit never becomes an answer without the reasoning step.
 
-Because the seed interface is just node ids, the pure-agentic MVP and the hybrid
-mode share one primitive; hybrid adds a shortlist step in front of it rather than
-a second retrieval path.
+Pure-agentic navigation passes no seeds; hybrid passes validated locator seeds.
+Both share one primitive; hybrid adds a shortlist step in front of it.
 
 ## Boundaries and Import Contracts
 
-Placement must satisfy the seven `import-linter` contracts. Relevant directions:
+Placement must satisfy the `import-linter` contracts. Relevant directions:
 `knowledge` is a leaf; `library` imports only `knowledge`; `rag` imports only
-`preprocess`; `flows` + `magic` is the apex.
+`preprocess`; `flows` + `magic` is the apex, and may import `mind`.
 
-- `quantmind.mind` does not exist yet and is only named as a forbidden import
-  inside the `library` and `rag` contracts. When implemented, add a contract
-  pinning `mind -> library -> knowledge`: `mind` may import `knowledge`,
-  `library`, `configs`, and `utils`, but not `flows`, `magic`, `rag`, or
-  `preprocess`. `library` and `rag` remain barred from importing `mind`.
+- When `mind` is implemented, add a contract pinning `mind -> library ->
+  knowledge`: `mind` may import `knowledge`, `library`, `configs`, and `utils`,
+  but not `flows`, `magic`, `rag`, or `preprocess`. `library` and `rag` remain
+  barred from importing `mind`.
+- The shared runtime that both `flows` and `mind` use lives at or below `mind`
+  (see [Shared Agent Runtime](#shared-agent-runtime)); the contract must permit
+  `flows -> mind` and forbid `mind -> flows`.
 - The stateless draft helper stays in `rag` and keeps `rag`'s
   imports-only-`preprocess` rule intact.
-- Canonical tree construction stays in `flows`, which already sits above
-  `knowledge` and `library`.
+- Canonical artifact construction stays in `flows`.
 
 The existing `## PageIndex Boundary` (library) and `## Collection Search and
-PageIndex` (rag) sections should cross-link this page and note that agentic,
-library-backed navigation is owned by `mind`, while `rag` remains draft-only.
+PageIndex` (rag) sections cross-link this page; agentic, library-backed
+navigation is owned by `mind`, while `rag` remains draft-only.
 
 ## Phasing
 
-Each phase is independently shippable and testable.
+Each phase is independently shippable and testable, and only P2 introduces
+embeddings.
 
-- **P0 — Build and persist.** Deterministic outline signals in `preprocess`, the
-  `Citation.end_page` addition, the `flows` structuring step producing a
-  verified canonical `TreeKnowledge` linked to a `PaperSourceRevision`, and
-  `library.put()` persistence with per-node projections.
-- **P1 — Agentic navigation.** The `mind.navigation` primitive with single-pass
-  classification and agentic traversal over the persisted tree, returning node
-  evidence. Uses the single model-resolution seam.
-- **P2 — Hybrid pre-filter.** Seed navigation from `library.search()` node hits.
-  No new storage; a shortlist step in front of P1.
-- **P3 — Corpus navigation.** Extend seeds and traversal across many documents.
-  Design-only here; it must not add a provider registry or a second store.
+- **P0 — Build and persist, vectorless.** Deterministic outline signals, the
+  `Citation.end_page` addition, the `PaperNavigationArtifact` with producer
+  identity and lineage, code-owned canonicalization and full integrity
+  validation, and library persistence **without** projections. No embedding
+  provider is required.
+- **P1 — Agentic navigation, vectorless.** The shared runtime relocation and the
+  `mind.navigation` primitive with single-pass and agentic traversal over the
+  persisted artifact, returning node evidence. Still no embeddings.
+- **P2 — Semantic projections and hybrid.** Build per-node projections as an
+  explicit step, then seed navigation from validated `search()` locators. This is
+  the first phase that needs an embedding provider.
+- **P3 — Corpus navigation.** Extend seeds and traversal across artifacts using
+  full locators. Design-only here; it must not add a provider registry or a
+  second store.
+
+## Acceptance and Evaluation
+
+Implementation is accepted against measurable criteria, not just green unit
+tests:
+
+- **Structure fixtures**: documents with a clean table of contents, with no
+  table of contents, with a printed page-number reset (roman front matter), and
+  with in-body cross-references. Each must build a valid, fully validated tree or
+  a declared flat fallback.
+- **Citation accuracy**: sampled node citations resolve to the correct source
+  pages above a stated accuracy floor.
+- **Evidence recall**: for a labelled question set, the fraction of gold evidence
+  nodes returned by navigation.
+- **Cost and latency**: model calls, tokens, and wall-clock for build and per
+  query, reported rather than assumed.
+- **Comparison**: pure-agentic vs hybrid vs the existing vector-search baseline
+  on the same question set, so the mode choice is evidence-backed.
 
 ## Relationship to Prior Art
 
@@ -259,10 +330,10 @@ Each phase is independently shippable and testable.
 recursive node subdivision, a node schema of title / id / page-range / summary /
 children, and two retrieval paths (single-pass node selection and an Agents-SDK
 tool loop). QuantMind reuses these mechanics where useful but keeps its own
-tree, financial-time, provenance, and citation contracts, and treats PDF content
-as untrusted input to structuring calls. Reuse of PageIndex code remains subject
-to license, dependency, and contract review; commodity mechanics are not
-reimplemented before that review.
+artifact identity, financial-time, provenance, and citation contracts, and
+treats PDF content as untrusted input to structuring calls. Reuse of PageIndex
+code remains subject to license, dependency, and contract review; commodity
+mechanics are not reimplemented before that review.
 
 A related internal system (FinMind / SmartAsk) validated a two-level
 document-then-page navigation with two-step model selection and measured gains

--- a/contexts/design/mind/navigation.md
+++ b/contexts/design/mind/navigation.md
@@ -1,0 +1,281 @@
+# Build and navigate page-preserving knowledge trees
+
+## Quick Summary
+
+- **Purpose**: Define how QuantMind builds a page-preserving, independently
+  versioned knowledge tree from a source-first paper and how a reasoning agent
+  navigates it, without embeddings replacing that reasoning.
+- **Read when**: Designing or changing PageIndex-style tree construction, the
+  `mind` navigation package, hybrid semantic-plus-agentic retrieval, or the
+  multi-provider model seam these use.
+- **Status**: Planned. No implementation exists on `master`. This page records
+  the accepted design and refines issue #95 for the source-first Paper Flow V1
+  model shipped in #120; the `quantmind.mind` package does not exist yet.
+- **Core rule**: Navigation reasons over titles and summaries; embeddings are a
+  coarse pre-filter, never a replacement. The tree is a rebuildable derived
+  artifact linked to an exact source, never a second canonical identity.
+- **Related work**: issues #95 (feature request), #71 (`mind` scaffold), #111
+  (`LocalKnowledgeLibrary`, closed), #120 (source-first Paper Flow V1);
+  prior art `VectifyAI/PageIndex` (MIT).
+
+## Contents
+
+- [Motivation](#motivation)
+- [Non-Goals](#non-goals)
+- [Ownership](#ownership)
+- [Tree Model](#tree-model)
+- [Build Pipeline](#build-pipeline)
+- [Navigation Retrieval](#navigation-retrieval)
+- [Multi-Model Compatibility](#multi-model-compatibility)
+- [Hybrid Search Compatibility](#hybrid-search-compatibility)
+- [Boundaries and Import Contracts](#boundaries-and-import-contracts)
+- [Phasing](#phasing)
+- [Relationship to Prior Art](#relationship-to-prior-art)
+- [Out of Scope](#out-of-scope)
+
+## Motivation
+
+Vector retrieval assumes the passage most similar to a query in embedding space
+is the most relevant one. For long, structured financial documents (10-K/10-Q
+filings, prospectuses, research reports) that assumption breaks in ways that
+matter: near-identical passages differ on a threshold, condition, or exception;
+fixed-size chunking fragments a table or a clause; a cross-reference such as
+"see Item 7A" shares no semantic similarity with its target; and a stateless
+retriever cannot use prior reasoning or conversation to decide where to look.
+
+Reasoning-based navigation reframes retrieval as relevance classification
+performed by the model over a document's real structure. The agent reads a
+tree of section titles and summaries, picks a branch, drills down, and lazily
+loads leaf text with exact page provenance. `quantmind.knowledge` already
+records this as the purpose of `TreeKnowledge`: "an agent reads the root
+summary plus children summaries, picks the most likely branch, drills down, and
+lazy-loads leaf content. Embeddings (when available) act as a coarse pre-filter,
+never as a replacement for that reasoning."
+
+This page defines how that capability is built and owned across packages so the
+pieces compose without a new framework.
+
+## Non-Goals
+
+Carried from issue #95 and the existing library and RAG boundaries:
+
+- A general-purpose RAG or PageIndex framework, provider registry, or retriever
+  hierarchy.
+- A second tree schema (`PageIndexNode`) or a generic `Document` model. The
+  design reuses `TreeKnowledge`, `TreeNode`, and `Citation`.
+- A second persistence layer or semantic index. Persistence and semantic
+  candidates stay in `LocalKnowledgeLibrary`.
+- Answer synthesis inside the navigation primitive. Navigation returns node
+  evidence; a caller composes an answer.
+- Making `Paper` a `TreeKnowledge` again. Paper Flow V1 deliberately has no
+  paper tree; a navigation tree is a separate, independently versioned artifact.
+
+## Ownership
+
+The feature is cross-cutting. Each existing package keeps its current
+responsibility; only the agentic traversal introduces a new owner, `mind`.
+
+| Owner | Responsibility |
+|---|---|
+| `quantmind.preprocess` | Preserve page boundaries and emit deterministic outline signals (heading candidates, table-of-contents pages, printed-to-physical page offset). No LLM calls. |
+| `quantmind.rag` | Optional stateless helper: propose a draft outline or navigation evidence from one `ParsedDocument`. Returns a bounded draft, never canonical identity. Imports only `preprocess`. |
+| `quantmind.knowledge` | Provide the canonical `TreeKnowledge` / `TreeNode` / `Citation` models and page provenance. No I/O, no retrieval-text choice. |
+| `quantmind.flows` | Build and enrich the canonical tree with the Agents SDK, linking it to an exact `PaperSourceRevision`. Persistence stays explicit. |
+| `quantmind.library` | Persist the canonical tree and provide semantic candidates through existing per-node projections. Adds no second store or index. |
+| `quantmind.mind` | Perform agentic traversal over titles and summaries and return node evidence. May request a semantic shortlist from `library`. |
+
+This resolves a prior tension. `contexts/design/library/local.md` and
+`contexts/design/rag/document.md` say a future PageIndex operation "may live
+under `quantmind.rag`". That remains true only for the stateless,
+document-local draft producer, because `rag` may import only `preprocess`. The
+stateful parts — building a persisted canonical tree and running hybrid,
+library-backed agentic navigation — sit above `library` and therefore belong to
+`flows` (build) and `mind` (navigate).
+
+## Tree Model
+
+The navigation tree is a canonical `TreeKnowledge` value, not a new schema.
+
+- `TreeNode` already carries `node_id`, `parent_id`, `position`, `title`,
+  `summary`, optional `content`, `citations`, and `children_ids`. A section maps
+  to a node; the ordered PDF pages it spans map to node `citations`.
+- Page provenance uses `Citation`. `Citation.page` is the 1-based inclusive
+  start. Add an optional `Citation.end_page`: an omitted end means one page, and
+  a present end must satisfy `end_page >= page`. This is the only canonical-model
+  change and matches issue #95.
+- The tree is a derived artifact, not a second identity. It sets `source` to the
+  same `SourceRef` as the paper it describes, sets `extraction` to the
+  building flow and model, and links every node's leaf text back to exact source
+  pages. It is independently versioned by its producer configuration, exactly as
+  `PaperChunkSet` and `PaperGlobalSummary` are.
+- `TreeKnowledge` navigation helpers (`root()`, `children_of()`, `walk_dfs()`,
+  `find_path()`) are the traversal surface; the navigation package adds no
+  parallel tree structure.
+
+A navigation tree is built from a `PaperSourceRevision` and its `PaperChunkSet`
+so that a node's `content` and page citations reuse already-validated chunk text
+and spans rather than re-parsing the PDF.
+
+## Build Pipeline
+
+Construction separates deterministic work from model work so page and outline
+facts stay reproducible and free of LLM cost.
+
+1. **Outline signals (`preprocess`, deterministic).** From the page-aware
+   `ParsedDocument`, detect table-of-contents pages, heading candidates, and the
+   printed-to-physical page offset. Emit ordered, page-anchored signals; make no
+   LLM call and no ranking decision.
+2. **Structuring (`flows`, Agents SDK).** An agent turns outline signals and
+   chunk text into a `TreeKnowledge`: section titles, hierarchy, per-node
+   summaries, and page-range citations. When no usable table of contents exists,
+   the agent proposes a hierarchy directly from content. Oversized sections are
+   split by bounded page and token budgets, mirroring PageIndex's recursive node
+   subdivision.
+3. **Verification (`flows`, deterministic guardrail).** Sample node titles and
+   confirm each claimed section actually begins on its cited page against
+   `ParsedDocument` evidence. Below an accuracy floor, fall back to a weaker
+   structuring mode or a flat single-level tree rather than emit an unverified
+   hierarchy.
+4. **Persistence (`library`).** `put()` stores the canonical `TreeKnowledge`
+   using existing `knowledge_items` / `knowledge_nodes` rows and produces one
+   aggregate projection plus one projection for every non-root node. No new
+   table is required for the MVP.
+
+Steps 1 and 3 hold no model dependency, so page and outline correctness are
+testable without a network. Step 2 is the only provider-dependent stage.
+
+## Navigation Retrieval
+
+Navigation lives in `quantmind.mind.navigation` and returns node evidence
+(locators, titles, page-cited content), never a synthesized answer. Two grains
+are supported, matching the two paths in the reference implementation.
+
+- **Single-pass classification.** Serialize the tree with node text stripped
+  (ids, titles, summaries, hierarchy only), ask the model once for the relevant
+  node ids, then load exact page-cited content for those nodes. Cheap and
+  bounded: two model calls independent of tree depth.
+- **Agentic traversal.** Expose SDK `@function_tool` functions over the tree —
+  `get_document_structure()` (tree without leaf text) and
+  `get_page_content(pages)` (exact page-cited leaf text) — and let an Agent
+  decide, turn by turn, which branch to open and when it has enough evidence.
+  This path can follow cross-references and use conversation state, at variable
+  model cost.
+
+Both run through the shared `flows._runner` observability wrapper so tracing,
+turn limits, and the memory hook behave as they do for every other agent. The
+navigation primitive takes a tree, a question, and an optional set of seed node
+ids (see [Hybrid Search Compatibility](#hybrid-search-compatibility)); it does
+not own persistence, embedding, or answer generation.
+
+## Multi-Model Compatibility
+
+The design must not hard-lock to one provider for either generation or
+embeddings. On `master` today `cfg.model` is a plain string passed straight to
+`agents.Agent(model=...)`, there is no provider-detection helper, and the only
+embedding provider is OpenAI. The design commits to two seams.
+
+- **One model-resolution seam for generation.** Structuring, single-pass
+  classification, and agentic traversal all take their model from
+  `BaseFlowCfg.model`. Provider resolution is centralized in one helper that maps
+  a model string to an SDK model, using the Agents SDK LiteLLM integration
+  (`agents.extensions.models.litellm_model.LitellmModel`, and the
+  `litellm/<provider>/<model>` convention) for non-OpenAI providers. `litellm`
+  is already a pinned dependency. No call site constructs a provider inline and
+  no per-flow model registry is added.
+- **Provider-agnostic embeddings for the hybrid pre-filter.** The library
+  already isolates embeddings behind the private `_EmbeddingProvider` Protocol
+  (`embed(texts, *, model, dimensions)` / `close()`). Hybrid navigation depends
+  only on that seam and on `SemanticQuery`/`SemanticHit`, never on a specific
+  embedding vendor. Promoting the seam to a supported swap point is a library
+  decision tracked separately; navigation must not assume OpenAI.
+
+Multi-model support is therefore a property of these two seams, not a provider
+registry or a retriever hierarchy — both explicit non-goals.
+
+## Hybrid Search Compatibility
+
+Hybrid retrieval — use semantic search to shortlist nodes, then let the agent
+reason over that shortlist — is a first-class future mode, and the current
+storage model already makes it nearly free.
+
+- When a navigation `TreeKnowledge` is stored, `library` produces one projection
+  for every non-root node. `search(SemanticQuery(...))` over those projections
+  returns `SemanticHit` values whose `node_id` identifies candidate nodes in the
+  same tree.
+- The navigation primitive accepts optional seed node ids. Hybrid mode is the
+  composition: run `library.search()`, map the hits' `node_id` values to seeds,
+  and start agentic traversal from those nodes instead of the root; the agent
+  still expands, drills down, and follows cross-references from there.
+- Embeddings stay a coarse pre-filter. The agent may leave the seeded subtree,
+  and a hit never becomes an answer without the reasoning step. This is the
+  `TreeKnowledge` contract restated, not a new one.
+- The candidate source is pluggable. Pure-agentic navigation passes no seeds;
+  hybrid passes library seeds; a future corpus-level policy could pass seeds from
+  a different index without changing the navigation signature.
+
+Because the seed interface is just node ids, the pure-agentic MVP and the hybrid
+mode share one primitive; hybrid adds a shortlist step in front of it rather than
+a second retrieval path.
+
+## Boundaries and Import Contracts
+
+Placement must satisfy the seven `import-linter` contracts. Relevant directions:
+`knowledge` is a leaf; `library` imports only `knowledge`; `rag` imports only
+`preprocess`; `flows` + `magic` is the apex.
+
+- `quantmind.mind` does not exist yet and is only named as a forbidden import
+  inside the `library` and `rag` contracts. When implemented, add a contract
+  pinning `mind -> library -> knowledge`: `mind` may import `knowledge`,
+  `library`, `configs`, and `utils`, but not `flows`, `magic`, `rag`, or
+  `preprocess`. `library` and `rag` remain barred from importing `mind`.
+- The stateless draft helper stays in `rag` and keeps `rag`'s
+  imports-only-`preprocess` rule intact.
+- Canonical tree construction stays in `flows`, which already sits above
+  `knowledge` and `library`.
+
+The existing `## PageIndex Boundary` (library) and `## Collection Search and
+PageIndex` (rag) sections should cross-link this page and note that agentic,
+library-backed navigation is owned by `mind`, while `rag` remains draft-only.
+
+## Phasing
+
+Each phase is independently shippable and testable.
+
+- **P0 — Build and persist.** Deterministic outline signals in `preprocess`, the
+  `Citation.end_page` addition, the `flows` structuring step producing a
+  verified canonical `TreeKnowledge` linked to a `PaperSourceRevision`, and
+  `library.put()` persistence with per-node projections.
+- **P1 — Agentic navigation.** The `mind.navigation` primitive with single-pass
+  classification and agentic traversal over the persisted tree, returning node
+  evidence. Uses the single model-resolution seam.
+- **P2 — Hybrid pre-filter.** Seed navigation from `library.search()` node hits.
+  No new storage; a shortlist step in front of P1.
+- **P3 — Corpus navigation.** Extend seeds and traversal across many documents.
+  Design-only here; it must not add a provider registry or a second store.
+
+## Relationship to Prior Art
+
+`VectifyAI/PageIndex` (MIT) validates the approach: table-of-contents detection,
+recursive node subdivision, a node schema of title / id / page-range / summary /
+children, and two retrieval paths (single-pass node selection and an Agents-SDK
+tool loop). QuantMind reuses these mechanics where useful but keeps its own
+tree, financial-time, provenance, and citation contracts, and treats PDF content
+as untrusted input to structuring calls. Reuse of PageIndex code remains subject
+to license, dependency, and contract review; commodity mechanics are not
+reimplemented before that review.
+
+A related internal system (FinMind / SmartAsk) validated a two-level
+document-then-page navigation with two-step model selection and measured gains
+over an embedding baseline on FinanceBench. This design generalizes that to a
+verified multi-level tree with exact page-range citations and a hybrid pre-filter
+rather than a fixed two levels.
+
+## Out of Scope
+
+- A second tree, node, or document schema; a `PaperTree` on `Paper`.
+- A public retriever, vector-store, provider registry, or query-engine hierarchy.
+- A second persistence or semantic-index layer.
+- Answer synthesis or agent memory inside the navigation primitive.
+- Corpus-level virtual nodes or query-time tree reconstruction (design only,
+  after single-document navigation ships).
+- Knowledge-graph construction.

--- a/contexts/design/mind/navigation.md
+++ b/contexts/design/mind/navigation.md
@@ -23,6 +23,7 @@
 ## Contents
 
 - [Motivation](#motivation)
+- [Design at a Glance](#design-at-a-glance)
 - [Ownership](#ownership)
 - [Navigation Tree Base and Paper Binding](#navigation-tree-base-and-paper-binding)
 - [Build Pipeline](#build-pipeline)
@@ -49,6 +50,44 @@ page provenance. `quantmind.knowledge` already records this as the purpose of
 `TreeKnowledge`, and embeddings there "act as a coarse pre-filter, never as a
 replacement for that reasoning."
 
+## Design at a Glance
+
+The build spine is solid; the dotted branch is the later hybrid path that adds
+embeddings. Each package owns one stage, and every deterministic or code-owned
+stage carries no model call.
+
+```mermaid
+flowchart TD
+    PD["ParsedDocument (page-aware)"]
+    subgraph PRE["preprocess — deterministic"]
+        OUT["outline signals: TOC / headings / page offset"]
+    end
+    subgraph FLW["flows"]
+        DRAFT["draft structuring agent (model, private draft)"]
+    end
+    subgraph KNW["knowledge"]
+        FD["PaperNavigationTree.from_draft() (code): mint ids, links, citations + validate() gate"]
+    end
+    subgraph LIB["library"]
+        PUT["put artifact: paper_artifacts (no embeddings)"]
+        PROJ["per-node projections (embeddings)"]
+        SRCH["search(SemanticQuery)"]
+        RES["resolve(locator): page-cited content"]
+    end
+    subgraph MND["mind"]
+        NAV["navigate(tree, question): single-pass / agentic"]
+    end
+    PD --> OUT
+    OUT --> DRAFT
+    DRAFT --> FD
+    FD --> PUT
+    PUT --> NAV
+    NAV -->|get_node_content| RES
+    PUT -.->|P2 projections| PROJ
+    PROJ -.->|candidates| SRCH
+    SRCH -.->|seed_locators| NAV
+```
+
 ## Ownership
 
 Each existing package keeps its responsibility; only agentic traversal introduces
@@ -69,6 +108,53 @@ LLM dependency and hosts no PageIndex draft producer.
 
 The tree structure is shared across document types; the identity binding is not.
 The design factors the two apart so the codebase keeps exactly one tree, not two.
+
+```mermaid
+classDiagram
+    class NavigationTree {
+        <<structural base>>
+        +UUID root_node_id
+        +Map nodes
+        +root()
+        +children_of()
+        +walk_dfs()
+        +find_path()
+        +validate()
+    }
+    class TreeNode {
+        +UUID node_id
+        +UUID parent_id
+        +str title
+        +str summary
+    }
+    class Citation {
+        +int page
+        +UUID node_id
+    }
+    class BaseKnowledge {
+        <<canonical identity>>
+    }
+    class TreeKnowledge
+    class PaperNavigationTree {
+        +PaperArtifactKind artifact_kind
+        +UUID source_revision_id
+        +str producer_config_hash
+        +str content_hash
+        +from_draft()
+    }
+    class PaperSourceRevision {
+        <<source-first anchor>>
+    }
+    class PaperChunkSet
+
+    NavigationTree <|-- TreeKnowledge
+    BaseKnowledge <|-- TreeKnowledge
+    NavigationTree <|-- PaperNavigationTree
+    NavigationTree *-- TreeNode : nodes
+    TreeNode *-- Citation : citations
+    PaperNavigationTree ..> PaperSourceRevision : source_revision_id
+    PaperNavigationTree ..> PaperChunkSet : lineage
+```
 
 `NavigationTree` is a structural base — a plain `BaseModel` with no
 `BaseKnowledge` identity: `root_node_id: UUID`, `nodes: dict[UUID, TreeNode]`, the

--- a/contexts/design/mind/navigation.md
+++ b/contexts/design/mind/navigation.md
@@ -9,10 +9,12 @@
 - **Status**: Planned. No implementation exists on `master`. This page records
   the accepted design and refines issue #95 for the source-first Paper Flow V1
   model shipped in #120; the `quantmind.mind` package does not exist yet.
-- **Core rule**: The tree is one more source-linked paper artifact with
-  code-owned identity and citations; the model returns only a draft, and code
-  validates every node. Navigation reasons over titles and summaries; embeddings
-  are a coarse pre-filter added later, never a replacement.
+- **Core rule**: One tree implementation. A shared `NavigationTree` base carries
+  structure, navigation, and the integrity gate; each document type subclasses it
+  for identity. The paper tree is a derived, source-linked artifact whose model
+  returns only a draft while code validates every node. Navigation reasons over
+  titles and summaries; embeddings are a coarse pre-filter added later, never a
+  replacement.
 - **Canonical models**: [Paper source and artifact design](../knowledge/paper.md).
 - **Related work**: issues #122 (context), #95 (feature request), #71 (`mind`
   scaffold), #120 (source-first Paper Flow V1); prior art `VectifyAI/PageIndex`
@@ -22,7 +24,7 @@
 
 - [Motivation](#motivation)
 - [Ownership](#ownership)
-- [Navigation Tree Artifact](#navigation-tree-artifact)
+- [Navigation Tree Base and Paper Binding](#navigation-tree-base-and-paper-binding)
 - [Build Pipeline](#build-pipeline)
 - [Navigation Retrieval](#navigation-retrieval)
 - [Multi-Model Compatibility](#multi-model-compatibility)
@@ -55,7 +57,7 @@ a new owner, `mind`. No shared runtime is moved and no second store is added.
 | Owner | Responsibility |
 |---|---|
 | `quantmind.preprocess` | Emit deterministic outline signals (heading candidates, table-of-contents pages, printed-to-physical page offset) from a parsed document. No LLM calls. |
-| `quantmind.knowledge` | Add one flat `PaperNavigationTree` artifact reusing `TreeNode` / `Citation`, with a `from_draft` constructor that mints identity and validates integrity. |
+| `quantmind.knowledge` | Add the `NavigationTree` structural base (reused by a refactored `TreeKnowledge`) plus a `PaperNavigationTree(NavigationTree)` artifact whose `from_draft` constructor mints identity and runs the shared integrity gate. |
 | `quantmind.flows` | Run one draft-structuring agent and call the knowledge constructor. Reuses `flows._runner` unchanged. Persistence stays explicit. |
 | `quantmind.library` | Persist the artifact through the existing paper artifact tables and extend `resolve()` to the new kind. Per-node projections are a separate later step. |
 | `quantmind.mind` | Traverse the tree with the Agents SDK and return node evidence. May request a semantic shortlist from `library`. |
@@ -63,27 +65,36 @@ a new owner, `mind`. No shared runtime is moved and no second store is added.
 `quantmind.rag` is unchanged: it stays deterministic chunking and BM25 with no
 LLM dependency and hosts no PageIndex draft producer.
 
-## Navigation Tree Artifact
+## Navigation Tree Base and Paper Binding
 
-The tree is a flat paper artifact, a sibling of `PaperChunkSet` and
-`PaperGlobalSummary`, not a nested `TreeKnowledge`. Nesting a `TreeKnowledge`
-would create two competing identities (the paper-artifact identity plus the
-inner model's own random `id`, mandatory `as_of`, and `source`), so the design
-carries the tree payload directly instead.
+The tree structure is shared across document types; the identity binding is not.
+The design factors the two apart so the codebase keeps exactly one tree, not two.
 
-`PaperNavigationTree` records:
+`NavigationTree` is a structural base — a plain `BaseModel` with no
+`BaseKnowledge` identity: `root_node_id: UUID`, `nodes: dict[UUID, TreeNode]`, the
+navigation surface (`root()`, `children_of()`, `walk_dfs()`, `find_path()`), and
+the `validate()` integrity gate. It carries no `id`, `as_of`, or `source`, so a
+subclass adds whatever identity its storage model needs without a second
+competing identity. The existing `TreeKnowledge` is refactored to
+`TreeKnowledge(BaseKnowledge, NavigationTree)` and reuses the same nodes,
+helpers, and gate instead of defining its own.
+
+A navigation tree is a derived artifact — rebuildable from a source plus a
+producer configuration, like `PaperChunkSet` — not canonical knowledge, so the
+paper binding is a paper artifact rather than a `TreeKnowledge` stored as a
+knowledge item. `PaperNavigationTree(NavigationTree)` adds:
 
 - `artifact_kind = PaperArtifactKind.NAVIGATION_TREE` and `schema_version`;
 - `source_revision_id` binding it to an exact `PaperSourceRevision`;
 - a `producer` config (model, prompt version, input chunk-set id, instructions
   hash, structuring bounds) and its `producer_config_hash`;
 - a `content_hash` over the canonical tree and lineage to the input
-  `PaperChunkSet` via `paper_artifact_lineage`;
-- `root_node_id: UUID` and `nodes: dict[UUID, TreeNode]` as its own fields.
+  `PaperChunkSet` via `paper_artifact_lineage`.
 
 A stable, source-and-producer-derived id makes an unchanged re-run idempotent and
 versions a changed configuration rather than overwriting it, exactly as the other
-paper artifacts behave.
+paper artifacts behave. A future document type adds its own `NavigationTree`
+subclass with its own source binding; nothing paper-specific leaks into the base.
 
 Page ranges reuse `Citation`: a node spanning pages 5-8 carries four
 `Citation(page=5..8)` entries on `TreeNode.citations`. No `end_page` field or new
@@ -106,12 +117,13 @@ call for the draft, and code-owned identity and validation.
    ids, links, or canonical citations, exactly like the summary draft.
 3. **Canonicalization and integrity gate (`knowledge`).**
    `PaperNavigationTree.from_draft(chunk_set, *, producer, draft)` mints node
-   ids, builds parent/child links, resolves each node's `Citation` entries from
-   the chunk set, and rejects any tree that is not single-rooted and acyclic with
-   every node reachable, bidirectional parent/child consistency, unique sibling
-   positions, no orphan, every cited page within the source, and every child's
-   cited pages contained in its parent's. A low structuring-quality signal falls
-   back to a flat single-level tree rather than an unverified hierarchy.
+   ids, builds parent/child links, and resolves each node's `Citation` entries
+   from the chunk set, then runs the shared `NavigationTree.validate()` gate. The
+   gate rejects any tree that is not single-rooted and acyclic with every node
+   reachable, bidirectional parent/child consistency, unique sibling positions,
+   no orphan, every cited page within the source, and every child's cited pages
+   contained in its parent's. A low structuring-quality signal falls back to a
+   flat single-level tree rather than an unverified hierarchy.
 4. **Persistence (`library`).** Store the artifact through the paper artifact
    tables. Persistence needs no embeddings.
 
@@ -123,11 +135,13 @@ Navigation lives in `quantmind.mind.navigation` and returns node evidence, never
 a synthesized answer:
 
 ```text
-navigate(artifact, question, *, library, cfg, seed_locators=None)
+navigate(tree, question, *, library, cfg, seed_locators=None)
   -> list[NavigationEvidence]
 ```
 
-Leaf content is resolved through the existing `LocalKnowledgeLibrary.resolve()`,
+`tree` is any `NavigationTree` — a `PaperNavigationTree` today. Navigation is
+written against the base, so a future document type reuses it unchanged. Leaf
+content is resolved through the existing `LocalKnowledgeLibrary.resolve()`,
 extended to the new artifact kind, so no parallel page-resolver concept is added.
 Two grains are supported:
 
@@ -204,8 +218,8 @@ non-OpenAI model to exercise the capability requirement.
 
 ## Out of Scope
 
-- a nested `TreeKnowledge`, a second tree or node schema, or a `PaperTree` on
-  `Paper`;
+- a nested `TreeKnowledge` inside an artifact, a second parallel tree
+  implementation, or a `PaperTree` on `Paper`;
 - a `Citation.end_page` field or a separate page-resolver concept;
 - a shared runtime module or moving `flows._runner`;
 - a public retriever, vector-store, provider registry, or query-engine hierarchy;

--- a/contexts/design/mind/navigation.md
+++ b/contexts/design/mind/navigation.md
@@ -1,352 +1,215 @@
-# Build and navigate page-preserving knowledge trees
+# Build and navigate a page-preserving paper tree
 
 ## Quick Summary
 
-- **Purpose**: Define how QuantMind builds a page-preserving, source-linked
-  navigation tree from a source-first paper and how a reasoning agent navigates
-  it, without embeddings replacing that reasoning.
+- **Purpose**: Define how a source-first paper gains a validated navigation tree
+  and how a reasoning agent traverses it, without embeddings replacing reasoning.
 - **Read when**: Designing or changing PageIndex-style tree construction, the
-  `mind` navigation package, the shared agent runtime seam, hybrid
-  semantic-plus-agentic retrieval, or the multi-provider model matrix.
+  `mind` navigation package, or hybrid semantic-plus-agentic retrieval.
 - **Status**: Planned. No implementation exists on `master`. This page records
   the accepted design and refines issue #95 for the source-first Paper Flow V1
   model shipped in #120; the `quantmind.mind` package does not exist yet.
-- **Core rule**: A navigation tree is a source-linked, independently versioned
-  artifact with code-owned identity, links, and citations. The model proposes a
-  draft; code validates every node. Navigation reasons over titles and
-  summaries; embeddings are a coarse pre-filter, never a replacement.
+- **Core rule**: The tree is one more source-linked paper artifact with
+  code-owned identity and citations; the model returns only a draft, and code
+  validates every node. Navigation reasons over titles and summaries; embeddings
+  are a coarse pre-filter added later, never a replacement.
+- **Canonical models**: [Paper source and artifact design](../knowledge/paper.md).
 - **Related work**: issues #122 (context), #95 (feature request), #71 (`mind`
-  scaffold), #111 (`LocalKnowledgeLibrary`, closed), #120 (source-first Paper
-  Flow V1); prior art `VectifyAI/PageIndex` (MIT).
+  scaffold), #120 (source-first Paper Flow V1); prior art `VectifyAI/PageIndex`
+  (MIT).
 
 ## Contents
 
 - [Motivation](#motivation)
-- [Non-Goals](#non-goals)
 - [Ownership](#ownership)
-- [Artifact Identity](#artifact-identity)
-- [Tree Model](#tree-model)
+- [Navigation Tree Artifact](#navigation-tree-artifact)
 - [Build Pipeline](#build-pipeline)
 - [Navigation Retrieval](#navigation-retrieval)
-- [Shared Agent Runtime](#shared-agent-runtime)
 - [Multi-Model Compatibility](#multi-model-compatibility)
 - [Hybrid Search Compatibility](#hybrid-search-compatibility)
 - [Boundaries and Import Contracts](#boundaries-and-import-contracts)
-- [Phasing](#phasing)
-- [Acceptance and Evaluation](#acceptance-and-evaluation)
-- [Relationship to Prior Art](#relationship-to-prior-art)
+- [Verification Slice](#verification-slice)
 - [Out of Scope](#out-of-scope)
 
 ## Motivation
 
 Vector retrieval assumes the passage most similar to a query in embedding space
-is the most relevant one. For long, structured financial documents (10-K/10-Q
-filings, prospectuses, research reports) that assumption breaks in ways that
-matter: near-identical passages differ on a threshold, condition, or exception;
-fixed-size chunking fragments a table or a clause; a cross-reference such as
-"see Item 7A" shares no semantic similarity with its target; and a stateless
-retriever cannot use prior reasoning or conversation to decide where to look.
+is the most relevant one. For long, structured financial documents that
+assumption breaks: near-identical passages differ on a threshold or exception;
+fixed-size chunking fragments a table; a cross-reference such as "see Item 7A"
+shares no similarity with its target; and a stateless retriever cannot use prior
+reasoning to decide where to look.
 
-Reasoning-based navigation reframes retrieval as relevance classification
-performed by the model over a document's real structure. The agent reads a tree
-of section titles and summaries, picks a branch, drills down, and lazily loads
-leaf text with exact page provenance. `quantmind.knowledge` already records this
-as the purpose of `TreeKnowledge`: "an agent reads the root summary plus
-children summaries, picks the most likely branch, drills down, and lazy-loads
-leaf content. Embeddings (when available) act as a coarse pre-filter, never as a
+Reasoning-based navigation reframes retrieval as relevance classification over a
+document's real structure: an agent reads a tree of section titles and
+summaries, picks a branch, drills down, and lazily loads leaf text with exact
+page provenance. `quantmind.knowledge` already records this as the purpose of
+`TreeKnowledge`, and embeddings there "act as a coarse pre-filter, never as a
 replacement for that reasoning."
-
-This page defines how that capability is built and owned across packages so the
-pieces compose without a new framework.
-
-## Non-Goals
-
-Carried from issue #95 and the existing library and RAG boundaries:
-
-- A general-purpose RAG or PageIndex framework, provider registry, or retriever
-  hierarchy.
-- A second tree schema (`PageIndexNode`) or a generic `Document` model. The tree
-  payload reuses `TreeKnowledge`, `TreeNode`, and `Citation`.
-- A second persistence layer or semantic index. Persistence and semantic
-  candidates stay in `LocalKnowledgeLibrary`.
-- Answer synthesis inside the navigation primitive. Navigation returns node
-  evidence; a caller composes an answer.
-- Making `Paper` a `TreeKnowledge` again. Paper Flow V1 deliberately has no
-  paper tree; a navigation tree is a separate, source-linked artifact.
 
 ## Ownership
 
-The feature is cross-cutting. Each existing package keeps its current
-responsibility; the agentic traversal introduces a new owner, `mind`, and the
-shared agent runtime moves below `flows`.
+Each existing package keeps its responsibility; only agentic traversal introduces
+a new owner, `mind`. No shared runtime is moved and no second store is added.
 
 | Owner | Responsibility |
 |---|---|
-| `quantmind.preprocess` | Preserve page boundaries and emit deterministic outline signals (heading candidates, table-of-contents pages, printed-to-physical page offset). No LLM calls. |
-| `quantmind.rag` | Optional stateless helper: propose a draft outline from one `ParsedDocument`. Returns a bounded draft, never canonical identity. Imports only `preprocess`. |
-| `quantmind.knowledge` | Provide the `TreeKnowledge` / `TreeNode` / `Citation` payload models and the `PaperNavigationArtifact` envelope with its validation rules. No I/O, no retrieval-text choice. |
-| `quantmind.flows` | Turn a model draft into a validated canonical artifact linked to an exact `PaperSourceRevision` and chunk set. Persistence stays explicit. |
-| `quantmind.library` | Persist the canonical artifact through the paper artifact tables and, as an explicit later step, build per-node projections. Adds no second store or index. |
-| `quantmind.mind` | Own the shared agent runtime seam and perform agentic traversal, returning node evidence. May request a semantic shortlist from `library`. |
+| `quantmind.preprocess` | Emit deterministic outline signals (heading candidates, table-of-contents pages, printed-to-physical page offset) from a parsed document. No LLM calls. |
+| `quantmind.knowledge` | Add one flat `PaperNavigationTree` artifact reusing `TreeNode` / `Citation`, with a `from_draft` constructor that mints identity and validates integrity. |
+| `quantmind.flows` | Run one draft-structuring agent and call the knowledge constructor. Reuses `flows._runner` unchanged. Persistence stays explicit. |
+| `quantmind.library` | Persist the artifact through the existing paper artifact tables and extend `resolve()` to the new kind. Per-node projections are a separate later step. |
+| `quantmind.mind` | Traverse the tree with the Agents SDK and return node evidence. May request a semantic shortlist from `library`. |
 
-This resolves a prior tension. `contexts/design/library/local.md` and
-`contexts/design/rag/document.md` say a future PageIndex operation "may live
-under `quantmind.rag`". That holds only for the stateless, document-local draft
-producer, because `rag` may import only `preprocess`. Building a persisted
-canonical artifact and running hybrid, library-backed navigation sit above
-`library` and belong to `flows` (build) and `mind` (navigate).
+`quantmind.rag` is unchanged: it stays deterministic chunking and BM25 with no
+LLM dependency and hosts no PageIndex draft producer.
 
-## Artifact Identity
+## Navigation Tree Artifact
 
-A navigation tree is a source-first artifact, not a bare `TreeKnowledge`. A
-plain `TreeKnowledge` cannot carry the identity the paper design requires: its
-`id` defaults to a random UUID, `ExtractionRef` records no producer
-configuration or input artifact, and `knowledge_items` has no link to
-`paper_sources` or `paper_artifact_lineage`. Persisting it with the conventional
-`put()` would make re-runs non-idempotent, allow a deleted source to orphan a
-tree, and hide the tree from `get_paper()`.
+The tree is a flat paper artifact, a sibling of `PaperChunkSet` and
+`PaperGlobalSummary`, not a nested `TreeKnowledge`. Nesting a `TreeKnowledge`
+would create two competing identities (the paper-artifact identity plus the
+inner model's own random `id`, mandatory `as_of`, and `source`), so the design
+carries the tree payload directly instead.
 
-The design therefore adds a `PaperNavigationArtifact` envelope, mirroring
-`PaperChunkSet` and `PaperGlobalSummary`:
+`PaperNavigationTree` records:
 
-- a new `PaperArtifactKind` value (for example `paper_navigation_tree`);
+- `artifact_kind = PaperArtifactKind.NAVIGATION_TREE` and `schema_version`;
 - `source_revision_id` binding it to an exact `PaperSourceRevision`;
 - a `producer` config (model, prompt version, input chunk-set id, instructions
-  hash, structuring bounds) and a `producer_config_hash`;
-- a `content_hash` over the canonical tree;
-- lineage to the input `PaperChunkSet` via `paper_artifact_lineage`;
-- a stable, content-derived artifact id, so an unchanged re-run is idempotent and
-  a changed producer configuration versions rather than overwrites.
+  hash, structuring bounds) and its `producer_config_hash`;
+- a `content_hash` over the canonical tree and lineage to the input
+  `PaperChunkSet` via `paper_artifact_lineage`;
+- `root_node_id: UUID` and `nodes: dict[UUID, TreeNode]` as its own fields.
 
-The envelope reuses `TreeKnowledge` / `TreeNode` as its payload; it does not
-introduce a second tree schema. It is persisted through the existing
-`paper_artifacts` / `paper_artifact_members` / `paper_artifact_lineage` tables
-(nodes as members), never `knowledge_items`, so identity, lineage, and
-fail-closed rehydration match every other paper artifact.
+A stable, source-and-producer-derived id makes an unchanged re-run idempotent and
+versions a changed configuration rather than overwriting it, exactly as the other
+paper artifacts behave.
 
-## Tree Model
-
-- `TreeNode` already carries `node_id`, `parent_id`, `position`, `title`,
-  `summary`, optional `content`, `citations`, and `children_ids`. A section maps
-  to a node; the ordered PDF pages it spans map to node `citations`.
-- Page provenance uses `Citation`. Add an optional `Citation.end_page`:
-  `Citation.page` is the 1-based inclusive start (constrained `>= 1`), an omitted
-  end means one page, a present end must satisfy `end_page >= page`, an end with
-  no start is rejected, and both must fall within the source page count.
-- A node's `content` and page citations reuse already-validated `PaperChunk`
-  text and `PaperSourceSpan` page numbers rather than re-parsing the PDF, so a
-  leaf never invents text or a page.
+Page ranges reuse `Citation`: a node spanning pages 5-8 carries four
+`Citation(page=5..8)` entries on `TreeNode.citations`. No `end_page` field or new
+range rule is added. A leaf does not copy chunk text; `TreeNode.content` stays
+empty and provenance is a citation pointing at the owning chunk, so source text
+is never duplicated into the tree.
 
 ## Build Pipeline
 
-Construction separates deterministic work from model work, and keeps canonical
-identity, links, and content in code rather than in model output.
+Construction mirrors `paper_flow`: deterministic work in code, one bounded model
+call for the draft, and code-owned identity and validation.
 
 1. **Outline signals (`preprocess`, deterministic).** From the page-aware
    `ParsedDocument`, detect table-of-contents pages, heading candidates, and the
    printed-to-physical page offset. Emit ordered, page-anchored signals; make no
-   LLM call and no ranking decision.
-2. **Draft structuring (`flows`, Agents SDK).** An agent proposes a *private
-   draft* hierarchy from outline signals and chunk text: titles, nesting, and
-   per-node draft summaries with candidate page ranges. The model output is never
-   canonical; it is the equivalent of `PaperCitationDraft`.
-3. **Canonicalization (`flows`, code-owned).** Code assigns node ids, builds
-   parent/child links, resolves each leaf's `content` and `citations` from the
-   `PaperChunkSet`, and assembles the `PaperNavigationArtifact` with its producer
-   identity and lineage.
-4. **Full integrity validation (`knowledge` + `flows`, deterministic).** Reject
-   any artifact that is not a single-rooted, acyclic tree with: every node
-   reachable from the root; bidirectional parent/child consistency; unique
-   sibling positions; no orphan or unreachable node; every citation range inside
-   the source page count; and every child page span contained in its parent's
-   span. This is the integrity gate. Title-appearance sampling is retained only
-   as a quality signal, not as the gate, and a low quality score falls back to a
-   flat single-level tree rather than emitting an unverified hierarchy.
-5. **Persistence (`library`).** Store the canonical `PaperNavigationArtifact`
-   through the paper artifact tables. Persistence does not require embeddings;
-   projections are a separate, explicit step (see
-   [Phasing](#phasing)).
+   LLM call.
+2. **Draft structuring (`flows`, one agent).** An agent proposes a private draft
+   hierarchy from outline signals and chunk summaries: titles, nesting, per-node
+   draft summaries, and candidate chunk indices per node. The draft chooses no
+   ids, links, or canonical citations, exactly like the summary draft.
+3. **Canonicalization and integrity gate (`knowledge`).**
+   `PaperNavigationTree.from_draft(chunk_set, *, producer, draft)` mints node
+   ids, builds parent/child links, resolves each node's `Citation` entries from
+   the chunk set, and rejects any tree that is not single-rooted and acyclic with
+   every node reachable, bidirectional parent/child consistency, unique sibling
+   positions, no orphan, every cited page within the source, and every child's
+   cited pages contained in its parent's. A low structuring-quality signal falls
+   back to a flat single-level tree rather than an unverified hierarchy.
+4. **Persistence (`library`).** Store the artifact through the paper artifact
+   tables. Persistence needs no embeddings.
 
-Steps 1, 3, and 4 hold no model dependency, so page, link, and content
-correctness are testable without a network. Step 2 is the only stage that calls
-a model.
+Steps 1, 3, and 4 have no model dependency and are testable without a network.
 
 ## Navigation Retrieval
 
-Navigation lives in `quantmind.mind.navigation` and returns node evidence
-(locators, titles, page-cited content), never a synthesized answer. Its inputs
-are explicit, so every tool it exposes is implementable:
+Navigation lives in `quantmind.mind.navigation` and returns node evidence, never
+a synthesized answer:
 
 ```text
-navigate(artifact, question, *, page_resolver, seed_locators=None)
+navigate(artifact, question, *, library, cfg, seed_locators=None)
   -> list[NavigationEvidence]
 ```
 
-- `artifact` is the `PaperNavigationArtifact` (tree payload plus identity, so
-  seed locators can be validated against it).
-- `page_resolver` resolves node or page content from the exact
-  `PaperSourceRevision` / `PaperChunkSet`. The tree is not page storage; leaf
-  text comes from the resolver, matching how the reference implementation reads
-  cached pages rather than reconstructing them from the tree.
-
+Leaf content is resolved through the existing `LocalKnowledgeLibrary.resolve()`,
+extended to the new artifact kind, so no parallel page-resolver concept is added.
 Two grains are supported:
 
-- **Single-pass selection.** Serialize the tree with node text stripped (ids,
-  titles, summaries, hierarchy only), make **one** model call for the relevant
-  node ids, then load exact page-cited content for those nodes through the
-  resolver in code. Cheap and predictable.
-- **Agentic traversal.** Expose SDK `@function_tool` functions —
-  `get_document_structure()` (tree without leaf text), `get_children(node_id)`
-  (progressive expansion for large trees), and `get_node_content(node_ids)`
-  (exact page-cited leaf text via the resolver) — and let an Agent decide, turn
-  by turn, which branch to open and when it has enough evidence. This path can
-  follow cross-references and use conversation state, at variable model cost.
+- **Single-pass selection.** Serialize the tree with leaf text stripped (ids,
+  titles, summaries, hierarchy), make **one** model call for the relevant node
+  ids, then resolve their page-cited content in code.
+- **Agentic traversal.** Expose two SDK `@function_tool` functions —
+  `get_document_structure()` (tree without leaf text) and
+  `get_node_content(node_ids)` (page-cited leaf text via `resolve()`) — and let an
+  Agent decide, turn by turn, which node to open and when it has enough evidence.
 
-Serializing the whole structure is bounded by node count, not depth, so large
-trees use a structure token budget plus `get_children()` progressive expansion
-rather than one giant blob. Both grains run through the shared runtime seam (see
-below) for tracing and turn limits.
-
-## Shared Agent Runtime
-
-Navigation must reuse the observability run wrapper and the model seam that
-`flows` uses, but `mind` may not import `flows`. The shared runtime therefore
-does not live in `flows`.
-
-Decision: place the run wrapper and model resolution in a shared module that both
-layers import downward — `quantmind.mind.runtime` (with `flows` depending on
-`mind`, which the contracts already permit) or a neutral `quantmind.runtime`
-module. The existing `flows._runner` moves there. `flows` and `mind.navigation`
-both call the shared runner; neither owns a private copy. This choice couples
-with the #71 `mind` scaffold and is a prerequisite for P1.
+Navigation calls `agents.Runner.run(...)` with its own `RunConfig` directly; it
+does not import `flows._runner`. Whole-tree serialization is bounded by a
+structure token budget over titles and summaries.
 
 ## Multi-Model Compatibility
 
-The design must not hard-lock to one provider for generation or embeddings. On
-`master` today `cfg.model` is a plain string passed straight to
-`agents.Agent(model=...)`, and the only embedding provider is OpenAI.
-
-- **Rely on the SDK, do not wrap it.** The Agents SDK already routes a
-  `litellm/<provider>/<model>` model string through its multi-provider support,
-  so the design adds no bespoke provider-resolution wrapper. `cfg.model` flows
-  unchanged into the shared runtime seam.
-- **Define a capability contract instead.** Each stage states what it needs from
-  a model: draft structuring needs reliable structured output; agentic traversal
-  needs tool-calling; all stages need usage reporting for the cost caps in
-  `BaseFlowCfg`. A provider that cannot meet a stage's contract is unsupported
-  for that stage, and this is covered by a provider test matrix (at least one
-  OpenAI and one non-OpenAI model across structuring and traversal), not by a
-  runtime abstraction.
-- **Provider-agnostic embeddings.** The library isolates embeddings behind the
-  private `_EmbeddingProvider` Protocol. Hybrid navigation depends only on that
-  seam and on `SemanticQuery` / `SemanticHit`, never on a specific vendor.
+- **Rely on the SDK.** `cfg.model` (a plain string, including a
+  `litellm/<provider>/<model>` value) flows unchanged into the SDK `Runner`,
+  which already routes multiple providers. No provider-resolution wrapper is
+  added.
+- **Capability requirement.** Draft structuring needs reliable structured output
+  and agentic traversal needs tool-calling; a provider that lacks the capability a
+  stage needs is unsupported for that stage. Tests cover at least one non-OpenAI
+  model across both stages.
+- **Embeddings.** The hybrid step depends only on the library's existing
+  `_EmbeddingProvider` seam and on `SemanticQuery` / `SemanticHit`, never on a
+  specific vendor.
 
 ## Hybrid Search Compatibility
 
-Hybrid retrieval — use semantic search to shortlist nodes, then let the agent
-reason over that shortlist — is a first-class later mode. It reuses locator
-identity end to end.
+Hybrid retrieval — shortlist nodes by semantic search, then reason over the
+shortlist — is a later, explicit step that reuses locator identity end to end. It
+is the only part that needs an embedding provider; build and pure-agentic
+navigation do not.
 
-- After a navigation artifact's nodes are projected (the explicit P2 step),
-  `search(SemanticQuery(...))` over those projections returns `SemanticHit`
-  values. Each hit already carries a full `ArtifactLocator` (source revision,
-  artifact id, artifact kind, member id); the design keeps the locator and does
-  not collapse a hit to a bare `node_id`.
-- Seeds are locators, not node ids: `navigate(..., seed_locators=hits.locator)`.
-  Single-tree mode constrains the query with
-  `SemanticQuery(tree_id=artifact.id, artifact_kinds=[paper_navigation_tree])`
-  and rejects any seed whose artifact id does not match the artifact under
-  navigation, so a hit from another tree, a flat item, or a chunk cannot leak in.
-- Corpus mode (P3) navigates across artifacts and therefore keys seeds by the
-  full `(artifact_id, node_id)` locator, not node id alone.
-- Embeddings stay a coarse pre-filter. The agent may leave the seeded subtree,
-  and a hit never becomes an answer without the reasoning step.
+- Building per-node projections is an explicit later step. Once built,
+  `search(SemanticQuery(...))` returns `SemanticHit` values that already carry a
+  full `ArtifactLocator`; the design keeps the locator and never collapses a hit
+  to a bare `node_id`.
+- Seeds are validated locators: `navigate(..., seed_locators=...)`. Single-tree
+  mode constrains the query with `tree_id = artifact.id` and rejects any seed
+  whose artifact id does not match, so a hit from another tree, a flat item, or a
+  chunk cannot leak in. Cross-artifact traversal keys seeds by the full
+  `(artifact_id, node_id)` locator.
+- Embeddings stay a coarse pre-filter: the agent may leave the seeded subtree, and
+  a hit never becomes an answer without the reasoning step.
 
-Pure-agentic navigation passes no seeds; hybrid passes validated locator seeds.
-Both share one primitive; hybrid adds a shortlist step in front of it.
+Pure-agentic navigation passes no seeds; hybrid adds one shortlist step in front
+of the same primitive.
 
 ## Boundaries and Import Contracts
 
-Placement must satisfy the `import-linter` contracts. Relevant directions:
-`knowledge` is a leaf; `library` imports only `knowledge`; `rag` imports only
-`preprocess`; `flows` + `magic` is the apex, and may import `mind`.
+Placement satisfies the existing `import-linter` contracts, which already forbid
+`library` and `rag` from importing `quantmind.mind`. When `mind` is implemented,
+add one contract pinning `mind -> library -> knowledge`: `mind` may import
+`knowledge`, `library`, `configs`, and `utils`, but not `flows`, `magic`, `rag`,
+or `preprocess`; `flows` may import `mind`. Nothing moves out of `flows`, and
+`rag` keeps its imports-only-`preprocess` rule.
 
-- When `mind` is implemented, add a contract pinning `mind -> library ->
-  knowledge`: `mind` may import `knowledge`, `library`, `configs`, and `utils`,
-  but not `flows`, `magic`, `rag`, or `preprocess`. `library` and `rag` remain
-  barred from importing `mind`.
-- The shared runtime that both `flows` and `mind` use lives at or below `mind`
-  (see [Shared Agent Runtime](#shared-agent-runtime)); the contract must permit
-  `flows -> mind` and forbid `mind -> flows`.
-- The stateless draft helper stays in `rag` and keeps `rag`'s
-  imports-only-`preprocess` rule intact.
-- Canonical artifact construction stays in `flows`.
+## Verification Slice
 
-The existing `## PageIndex Boundary` (library) and `## Collection Search and
-PageIndex` (rag) sections cross-link this page; agentic, library-backed
-navigation is owned by `mind`, while `rag` remains draft-only.
+Offline tests use fixed generated PDFs and a fake structuring provider. They
+cover a clean table of contents, a missing table of contents, a printed
+page-number reset, and an in-body cross-reference; integrity rejection of cyclic,
+orphaned, and out-of-page-range trees; stable ids and idempotent re-runs; citation
+resolution to correct pages; reopen behavior; and, once projections exist, seeded
+hybrid navigation with locator validation.
 
-## Phasing
-
-Each phase is independently shippable and testable, and only P2 introduces
-embeddings.
-
-- **P0 — Build and persist, vectorless.** Deterministic outline signals, the
-  `Citation.end_page` addition, the `PaperNavigationArtifact` with producer
-  identity and lineage, code-owned canonicalization and full integrity
-  validation, and library persistence **without** projections. No embedding
-  provider is required.
-- **P1 — Agentic navigation, vectorless.** The shared runtime relocation and the
-  `mind.navigation` primitive with single-pass and agentic traversal over the
-  persisted artifact, returning node evidence. Still no embeddings.
-- **P2 — Semantic projections and hybrid.** Build per-node projections as an
-  explicit step, then seed navigation from validated `search()` locators. This is
-  the first phase that needs an embedding provider.
-- **P3 — Corpus navigation.** Extend seeds and traversal across artifacts using
-  full locators. Design-only here; it must not add a provider registry or a
-  second store.
-
-## Acceptance and Evaluation
-
-Implementation is accepted against measurable criteria, not just green unit
-tests:
-
-- **Structure fixtures**: documents with a clean table of contents, with no
-  table of contents, with a printed page-number reset (roman front matter), and
-  with in-body cross-references. Each must build a valid, fully validated tree or
-  a declared flat fallback.
-- **Citation accuracy**: sampled node citations resolve to the correct source
-  pages above a stated accuracy floor.
-- **Evidence recall**: for a labelled question set, the fraction of gold evidence
-  nodes returned by navigation.
-- **Cost and latency**: model calls, tokens, and wall-clock for build and per
-  query, reported rather than assumed.
-- **Comparison**: pure-agentic vs hybrid vs the existing vector-search baseline
-  on the same question set, so the mode choice is evidence-backed.
-
-## Relationship to Prior Art
-
-`VectifyAI/PageIndex` (MIT) validates the approach: table-of-contents detection,
-recursive node subdivision, a node schema of title / id / page-range / summary /
-children, and two retrieval paths (single-pass node selection and an Agents-SDK
-tool loop). QuantMind reuses these mechanics where useful but keeps its own
-artifact identity, financial-time, provenance, and citation contracts, and
-treats PDF content as untrusted input to structuring calls. Reuse of PageIndex
-code remains subject to license, dependency, and contract review; commodity
-mechanics are not reimplemented before that review.
-
-A related internal system (FinMind / SmartAsk) validated a two-level
-document-then-page navigation with two-step model selection and measured gains
-over an embedding baseline on FinanceBench. This design generalizes that to a
-verified multi-level tree with exact page-range citations and a hybrid pre-filter
-rather than a fixed two levels.
+A bounded live slice builds a navigation tree over one exact arXiv revision with a
+real model, traverses it single-pass and agentically, and prints the selected
+titles, resolved page-cited content, and citation pages. It runs at least one
+non-OpenAI model to exercise the capability requirement.
 
 ## Out of Scope
 
-- A second tree, node, or document schema; a `PaperTree` on `Paper`.
-- A public retriever, vector-store, provider registry, or query-engine hierarchy.
-- A second persistence or semantic-index layer.
-- Answer synthesis or agent memory inside the navigation primitive.
-- Corpus-level virtual nodes or query-time tree reconstruction (design only,
-  after single-document navigation ships).
-- Knowledge-graph construction.
+- a nested `TreeKnowledge`, a second tree or node schema, or a `PaperTree` on
+  `Paper`;
+- a `Citation.end_page` field or a separate page-resolver concept;
+- a shared runtime module or moving `flows._runner`;
+- a public retriever, vector-store, provider registry, or query-engine hierarchy;
+- a second persistence or semantic-index layer;
+- answer synthesis or agent memory inside the navigation primitive;
+- corpus-level virtual nodes or query-time tree reconstruction;
+- knowledge-graph construction.

--- a/contexts/design/mind/retrieval.md
+++ b/contexts/design/mind/retrieval.md
@@ -1,18 +1,18 @@
-# Build and navigate a page-preserving structure tree
+# Build and retrieve from a page-preserving structure tree
 
 ## Quick Summary
 
 - **Purpose**: Define how a source-first paper gains a validated structure tree
   and how a reasoning agent traverses it, without embeddings replacing reasoning.
 - **Read when**: Designing or changing PageIndex-style tree construction, the
-  `mind` navigation package, or hybrid semantic-plus-agentic retrieval.
+  `mind` retrieval package, or hybrid semantic-plus-agentic retrieval.
 - **Status**: Planned. No implementation exists on `master`. This page records
   the accepted design and refines issue #95 for the source-first Paper Flow V1
   model shipped in #120; the `quantmind.mind` package does not exist yet.
 - **Core rule**: One tree implementation. A shared `StructureTree` base carries
-  structure, navigation, and the integrity gate; each document type subclasses it
+  structure, traversal, and the integrity gate; each document type subclasses it
   for identity. The paper structure tree is a derived, source-linked artifact whose model
-  returns only a draft while code validates every node. Navigation reasons over
+  returns only a draft while code validates every node. Retrieval reasons over
   titles and summaries; embeddings are a coarse pre-filter added later, never a
   replacement.
 - **Canonical models**: [Paper source and artifact design](../knowledge/paper.md).
@@ -27,7 +27,7 @@
 - [Ownership](#ownership)
 - [Structure Tree Base and Paper Binding](#structure-tree-base-and-paper-binding)
 - [Build Pipeline](#build-pipeline)
-- [Navigation Retrieval](#navigation-retrieval)
+- [Retrieval](#retrieval)
 - [Multi-Model Compatibility](#multi-model-compatibility)
 - [Hybrid Search Compatibility](#hybrid-search-compatibility)
 - [Boundaries and Import Contracts](#boundaries-and-import-contracts)
@@ -43,7 +43,7 @@ fixed-size chunking fragments a table; a cross-reference such as "see Item 7A"
 shares no similarity with its target; and a stateless retriever cannot use prior
 reasoning to decide where to look.
 
-Reasoning-based navigation reframes retrieval as relevance classification over a
+Reasoning-based retrieval reframes the problem as relevance classification over a
 document's real structure: an agent reads a tree of section titles and
 summaries, picks a branch, drills down, and lazily loads leaf text with exact
 page provenance. `quantmind.knowledge` already records this as the purpose of
@@ -75,7 +75,7 @@ flowchart TD
         RES["resolve(locator): page-cited content"]
     end
     subgraph MND["mind"]
-        NAV["navigate(structure, question): single-pass / agentic"]
+        NAV["retrieve(structure, question): single-pass / agentic"]
     end
     PD --> OUT
     OUT --> DRAFT
@@ -158,7 +158,7 @@ classDiagram
 
 `StructureTree` is a structural base — a plain `BaseModel` with no
 `BaseKnowledge` identity: `root_node_id: UUID`, `nodes: dict[UUID, TreeNode]`, the
-navigation surface (`root()`, `children_of()`, `walk_dfs()`, `find_path()`), and
+traversal surface (`root()`, `children_of()`, `walk_dfs()`, `find_path()`), and
 the `validate()` integrity gate. It carries no `id`, `as_of`, or `source`, so a
 subclass adds whatever identity its storage model needs without a second
 competing identity. The existing `TreeKnowledge` is refactored to
@@ -215,17 +215,17 @@ call for the draft, and code-owned identity and validation.
 
 Steps 1, 3, and 4 have no model dependency and are testable without a network.
 
-## Navigation Retrieval
+## Retrieval
 
-Navigation lives in `quantmind.mind.navigation` and returns node evidence, never
+Retrieval lives in `quantmind.mind.retrieval` and returns node evidence, never
 a synthesized answer:
 
 ```text
-navigate(structure, question, *, library, cfg, seed_locators=None)
-  -> list[NavigationEvidence]
+retrieve(structure, question, *, library, cfg, seed_locators=None)
+  -> list[RetrievalEvidence]
 ```
 
-`structure` is any `StructureTree` — a `PaperStructureTree` today. Navigation is
+`structure` is any `StructureTree` — a `PaperStructureTree` today. Retrieval is
 written against the base, so a future document type reuses it unchanged. Leaf
 content is resolved through the existing `LocalKnowledgeLibrary.resolve()`,
 extended to the new artifact kind, so no parallel page-resolver concept is added.
@@ -239,7 +239,7 @@ Two grains are supported:
   `get_node_content(node_ids)` (page-cited leaf text via `resolve()`) — and let an
   Agent decide, turn by turn, which node to open and when it has enough evidence.
 
-Navigation calls `agents.Runner.run(...)` with its own `RunConfig` directly; it
+Retrieval calls `agents.Runner.run(...)` with its own `RunConfig` directly; it
 does not import `flows._runner`. Whole-tree serialization is bounded by a
 structure token budget over titles and summaries.
 
@@ -262,13 +262,13 @@ structure token budget over titles and summaries.
 Hybrid retrieval — shortlist nodes by semantic search, then reason over the
 shortlist — is a later, explicit step that reuses locator identity end to end. It
 is the only part that needs an embedding provider; build and pure-agentic
-navigation do not.
+retrieval do not.
 
 - Building per-node projections is an explicit later step. Once built,
   `search(SemanticQuery(...))` returns `SemanticHit` values that already carry a
   full `ArtifactLocator`; the design keeps the locator and never collapses a hit
   to a bare `node_id`.
-- Seeds are validated locators: `navigate(..., seed_locators=...)`. Single-tree
+- Seeds are validated locators: `retrieve(..., seed_locators=...)`. Single-tree
   mode constrains the query with `tree_id = artifact.id` and rejects any seed
   whose artifact id does not match, so a hit from another tree, a flat item, or a
   chunk cannot leak in. Cross-artifact traversal keys seeds by the full
@@ -276,7 +276,7 @@ navigation do not.
 - Embeddings stay a coarse pre-filter: the agent may leave the seeded subtree, and
   a hit never becomes an answer without the reasoning step.
 
-Pure-agentic navigation passes no seeds; hybrid adds one shortlist step in front
+Pure-agentic retrieval passes no seeds; hybrid adds one shortlist step in front
 of the same primitive.
 
 ## Boundaries and Import Contracts
@@ -295,7 +295,7 @@ cover a clean table of contents, a missing table of contents, a printed
 page-number reset, and an in-body cross-reference; integrity rejection of cyclic,
 orphaned, and out-of-page-range trees; stable ids and idempotent re-runs; citation
 resolution to correct pages; reopen behavior; and, once projections exist, seeded
-hybrid navigation with locator validation.
+hybrid retrieval with locator validation.
 
 A bounded live slice builds a structure tree over one exact arXiv revision with a
 real model, traverses it single-pass and agentically, and prints the selected
@@ -310,6 +310,6 @@ non-OpenAI model to exercise the capability requirement.
 - a shared runtime module or moving `flows._runner`;
 - a public retriever, vector-store, provider registry, or query-engine hierarchy;
 - a second persistence or semantic-index layer;
-- answer synthesis or agent memory inside the navigation primitive;
+- answer synthesis or agent memory inside the retrieval primitive;
 - corpus-level virtual nodes or query-time tree reconstruction;
 - knowledge-graph construction.

--- a/contexts/design/preprocess/pdf.md
+++ b/contexts/design/preprocess/pdf.md
@@ -31,6 +31,6 @@ Preprocessing ends after producing `ParsedDocument`. It does not chunk, index, r
 
 - [`quantmind.rag`](../rag/document.md) converts the parsed value into LlamaIndex-backed chunks and page-aware retrieval evidence.
 - [`paper_flow`](../flow/paper.md) uses the preserved source pages to build an exact source revision and a canonical chunk set before generating a cited summary.
-- A future PageIndex adapter may consume the same ordered pages to propose independently versioned navigation evidence.
+- A future PageIndex adapter may consume the same ordered pages to propose independently versioned outline signals for a structure tree.
 
 Flattened Markdown remains a compatibility view produced from the preserved pages. It is not the primary parsing result.

--- a/contexts/design/rag/document.md
+++ b/contexts/design/rag/document.md
@@ -56,7 +56,7 @@ The conversion replaces parser paths with canonical source asset IDs and validat
 
 Document-local RAG and collection search have different responsibilities. [`LocalKnowledgeLibrary`](../library/local.md) stores canonical sources and artifacts in SQLite and privately uses LlamaIndex for collection-wide embedding ranking. It does not persist transient `ParsedDocumentHit` values.
 
-Paper Flow V1 defines no paper tree. A PageIndex-style structure tree is not a RAG operation: deterministic outline signals live in `quantmind.preprocess`, building the persisted canonical tree lives in `quantmind.flows`, and library-backed agentic navigation lives in `quantmind.mind`. `quantmind.rag` stays deterministic chunking and BM25 with no LLM dependency and hosts no draft producer. See [Build and navigate a page-preserving structure tree](../mind/navigation.md). Canonical IDs, links, citations, and source-backed text remain code-owned throughout.
+Paper Flow V1 defines no paper tree. A PageIndex-style structure tree is not a RAG operation: deterministic outline signals live in `quantmind.preprocess`, building the persisted canonical tree lives in `quantmind.flows`, and library-backed agentic retrieval lives in `quantmind.mind`. `quantmind.rag` stays deterministic chunking and BM25 with no LLM dependency and hosts no draft producer. See [Build and retrieve from a page-preserving structure tree](../mind/retrieval.md). Canonical IDs, links, citations, and source-backed text remain code-owned throughout.
 
 ## What This Package Does Not Abstract
 

--- a/contexts/design/rag/document.md
+++ b/contexts/design/rag/document.md
@@ -56,7 +56,7 @@ The conversion replaces parser paths with canonical source asset IDs and validat
 
 Document-local RAG and collection search have different responsibilities. [`LocalKnowledgeLibrary`](../library/local.md) stores canonical sources and artifacts in SQLite and privately uses LlamaIndex for collection-wide embedding ranking. It does not persist transient `ParsedDocumentHit` values.
 
-Paper Flow V1 defines no paper tree. A future PageIndex implementation may live under `quantmind.rag` as another opinionated document operation. It may consume `ParsedDocument` or an exact paper source and return a bounded draft or navigation evidence, while canonical IDs, links, citations, and source-backed text remain code-owned.
+Paper Flow V1 defines no paper tree. Under `quantmind.rag`, a future PageIndex helper is limited to a stateless document-local operation: it may consume `ParsedDocument` and return a bounded draft outline or navigation evidence, because `rag` may import only `preprocess`. Building a persisted canonical tree and running library-backed agentic navigation sit above `library` and are owned by `quantmind.flows` and `quantmind.mind`. See [Build and navigate page-preserving knowledge trees](../mind/navigation.md). Canonical IDs, links, citations, and source-backed text remain code-owned throughout.
 
 ## What This Package Does Not Abstract
 

--- a/contexts/design/rag/document.md
+++ b/contexts/design/rag/document.md
@@ -56,7 +56,7 @@ The conversion replaces parser paths with canonical source asset IDs and validat
 
 Document-local RAG and collection search have different responsibilities. [`LocalKnowledgeLibrary`](../library/local.md) stores canonical sources and artifacts in SQLite and privately uses LlamaIndex for collection-wide embedding ranking. It does not persist transient `ParsedDocumentHit` values.
 
-Paper Flow V1 defines no paper tree. A PageIndex-style navigation tree is not a RAG operation: deterministic outline signals live in `quantmind.preprocess`, building the persisted canonical tree lives in `quantmind.flows`, and library-backed agentic navigation lives in `quantmind.mind`. `quantmind.rag` stays deterministic chunking and BM25 with no LLM dependency and hosts no draft producer. See [Build and navigate a page-preserving paper tree](../mind/navigation.md). Canonical IDs, links, citations, and source-backed text remain code-owned throughout.
+Paper Flow V1 defines no paper tree. A PageIndex-style structure tree is not a RAG operation: deterministic outline signals live in `quantmind.preprocess`, building the persisted canonical tree lives in `quantmind.flows`, and library-backed agentic navigation lives in `quantmind.mind`. `quantmind.rag` stays deterministic chunking and BM25 with no LLM dependency and hosts no draft producer. See [Build and navigate a page-preserving structure tree](../mind/navigation.md). Canonical IDs, links, citations, and source-backed text remain code-owned throughout.
 
 ## What This Package Does Not Abstract
 

--- a/contexts/design/rag/document.md
+++ b/contexts/design/rag/document.md
@@ -56,7 +56,7 @@ The conversion replaces parser paths with canonical source asset IDs and validat
 
 Document-local RAG and collection search have different responsibilities. [`LocalKnowledgeLibrary`](../library/local.md) stores canonical sources and artifacts in SQLite and privately uses LlamaIndex for collection-wide embedding ranking. It does not persist transient `ParsedDocumentHit` values.
 
-Paper Flow V1 defines no paper tree. Under `quantmind.rag`, a future PageIndex helper is limited to a stateless document-local operation: it may consume `ParsedDocument` and return a bounded draft outline or navigation evidence, because `rag` may import only `preprocess`. Building a persisted canonical tree and running library-backed agentic navigation sit above `library` and are owned by `quantmind.flows` and `quantmind.mind`. See [Build and navigate page-preserving knowledge trees](../mind/navigation.md). Canonical IDs, links, citations, and source-backed text remain code-owned throughout.
+Paper Flow V1 defines no paper tree. A PageIndex-style navigation tree is not a RAG operation: deterministic outline signals live in `quantmind.preprocess`, building the persisted canonical tree lives in `quantmind.flows`, and library-backed agentic navigation lives in `quantmind.mind`. `quantmind.rag` stays deterministic chunking and BM25 with no LLM dependency and hosts no draft producer. See [Build and navigate a page-preserving paper tree](../mind/navigation.md). Canonical IDs, links, citations, and source-backed text remain code-owned throughout.
 
 ## What This Package Does Not Abstract
 


### PR DESCRIPTION
## What this is

A **design-only** PR. It adds `contexts/design/mind/retrieval.md`, the accepted design for PageIndex-style, vectorless / reasoning-based retrieval over page-preserving document structure trees, and cross-links the existing knowledge, library, and RAG boundary sections. No implementation and no `quantmind` code changes.

Context and investigation are in #122.

## Decisions

- **Naming follows upstream PageIndex.** The type is `StructureTree` (not `NavigationTree`) and the operation is `retrieve()` (not `navigate()`). PageIndex's own code calls the tree `structure` (exposed as `get_document_structure()`) and frames the query path as *reasoning-based retrieval* / *tree search*; it uses "navigate" only as a human metaphor. The type names what the thing *is* (a structure); the operation names the caller's intent (retrieve). "artifact" is kept — it is the existing master term (`PaperArtifactKind`, `paper_artifacts`, `ArtifactLocator`, `PaperChunkSet`/`PaperGlobalSummary`) and standard in build/CI/ML tooling.
- **One tree implementation, factored for reuse.** A shared `StructureTree` structural base (a plain `BaseModel` with no `BaseKnowledge` identity) owns `root_node_id` / `nodes`, the traversal surface (`root` / `children_of` / `walk_dfs` / `find_path`), and the `validate()` integrity gate. The existing `TreeKnowledge` is refactored to `TreeKnowledge(BaseKnowledge, StructureTree)` so the codebase keeps one tree, not two. Other long-document types will subclass the same base.
- **The paper tree is a derived artifact, not canonical knowledge.** A structure tree is rebuildable from a source plus a producer configuration (like `PaperChunkSet`), so `PaperStructureTree(StructureTree)` is a paper artifact — `source_revision_id`, `producer` + `producer_config_hash`, `content_hash`, and chunk-set lineage — with a `from_draft` constructor that mints identity and runs the shared gate. It is not a `TreeKnowledge` stored as a knowledge item, and it is not a nested `TreeKnowledge` (which would create a second competing identity).
- **Page ranges reuse `Citation`.** A node spanning pages 5-8 carries four `Citation(page=5..8)` entries on `TreeNode.citations`; no `Citation.end_page` field is added. Leaves do not copy chunk text into the tree — content is resolved on demand, so source text is never duplicated.
- **`retrieve()` is written against the base.** `retrieve(structure, question, *, library, cfg, seed_locators=None)` reasons over titles and summaries and resolves leaf content through the existing `LocalKnowledgeLibrary.resolve()` (extended to the new kind) — no separate page-resolver, and no shared-runtime module: `mind.retrieval` calls `agents.Runner.run` directly rather than importing `flows._runner`.
- **Ownership** that satisfies the import-linter contracts: `preprocess` emits deterministic outline signals (no LLM); `knowledge` owns the `StructureTree` base + `PaperStructureTree`; `flows` runs one draft-structuring agent and calls the knowledge constructor (reusing `flows._runner` unchanged); `library` persists the artifact and extends `resolve()`; `mind` owns agentic retrieval. `rag` stays deterministic chunking + BM25 and hosts no PageIndex draft producer.

## Requirements baked in

- **Multi-model compatibility.** `cfg.model` (including a `litellm/<provider>/<model>` value) flows unchanged into the SDK `Runner`, which already routes providers — no bespoke resolver wrapper. Draft structuring needs structured output and agentic retrieval needs tool-calling; the provider test matrix covers at least one non-OpenAI model across both stages. Embeddings stay behind the library's existing `_EmbeddingProvider` seam.
- **Hybrid search compatibility.** Building per-node projections is an explicit later step; once built, `search()` returns `SemanticHit` values that keep a full `ArtifactLocator`. `retrieve(..., seed_locators=...)` seeds agentic retrieval from validated locators (single-tree mode constrains `tree_id` and rejects mismatched artifacts; cross-artifact mode keys by `(artifact_id, node_id)`). Embeddings stay a coarse pre-filter, never a replacement. Build and pure-agentic retrieval need no embedding provider.

## Diagrams

Two single-purpose Mermaid diagrams demonstrate a convention for `contexts/design`: a `classDiagram` for the type model (the `StructureTree` base and its subclasses) and a `flowchart` for the cross-package build-to-retrieve spine with a dotted hybrid branch. Both are theme-neutral and label edges with meaning.

## Occam pass

An independent no-context review flagged an earlier draft for multiplying entities. This version drops a shared-runtime module and the `flows._runner` move, drops `Citation.end_page`, drops a `rag` draft-helper allowance, folds a separate page-resolver into `resolve()`, and compresses the process sections to the corpus's `Verification Slice` style. Net new surface is one package (`quantmind.mind`) and one knowledge base + subclass; everything else reuses `TreeNode`, `Citation`, `ArtifactLocator`, the paper artifact tables, `resolve()`, the `from_draft` pattern, and `flows._runner` unchanged.

## Not in this PR

- No `quantmind.mind` package, no code, no tests, no dependency changes.
- The `mind -> library -> knowledge` import-linter contract lands with the implementation (depends on #71).

Closes #122. Refines #95. Depends on #71.
