### PR TITLE
fix(preprocess): parse shared exchange ticker lists

### DIFF
--- a/quantmind/preprocess/news.py
+++ b/quantmind/preprocess/news.py
@@ -56,6 +56,9 @@ _MARKDOWN_EMPHASIS_RE = re.compile(
     r"(?<!\*)\*{1,2}([A-Z][A-Z0-9.-]{0,9})\*{1,2}(?!\*)",
     re.IGNORECASE,
 )
+_SHARED_EXCHANGE_SYMBOL_RE = re.compile(
+    r"\s*,\s*([A-Z][A-Z0-9.-]{0,9})",
+)
 _EMAIL_PROTECTION_LINK_RE = re.compile(
     r"\[\[email protected]\]\(/cdn-cgi/l/email-protection#[^)]+\)"
 )
@@ -401,8 +404,9 @@ def canonicalize_source_url(url: str) -> str:
 def extract_exchange_ticker_hints(text: str) -> tuple[NewsTickerHint, ...]:
     """Extract exchange-qualified ticker mentions from PR-style text.
 
-    Examples matched include ``(NASDAQ: NVDA)`` and ``NYSE: IBM``. The result is
-    only a hint; downstream instrument resolution should still validate it.
+    Examples matched include ``(NASDAQ: NVDA)``, ``NYSE: IBM``, and a
+    parenthesized comma list such as ``(NYSE: EVEX, EVEXW)``. The result is only
+    a hint; downstream instrument resolution should still validate it.
     Markdown link and emphasis decoration is removed from a scan-only copy so
     stored news text and its content hash retain their original representation.
     """
@@ -425,6 +429,32 @@ def extract_exchange_ticker_hints(text: str) -> tuple[NewsTickerHint, ...]:
                 raw=match.group(0).strip(),
             )
         )
+        matched_text = match.group(0)
+        if not matched_text.lstrip().startswith(
+            "("
+        ) or matched_text.rstrip().endswith(")"):
+            continue
+
+        closing_parenthesis = scan_text.find(")", match.end())
+        if closing_parenthesis == -1:
+            continue
+        suffix = scan_text[match.end() : closing_parenthesis]
+        position = 0
+        while continuation := _SHARED_EXCHANGE_SYMBOL_RE.match(
+            suffix, position
+        ):
+            symbol = continuation.group(1).upper()
+            key = (symbol, exchange)
+            if key not in seen:
+                seen.add(key)
+                hints.append(
+                    NewsTickerHint(
+                        symbol=symbol,
+                        exchange=exchange,
+                        raw=continuation.group(0).strip(),
+                    )
+                )
+            position = continuation.end()
     return tuple(hints)
 
 

--- a/quantmind/preprocess/news.py
+++ b/quantmind/preprocess/news.py
@@ -56,9 +56,11 @@ _MARKDOWN_EMPHASIS_RE = re.compile(
     r"(?<!\*)\*{1,2}([A-Z][A-Z0-9.-]{0,9})\*{1,2}(?!\*)",
     re.IGNORECASE,
 )
-_SHARED_EXCHANGE_SYMBOL_RE = re.compile(
-    r"\s*,\s*([A-Z][A-Z0-9.-]{0,9})",
+_SHARED_EXCHANGE_GROUP_RE = re.compile(
+    r"(?P<members>(?:\s*,\s*[A-Z][A-Z0-9.-]{0,9})+)"
+    r"(?=\s*(?:\)|;\s*[A-Z][A-Z0-9 .-]*\s*:))",
 )
+_SHARED_EXCHANGE_SYMBOL_RE = re.compile(r",\s*([A-Z][A-Z0-9.-]{0,9})")
 _EMAIL_PROTECTION_LINK_RE = re.compile(
     r"\[\[email protected]\]\(/cdn-cgi/l/email-protection#[^)]+\)"
 )
@@ -418,31 +420,37 @@ def extract_exchange_ticker_hints(text: str) -> tuple[NewsTickerHint, ...]:
         raw_exchange = " ".join(match.group(1).upper().split())
         exchange = _EXCHANGE_NAMES.get(raw_exchange, raw_exchange)
         symbol = match.group(2).upper()
-        key = (symbol, exchange)
-        if key in seen:
-            continue
-        seen.add(key)
-        hints.append(
-            NewsTickerHint(
-                symbol=symbol,
-                exchange=exchange,
-                raw=match.group(0).strip(),
-            )
-        )
+        continuation_matches: list[re.Match[str]] = []
+        shared_group_raw: str | None = None
         matched_text = match.group(0)
-        if not matched_text.lstrip().startswith(
+        if matched_text.lstrip().startswith(
             "("
-        ) or matched_text.rstrip().endswith(")"):
-            continue
+        ) and not matched_text.rstrip().endswith(")"):
+            closing_parenthesis = scan_text.find(")", match.end())
+            if closing_parenthesis != -1:
+                suffix = scan_text[match.end() : closing_parenthesis + 1]
+                shared_group = _SHARED_EXCHANGE_GROUP_RE.match(suffix)
+                if shared_group:
+                    continuation_matches = list(
+                        _SHARED_EXCHANGE_SYMBOL_RE.finditer(
+                            shared_group.group("members")
+                        )
+                    )
+                    shared_group_raw = scan_text[
+                        match.start() : closing_parenthesis + 1
+                    ].strip()
 
-        closing_parenthesis = scan_text.find(")", match.end())
-        if closing_parenthesis == -1:
-            continue
-        suffix = scan_text[match.end() : closing_parenthesis]
-        position = 0
-        while continuation := _SHARED_EXCHANGE_SYMBOL_RE.match(
-            suffix, position
-        ):
+        key = (symbol, exchange)
+        if key not in seen:
+            seen.add(key)
+            hints.append(
+                NewsTickerHint(
+                    symbol=symbol,
+                    exchange=exchange,
+                    raw=shared_group_raw or matched_text.strip(),
+                )
+            )
+        for continuation in continuation_matches:
             symbol = continuation.group(1).upper()
             key = (symbol, exchange)
             if key not in seen:
@@ -451,10 +459,9 @@ def extract_exchange_ticker_hints(text: str) -> tuple[NewsTickerHint, ...]:
                     NewsTickerHint(
                         symbol=symbol,
                         exchange=exchange,
-                        raw=continuation.group(0).strip(),
+                        raw=shared_group_raw,
                     )
                 )
-            position = continuation.end()
     return tuple(hints)
 
 

--- a/tests/preprocess/test_news.py
+++ b/tests/preprocess/test_news.py
@@ -125,8 +125,42 @@ class NewsPreprocessTests(unittest.TestCase):
         self.assertEqual(
             tuple((hint.symbol, hint.exchange, hint.raw) for hint in hints),
             (
-                ("EVEX", "NYSE", "(NYSE: EVEX"),
-                ("EVEXW", "NYSE", ", EVEXW"),
+                ("EVEX", "NYSE", "(NYSE: EVEX, EVEXW)"),
+                ("EVEXW", "NYSE", "(NYSE: EVEX, EVEXW)"),
+            ),
+        )
+
+    def test_exchange_ticker_hints_stop_shared_list_at_semicolon(self):
+        hints = extract_exchange_ticker_hints(
+            "Example issuer (NYSE: EVEX, EVEXW; B3: EVEB31) announced results."
+        )
+
+        self.assertEqual(
+            tuple((hint.symbol, hint.exchange, hint.raw) for hint in hints),
+            (
+                (
+                    "EVEX",
+                    "NYSE",
+                    "(NYSE: EVEX, EVEXW; B3: EVEB31)",
+                ),
+                (
+                    "EVEXW",
+                    "NYSE",
+                    "(NYSE: EVEX, EVEXW; B3: EVEB31)",
+                ),
+            ),
+        )
+
+    def test_exchange_ticker_hints_capture_new_shared_list_members(self):
+        hints = extract_exchange_ticker_hints(
+            "Prior (NYSE: EVEX). Offering (NYSE: EVEX, EVEXW)."
+        )
+
+        self.assertEqual(
+            tuple((hint.symbol, hint.exchange, hint.raw) for hint in hints),
+            (
+                ("EVEX", "NYSE", "(NYSE: EVEX)"),
+                ("EVEXW", "NYSE", "(NYSE: EVEX, EVEXW)"),
             ),
         )
 
@@ -155,6 +189,21 @@ class NewsPreprocessTests(unittest.TestCase):
                 "semicolon boundary BMV",
                 "(NYSE: ASR; BMV: ASUR)",
                 (("ASR", "NYSE", "(NYSE: ASR"),),
+            ),
+            (
+                "ordinary prose inside parentheses",
+                "(NYSE: IBM, and revenue increased)",
+                (("IBM", "NYSE", "(NYSE: IBM"),),
+            ),
+            (
+                "uppercase token before ordinary prose",
+                "(NYSE: IBM, ABC and revenue increased)",
+                (("IBM", "NYSE", "(NYSE: IBM"),),
+            ),
+            (
+                "uppercase token before non-exchange semicolon",
+                "(NYSE: IBM, ABC; revenue increased)",
+                (("IBM", "NYSE", "(NYSE: IBM"),),
             ),
         )
 

--- a/tests/preprocess/test_news.py
+++ b/tests/preprocess/test_news.py
@@ -117,6 +117,58 @@ class NewsPreprocessTests(unittest.TestCase):
                     expected,
                 )
 
+    def test_exchange_ticker_hints_capture_shared_prefix_comma_list(self):
+        hints = extract_exchange_ticker_hints(
+            "Example issuer (NYSE: EVEX, EVEXW) announced results."
+        )
+
+        self.assertEqual(
+            tuple((hint.symbol, hint.exchange, hint.raw) for hint in hints),
+            (
+                ("EVEX", "NYSE", "(NYSE: EVEX"),
+                ("EVEXW", "NYSE", ", EVEXW"),
+            ),
+        )
+
+    def test_exchange_ticker_hints_stop_at_shared_prefix_boundaries(self):
+        cases = (
+            (
+                "balanced mention followed by prose",
+                "Shares of (NYSE: IBM), and (NASDAQ: AAPL) rose today.",
+                (
+                    ("IBM", "NYSE", "(NYSE: IBM)"),
+                    ("AAPL", "NASDAQ", "(NASDAQ: AAPL)"),
+                ),
+            ),
+            ("unsupported exchange", "(OTCID: QVCAQ, QVCGQ, QVCPQ)", ()),
+            (
+                "conjunction boundary",
+                "(NYSE: TME and HKEX: 1698)",
+                (("TME", "NYSE", "(NYSE: TME"),),
+            ),
+            (
+                "semicolon boundary TSXV",
+                "(NASDAQ: VMAR; TSXV: VMAR)",
+                (("VMAR", "NASDAQ", "(NASDAQ: VMAR"),),
+            ),
+            (
+                "semicolon boundary BMV",
+                "(NYSE: ASR; BMV: ASUR)",
+                (("ASR", "NYSE", "(NYSE: ASR"),),
+            ),
+        )
+
+        for name, text, expected in cases:
+            with self.subTest(name=name):
+                hints = extract_exchange_ticker_hints(text)
+
+                self.assertEqual(
+                    tuple(
+                        (hint.symbol, hint.exchange, hint.raw) for hint in hints
+                    ),
+                    expected,
+                )
+
     def test_build_sec_news_identity(self):
         self.assertEqual(
             build_sec_news_identity(


### PR DESCRIPTION
## Summary

Extend extract_exchange_ticker_hints only for the evidenced shared-prefix comma-list shape while preserving the existing balanced/simple capture behavior.

The parser now:

- considers continuation members only inside the same unmatched parenthesized exchange mention;
- accepts only uppercase ticker tokens separated by commas;
- terminates only at the closing parenthesis or before another explicit EXCHANGE: prefix;
- keeps the complete literal parenthesized source group as raw for every hint produced by that group;
- preserves existing first-match provenance when a candidate is not a valid shared list.

The PR remains limited to the parser and focused regression tests. The earlier example and design-document changes are removed.

## Why

Issue #108 identifies one supported-symbol gain in the observed PR Newswire window: EVEXW in (NYSE: EVEX, EVEXW; B3: EVEB31). A broad continuation scan is not justified by that small gain. This revision implements the narrow grammar represented by the evidence and rejects prose, conjunction, unsupported-exchange, and non-exchange semicolon boundaries.

## Review Follow-up

This revision addresses each blocking point from the requested-changes review:

- no scan after an already-balanced (EXCHANGE: SYMBOL) match;
- no case-insensitive continuation capture, so prose such as and cannot become a ticker;
- no reconstructed or dangling provenance for valid shared groups;
- no extra example;
- no design-document rewrite;
- duplicate suppression is covered when the first symbol was already observed.

## Verification

- pytest -o addopts='' tests/preprocess/test_news.py -q: 23 passed, 11 subtests passed.
- ruff format --check quantmind/preprocess/news.py tests/preprocess/test_news.py: passed.
- ruff check quantmind/preprocess/news.py tests/preprocess/test_news.py: passed.
- basedpyright quantmind/preprocess/news.py: 0 errors.
- lint-imports: 8 contracts kept, 0 broken.
- Full Windows harness: format, lint, type, and import-contract stages passed; pytest reached 412 passed with 85.47% coverage and 18 pre-existing platform failures in Windows SQLite temporary-file cleanup and LiteParse PDF handling. No failing test exercises the changed parser.

Fixes #108.