### PR TITLE
feat(utils): collect per-run token/time/step usage from SDK traces

### DIFF
--- a/.agents/skills/quantmind-dev/references/develop-components.md
+++ b/.agents/skills/quantmind-dev/references/develop-components.md
@@ -133,8 +133,11 @@ apply throughout.
 
 ### `quantmind/utils/`
 
-- Logger only. New general-purpose helpers need maintainer sign-off via an
-  issue first; the default answer is "put it in the module that uses it".
+- The logger, plus small dependency-free helpers that wrap an Agents SDK
+  seam and must be shared across layers without one importing another
+  (`structured_output`, `usage`). New helpers still need maintainer
+  sign-off via an issue first; the default answer is "put it in the module
+  that uses it".
 
 ## Public Operation Checklist
 

--- a/.agents/skills/quantmind-dev/references/write-contexts.md
+++ b/.agents/skills/quantmind-dev/references/write-contexts.md
@@ -1,56 +1,30 @@
 # Writing contexts pages for QuantMind
 
-The canonical standard for authoring or editing anything under `contexts/`. Read
-it before adding or changing a design or dev page. `tests/test_contexts.py`
-(part of `scripts/verify.sh`) enforces the structural rules below, so a page
-that ignores them fails the build.
+The canonical standard for authoring or editing anything under `contexts/`. Read it before adding or changing a design or dev page. `tests/test_contexts.py` (part of `scripts/verify.sh`) enforces the structural rules below, so a page that ignores them fails the build.
 
 ## When to add a page
 
-- Add a design page only for real design content — an agreed behavior an
-  implementation must preserve. No placeholders, empty directories, or
-  speculative component pages.
-- Organize by package or feature: `contexts/design/<package>/<topic>.md`. Do not
-  add an intermediate `components/` directory.
-- Keep code the source of truth for behavior; a page explains decisions and
-  lists any current gap (state whether it is current, planned, or both).
+- Add a design page only for real design content — an agreed behavior an implementation must preserve. No placeholders, empty directories, or speculative component pages.
+- Organize by package or feature: `contexts/design/<package>/<topic>.md`. Do not add an intermediate `components/` directory.
+- Keep code the source of truth for behavior; a page explains decisions and lists any current gap (state whether it is current, planned, or both).
 
 ## Required page structure
 
-- Every `contexts/**/*.md` opens with `## Quick Summary`, then `## Contents`,
-  both within the first 80 lines and in that order.
-- Quick Summary is the routing preview (Purpose / Read when / Load next or Owner
-  / Status). It routes a reader; it does not replace reading the page in full.
-- The `## Contents` links must **exactly** match the page's `##` section
-  headings, excluding Quick Summary and Contents. Anchors are GitHub-style:
-  lowercase, punctuation stripped, spaces and hyphens collapsed to one hyphen
-  (`## The Fallback Ladder` → `#the-fallback-ladder`).
-- Register the page in its index and keep index links resolving: a design page
-  in the global index `contexts/design/README.md`; a dev route in
-  `contexts/dev/README.md`.
-- Match the prose wrapping of the surrounding pages (existing contexts pages
-  hard-wrap at roughly 76 columns). The no-hard-wrap rule in `github-writing.md`
-  is for GitHub issue and PR bodies, not for contexts pages.
+- Every `contexts/**/*.md` opens with `## Quick Summary`, then `## Contents`, both within the first 80 lines and in that order.
+- Quick Summary is the routing preview (Purpose / Read when / Load next or Owner / Status). It routes a reader; it does not replace reading the page in full.
+- The `## Contents` links must **exactly** match the page's `##` section headings, excluding Quick Summary and Contents. Anchors are GitHub-style: lowercase, punctuation stripped, spaces and hyphens collapsed to one hyphen (`## The Fallback Ladder` → `#the-fallback-ladder`).
+- Register the page in its index and keep index links resolving: a design page in the global index `contexts/design/README.md`; a dev route in `contexts/dev/README.md`.
+- Do not hard-wrap prose to a fixed column width — fixed-width wrapping is for code, not prose. Keep each paragraph and list item on one physical line and let the renderer soft-wrap. This is the same no-hard-wrap prose rule defined in `github-writing.md`, which now applies to contexts pages as well as GitHub issue and PR bodies. Tables, fenced code blocks, and mermaid diagrams keep their own line structure.
 
 ## Mermaid diagrams
 
-GitHub renders a fenced ```` ```mermaid ```` block natively — embed the diagram,
-never a pre-rendered image. A mermaid block adds no `##` heading, so it never
-affects the Quick Summary / Contents anchor check. Keep diagrams compact:
+GitHub renders a fenced ```` ```mermaid ```` block natively — embed the diagram, never a pre-rendered image. A mermaid block adds no `##` heading, so it never affects the Quick Summary / Contents anchor check. Keep diagrams compact:
 
-- **Direction follows the diagram's story, not the screen.** Use `LR` for a
-  linear pipeline, ladder, or request path; use `TD` for a layered or
-  hierarchical structure (a subgraph-per-layer map).
-- **Prefer `LR` whenever the flow is essentially linear.** Mermaid's default
-  node height is large, so a `TD` chart stacks tall and pushes the page down
-  several screens; GitHub instead scrolls a wide `LR` chart horizontally.
-- **Short node text.** Push detail to edge labels or the prose beneath the
-  diagram. Quote any label with special characters (`()`, `/`, `=`, `→`).
-- **Split past ~15–20 nodes**, or group with `subgraph`. Do not mix `TD` and
-  `LR` in one chart; use subgraphs if parts need different layouts.
+- **Direction follows the diagram's story, not the screen.** Use `LR` for a linear pipeline, ladder, or request path; use `TD` for a layered or hierarchical structure (a subgraph-per-layer map).
+- **Prefer `LR` whenever the flow is essentially linear.** Mermaid's default node height is large, so a `TD` chart stacks tall and pushes the page down several screens; GitHub instead scrolls a wide `LR` chart horizontally.
+- **Short node text.** Push detail to edge labels or the prose beneath the diagram. Quote any label with special characters (`()`, `/`, `=`, `→`).
+- **Split past ~15–20 nodes**, or group with `subgraph`. Do not mix `TD` and `LR` in one chart; use subgraphs if parts need different layouts.
 
 ## Required check
 
-`tests/test_contexts.py` runs inside `bash scripts/verify.sh` and validates the
-progressive-disclosure structure, the Contents/anchor match, and every index
-link. Run it before pushing a contexts change.
+`tests/test_contexts.py` runs inside `bash scripts/verify.sh` and validates the progressive-disclosure structure, the Contents/anchor match, and every index link. Run it before pushing a contexts change.

--- a/.claude/skills/quantmind-dev/references/develop-components.md
+++ b/.claude/skills/quantmind-dev/references/develop-components.md
@@ -133,8 +133,11 @@ apply throughout.
 
 ### `quantmind/utils/`
 
-- Logger only. New general-purpose helpers need maintainer sign-off via an
-  issue first; the default answer is "put it in the module that uses it".
+- The logger, plus small dependency-free helpers that wrap an Agents SDK
+  seam and must be shared across layers without one importing another
+  (`structured_output`, `usage`). New helpers still need maintainer
+  sign-off via an issue first; the default answer is "put it in the module
+  that uses it".
 
 ## Public Operation Checklist
 

--- a/.claude/skills/quantmind-dev/references/write-contexts.md
+++ b/.claude/skills/quantmind-dev/references/write-contexts.md
@@ -1,56 +1,30 @@
 # Writing contexts pages for QuantMind
 
-The canonical standard for authoring or editing anything under `contexts/`. Read
-it before adding or changing a design or dev page. `tests/test_contexts.py`
-(part of `scripts/verify.sh`) enforces the structural rules below, so a page
-that ignores them fails the build.
+The canonical standard for authoring or editing anything under `contexts/`. Read it before adding or changing a design or dev page. `tests/test_contexts.py` (part of `scripts/verify.sh`) enforces the structural rules below, so a page that ignores them fails the build.
 
 ## When to add a page
 
-- Add a design page only for real design content — an agreed behavior an
-  implementation must preserve. No placeholders, empty directories, or
-  speculative component pages.
-- Organize by package or feature: `contexts/design/<package>/<topic>.md`. Do not
-  add an intermediate `components/` directory.
-- Keep code the source of truth for behavior; a page explains decisions and
-  lists any current gap (state whether it is current, planned, or both).
+- Add a design page only for real design content — an agreed behavior an implementation must preserve. No placeholders, empty directories, or speculative component pages.
+- Organize by package or feature: `contexts/design/<package>/<topic>.md`. Do not add an intermediate `components/` directory.
+- Keep code the source of truth for behavior; a page explains decisions and lists any current gap (state whether it is current, planned, or both).
 
 ## Required page structure
 
-- Every `contexts/**/*.md` opens with `## Quick Summary`, then `## Contents`,
-  both within the first 80 lines and in that order.
-- Quick Summary is the routing preview (Purpose / Read when / Load next or Owner
-  / Status). It routes a reader; it does not replace reading the page in full.
-- The `## Contents` links must **exactly** match the page's `##` section
-  headings, excluding Quick Summary and Contents. Anchors are GitHub-style:
-  lowercase, punctuation stripped, spaces and hyphens collapsed to one hyphen
-  (`## The Fallback Ladder` → `#the-fallback-ladder`).
-- Register the page in its index and keep index links resolving: a design page
-  in the global index `contexts/design/README.md`; a dev route in
-  `contexts/dev/README.md`.
-- Match the prose wrapping of the surrounding pages (existing contexts pages
-  hard-wrap at roughly 76 columns). The no-hard-wrap rule in `github-writing.md`
-  is for GitHub issue and PR bodies, not for contexts pages.
+- Every `contexts/**/*.md` opens with `## Quick Summary`, then `## Contents`, both within the first 80 lines and in that order.
+- Quick Summary is the routing preview (Purpose / Read when / Load next or Owner / Status). It routes a reader; it does not replace reading the page in full.
+- The `## Contents` links must **exactly** match the page's `##` section headings, excluding Quick Summary and Contents. Anchors are GitHub-style: lowercase, punctuation stripped, spaces and hyphens collapsed to one hyphen (`## The Fallback Ladder` → `#the-fallback-ladder`).
+- Register the page in its index and keep index links resolving: a design page in the global index `contexts/design/README.md`; a dev route in `contexts/dev/README.md`.
+- Do not hard-wrap prose to a fixed column width — fixed-width wrapping is for code, not prose. Keep each paragraph and list item on one physical line and let the renderer soft-wrap. This is the same no-hard-wrap prose rule defined in `github-writing.md`, which now applies to contexts pages as well as GitHub issue and PR bodies. Tables, fenced code blocks, and mermaid diagrams keep their own line structure.
 
 ## Mermaid diagrams
 
-GitHub renders a fenced ```` ```mermaid ```` block natively — embed the diagram,
-never a pre-rendered image. A mermaid block adds no `##` heading, so it never
-affects the Quick Summary / Contents anchor check. Keep diagrams compact:
+GitHub renders a fenced ```` ```mermaid ```` block natively — embed the diagram, never a pre-rendered image. A mermaid block adds no `##` heading, so it never affects the Quick Summary / Contents anchor check. Keep diagrams compact:
 
-- **Direction follows the diagram's story, not the screen.** Use `LR` for a
-  linear pipeline, ladder, or request path; use `TD` for a layered or
-  hierarchical structure (a subgraph-per-layer map).
-- **Prefer `LR` whenever the flow is essentially linear.** Mermaid's default
-  node height is large, so a `TD` chart stacks tall and pushes the page down
-  several screens; GitHub instead scrolls a wide `LR` chart horizontally.
-- **Short node text.** Push detail to edge labels or the prose beneath the
-  diagram. Quote any label with special characters (`()`, `/`, `=`, `→`).
-- **Split past ~15–20 nodes**, or group with `subgraph`. Do not mix `TD` and
-  `LR` in one chart; use subgraphs if parts need different layouts.
+- **Direction follows the diagram's story, not the screen.** Use `LR` for a linear pipeline, ladder, or request path; use `TD` for a layered or hierarchical structure (a subgraph-per-layer map).
+- **Prefer `LR` whenever the flow is essentially linear.** Mermaid's default node height is large, so a `TD` chart stacks tall and pushes the page down several screens; GitHub instead scrolls a wide `LR` chart horizontally.
+- **Short node text.** Push detail to edge labels or the prose beneath the diagram. Quote any label with special characters (`()`, `/`, `=`, `→`).
+- **Split past ~15–20 nodes**, or group with `subgraph`. Do not mix `TD` and `LR` in one chart; use subgraphs if parts need different layouts.
 
 ## Required check
 
-`tests/test_contexts.py` runs inside `bash scripts/verify.sh` and validates the
-progressive-disclosure structure, the Contents/anchor match, and every index
-link. Run it before pushing a contexts change.
+`tests/test_contexts.py` runs inside `bash scripts/verify.sh` and validates the progressive-disclosure structure, the Contents/anchor match, and every index link. Run it before pushing a contexts change.

--- a/contexts/README.md
+++ b/contexts/README.md
@@ -2,14 +2,10 @@
 
 ## Quick Summary
 
-- **Purpose**: Route agents to the smallest set of context pages needed for a
-  QuantMind task.
-- **Read when**: Starting repository development, library usage, or design
-  work.
-- **Load next**: Choose exactly one primary route below, then follow only links
-  required by the task.
-- **Authority**: Design pages record agreed behavior; code and tests show what
-  the current version implements.
+- **Purpose**: Route agents to the smallest set of context pages needed for a QuantMind task.
+- **Read when**: Starting repository development, library usage, or design work.
+- **Load next**: Choose exactly one primary route below, then follow only links required by the task.
+- **Authority**: Design pages record agreed behavior; code and tests show what the current version implements.
 
 ## Contents
 
@@ -18,31 +14,20 @@
 
 ## Routes
 
-This directory is the public repository context system for coding agents and
-maintainers. Start with the index that matches the work you are doing:
+This directory is the public repository context system for coding agents and maintainers. Start with the index that matches the work you are doing:
 
-- [Develop QuantMind](dev/README.md) for architecture, contribution, testing,
-  and verification guidance.
-- [Use QuantMind](usage/README.md) for public operations, examples, and usage
-  documentation.
-- [Design QuantMind](design/README.md) for accepted design decisions and
-  planned behavior that spans packages.
+- [Develop QuantMind](dev/README.md) for architecture, contribution, testing, and verification guidance.
+- [Use QuantMind](usage/README.md) for public operations, examples, and usage documentation.
+- [Design QuantMind](design/README.md) for accepted design decisions and planned behavior that spans packages.
 
 ## Where Information Lives
 
-- Keep each kind of information in one place so agents do not have to compare
-  competing versions.
+- Keep each kind of information in one place so agents do not have to compare competing versions.
 - `contexts/design/` records accepted design decisions and planned behavior.
-- `contexts/dev/` and `contexts/usage/` route readers to existing rules and
-  examples instead of copying them.
-- Code and tests show current behavior. Design pages list any planned behavior
-  that is not implemented yet.
-- `docs/` remains the home for user-facing guides, examples, and catalogs. It
-  may link to a design page but must not maintain a second copy of the design.
-- Update a component's context index only when its discoverable entry points
-  change, not for every implementation change.
-- Repository maintainers own this shared structure. Component contributors own
-  the links for the components they change.
+- `contexts/dev/` and `contexts/usage/` route readers to existing rules and examples instead of copying them.
+- Code and tests show current behavior. Design pages list any planned behavior that is not implemented yet.
+- `docs/` remains the home for user-facing guides, examples, and catalogs. It may link to a design page but must not maintain a second copy of the design.
+- Update a component's context index only when its discoverable entry points change, not for every implementation change.
+- Repository maintainers own this shared structure. Component contributors own the links for the components they change.
 
-Keep this layer limited to public repository information. Private,
-deployment-specific, and internal-only guidance does not belong here.
+Keep this layer limited to public repository information. Private, deployment-specific, and internal-only guidance does not belong here.

--- a/contexts/design/README.md
+++ b/contexts/design/README.md
@@ -2,23 +2,17 @@
 
 ## Quick Summary
 
-- **Purpose**: Find accepted designs for QuantMind packages and public
-  operations.
-- **Read when**: A task changes architecture, package responsibilities, public
-  behavior, or a required validation rule.
-- **Load next**: Open only the domain design that matches the task, then read
-  that page in full before implementation.
-- **Authority**: These pages explain agreed behavior. Each page lists any part
-  that is not implemented yet.
+- **Purpose**: Find accepted designs for QuantMind packages and public operations.
+- **Read when**: A task changes architecture, package responsibilities, public behavior, or a required validation rule.
+- **Load next**: Open only the domain design that matches the task, then read that page in full before implementation.
+- **Authority**: These pages explain agreed behavior. Each page lists any part that is not implemented yet.
 
 ## Contents
 
 - [Design Index](#design-index)
 - [Organization Rules](#organization-rules)
 
-This directory records QuantMind engineering decisions. Use it to understand
-which package owns each step, how packages work together, and what behavior an
-implementation must preserve.
+This directory records QuantMind engineering decisions. Use it to understand which package owns each step, how packages work together, and what behavior an implementation must preserve.
 
 ## Design Index
 
@@ -34,24 +28,14 @@ implementation must preserve.
 | Operations | [Public operation naming](operations/naming.md) |
 | Operations | [Orchestration and construction altitude](operations/orchestration.md) |
 | Utils | [Cross-provider structured output](utils/structured_output.md) |
+| Utils | [Collect per-run token and timing usage from SDK traces](utils/usage.md) |
 
 ## Organization Rules
 
-- Organize designs directly by package or feature, such as `flow/`, `knowledge/`,
-  `library/`, `operations/`, or `preprocess/`. Do not add an intermediate
-  `components/` directory.
-- Keep this page as the single global design index. Domain directories do not
-  need their own index.
-- Add a design page only for real design content. Do not create empty
-  directories, placeholders, or speculative component pages.
-- State whether a document describes current behavior, planned behavior, or
-  both. List current gaps so readers can distinguish a plan from working code.
-- Write headings and summaries as an action plus a concrete object. Avoid
-  unexplained project shorthand and define any necessary domain term when it
-  first appears.
-- Use code and tests to check current behavior. Keep `docs/` focused on
-  user-facing guides, examples, and catalogs; those pages may link here but
-  must not maintain a second copy of a design.
-- Follow the [contexts authoring standard](../../.agents/skills/quantmind-dev/references/write-contexts.md)
-  when adding or editing a page — required page structure, index registration,
-  and Mermaid diagram guidance live there.
+- Organize designs directly by package or feature, such as `flow/`, `knowledge/`, `library/`, `operations/`, or `preprocess/`. Do not add an intermediate `components/` directory.
+- Keep this page as the single global design index. Domain directories do not need their own index.
+- Add a design page only for real design content. Do not create empty directories, placeholders, or speculative component pages.
+- State whether a document describes current behavior, planned behavior, or both. List current gaps so readers can distinguish a plan from working code.
+- Write headings and summaries as an action plus a concrete object. Avoid unexplained project shorthand and define any necessary domain term when it first appears.
+- Use code and tests to check current behavior. Keep `docs/` focused on user-facing guides, examples, and catalogs; those pages may link here but must not maintain a second copy of a design.
+- Follow the [contexts authoring standard](../../.agents/skills/quantmind-dev/references/write-contexts.md) when adding or editing a page — required page structure, index registration, and Mermaid diagram guidance live there.

--- a/contexts/design/flow/news.md
+++ b/contexts/design/flow/news.md
@@ -22,35 +22,20 @@
 
 ## Scope and Current Support
 
-This page defines how the open-source package collects public company news. The
-first version supports PR Newswire only. It has one collection function, one
-time-window input, repeatable HTML cleanup, and visible item failures.
+This page defines how the open-source package collects public company news. The first version supports PR Newswire only. It has one collection function, one time-window input, repeatable HTML cleanup, and visible item failures.
 
-Its public name follows the
-[operation naming rules](../operations/naming.md): collection returns the news
-as published plus fetch details. A separate operation turns those documents
-into structured knowledge.
+Its public name follows the [operation naming rules](../operations/naming.md): collection returns the news as published plus fetch details. A separate operation turns those documents into structured knowledge.
 
-The primary requirement is that any caller can request a complete, one-shot
-collection of a past time window. A daily poll is therefore not a separate
-operation; it is simply a short window evaluated on a schedule.
+The primary requirement is that any caller can request a complete, one-shot collection of a past time window. A daily poll is therefore not a separate operation; it is simply a short window evaluated on a schedule.
 
 ## Design Principles
 
-1. **Ask for news, not fetch details.** Callers choose a source and time window.
-   They do not choose RSS, listing pages, how to move between pages, or article
-   parsing rules.
-2. **Return every source row.** QuantMind does not silently remove duplicate
-   source rows. Repeated rows remain repeated output records,
-   and may share the same stable ID.
-3. **Show partial failures.** The returned batch includes item failures. Invalid
-   inputs still raise before network work starts.
-4. **Hide source implementation details.** PR Newswire may later use a public
-   mechanism other than listing pages without changing the public function.
-5. **List supported sources explicitly.** The first version selects from a
-   closed source list. It does not expose a provider plugin API or registry.
-6. **Keep downstream choices separate.** The calling pipeline owns storage,
-   duplicate handling, relevance rules, output formats, and scheduling.
+1. **Ask for news, not fetch details.** Callers choose a source and time window. They do not choose RSS, listing pages, how to move between pages, or article parsing rules.
+2. **Return every source row.** QuantMind does not silently remove duplicate source rows. Repeated rows remain repeated output records, and may share the same stable ID.
+3. **Show partial failures.** The returned batch includes item failures. Invalid inputs still raise before network work starts.
+4. **Hide source implementation details.** PR Newswire may later use a public mechanism other than listing pages without changing the public function.
+5. **List supported sources explicitly.** The first version selects from a closed source list. It does not expose a provider plugin API or registry.
+6. **Keep downstream choices separate.** The calling pipeline owns storage, duplicate handling, relevance rules, output formats, and scheduling.
 
 ## Public API
 
@@ -72,18 +57,9 @@ batch = await collect_news(
 )
 ```
 
-`NewsWindow` requires timezone-aware timestamps. Its `[start, end)` interval
-includes `start` and excludes `end`. Regular collection and historical runs
-use the same call; there are no separate `poll_*`, `backfill_*`, or
-`fetch_wire_*` public functions.
+`NewsWindow` requires timezone-aware timestamps. Its `[start, end)` interval includes `start` and excludes `end`. Regular collection and historical runs use the same call; there are no separate `poll_*`, `backfill_*`, or `fetch_wire_*` public functions.
 
-`NewsCollectionCfg` keeps the shared `BaseFlowCfg` fields so it works with the
-repository's shared config handling. Its only
-collection-specific field is `retain_raw_html`, which controls whether fetched
-article HTML bytes remain in the result. It defaults to `False`, which is the
-storage-efficient behavior. The article is still fetched, hashed, parsed, and
-described by fetch details; only its byte payload is discarded. The collector
-does not otherwise use the shared model, tracing, or SDK-run fields.
+`NewsCollectionCfg` keeps the shared `BaseFlowCfg` fields so it works with the repository's shared config handling. Its only collection-specific field is `retain_raw_html`, which controls whether fetched article HTML bytes remain in the result. It defaults to `False`, which is the storage-efficient behavior. The article is still fetched, hashed, parsed, and described by fetch details; only its byte payload is discarded. The collector does not otherwise use the shared model, tracing, or SDK-run fields.
 
 ### Collection records are not knowledge
 
@@ -94,41 +70,25 @@ QuantMind keeps collected documents separate from structured knowledge:
 | `collect_news` | Source documents, fetch details, failures, and whether the full window was scanned | `quantmind.preprocess` |
 | future `extract_news_knowledge` | Extracted financial events | `quantmind.knowledge.News` |
 
-`NewsDocument` is therefore not a `KnowledgeItem`. It carries HTTP details,
-raw bytes, parsing output, and collection status that remain useful before any
-LLM or business data format is chosen. `knowledge.News` is a structured
-financial event with entities, sentiment, financial importance
-(`materiality`), source links, and text for embeddings. A pipeline may use both
-types, but one cannot replace the other.
+`NewsDocument` is therefore not a `KnowledgeItem`. It carries HTTP details, raw bytes, parsing output, and collection status that remain useful before any LLM or business data format is chosen. `knowledge.News` is a structured financial event with entities, sentiment, financial importance (`materiality`), source links, and text for embeddings. A pipeline may use both types, but one cannot replace the other.
 
 ## Returned Data
 
-`collect_news` returns a `NewsBatch` with four fields. Import these public types
-from `quantmind.preprocess`:
+`collect_news` returns a `NewsBatch` with four fields. Import these public types from `quantmind.preprocess`:
 
 - `documents`: successfully collected `NewsDocument` observations;
-- `failures`: lightweight `NewsFailure` records for work that could not be
-  completed;
-- `observed_count`: the number of source rows successfully converted into
-  in-window observations, before article processing;
+- `failures`: lightweight `NewsFailure` records for work that could not be completed;
+- `observed_count`: the number of source rows successfully converted into in-window observations, before article processing;
 - `complete`: whether the listing scan covered the full requested window.
 
-A `NewsDocument` contains the source name, stable ID, preferred article URL,
-title, publisher, publication time, cleaned Markdown, content hash, ticker
-hints, and two `NewsArtifact` records:
+A `NewsDocument` contains the source name, stable ID, preferred article URL, title, publisher, publication time, cleaned Markdown, content hash, ticker hints, and two `NewsArtifact` records:
 
 - a small record of the public listing row;
-- an article record containing fetch details and a content hash. Its
-  `bytes` field is `None` unless `retain_raw_html=True`.
+- an article record containing fetch details and a content hash. Its `bytes` field is `None` unless `retain_raw_html=True`.
 
-`NewsArtifact` records what was fetched. It contains the content hash,
-content type, source and resolved URLs, status, headers, and fetch time, with
-an optional byte payload.
+`NewsArtifact` records what was fetched. It contains the content hash, content type, source and resolved URLs, status, headers, and fetch time, with an optional byte payload.
 
-Repeated listing rows are not removed. If two rows point to the same release,
-the batch contains two observations with the same stable ID. A consumer can
-use that ID to update the same database row safely while still recording what
-QuantMind observed.
+Repeated listing rows are not removed. If two rows point to the same release, the batch contains two observations with the same stable ID. A consumer can use that ID to update the same database row safely while still recording what QuantMind observed.
 
 ## Collection Steps
 
@@ -143,48 +103,28 @@ NewsWindow
   -> NewsBatch
 ```
 
-PR Newswire discovery is based on its public news-release listing rather than
-the latest-items RSS snapshot. Pages are read newest to oldest until an
-observation strictly older than the requested start is seen. The strict
-boundary matters because several rows with the same minute-level timestamp may
-span two pages. A caller can therefore rerun a past-day request without a
-previously saved cursor.
+PR Newswire discovery is based on its public news-release listing rather than the latest-items RSS snapshot. Pages are read newest to oldest until an observation strictly older than the requested start is seen. The strict boundary matters because several rows with the same minute-level timestamp may span two pages. A caller can therefore rerun a past-day request without a previously saved cursor.
 
-PR Newswire exposes listing timestamps at minute precision. Scheduled callers
-should therefore use minute-aligned window bounds, as the live end-to-end check
-does.
+PR Newswire exposes listing timestamps at minute precision. Scheduled callers should therefore use minute-aligned window bounds, as the live end-to-end check does.
 
-RSS remains an internal parser and a live check. It is not a public
-`NewsInput`: choosing a feed is an implementation detail, and a limited feed
-snapshot cannot prove that it covered a complete time window.
+RSS remains an internal parser and a live check. It is not a public `NewsInput`: choosing a feed is an implementation detail, and a limited feed snapshot cannot prove that it covered a complete time window.
 
-The HTTP layer limits retries, waits between attempts, honors `Retry-After`,
-and limits requests per host. PR Newswire-specific URL construction and
-listing HTML parsing stay in the PR Newswire source module.
+The HTTP layer limits retries, waits between attempts, honors `Retry-After`, and limits requests per host. PR Newswire-specific URL construction and listing HTML parsing stay in the PR Newswire source module.
 
-`NewsWindow.source` lists every supported source. `collect_news` has an
-explicit branch for each one, so the type checker catches a source name added
-without a matching collector.
+`NewsWindow.source` lists every supported source. `collect_news` has an explicit branch for each one, so the type checker catches a source name added without a matching collector.
 
 ## Failures and the `complete` Flag
 
-Configuration errors raise immediately. Examples include a naive timestamp,
-an empty source, an unsupported source, or `end <= start`.
+Configuration errors raise immediately. Examples include a naive timestamp, an empty source, an unsupported source, or `end <= start`.
 
-After collection begins, one item failure does not stop independent items.
-Each `NewsFailure` records the source, failed step, URL, optional item ID, error
-category, and message.
+After collection begins, one item failure does not stop independent items. Each `NewsFailure` records the source, failed step, URL, optional item ID, error category, and message.
 
 `complete=False` when any of the following is true:
 
 - a listing page could not be fetched or parsed;
 - the listing scan stopped before crossing the window start.
 
-Article failures stay in `failures` but do not change whether all listing rows
-were found. A caller can distinguish "the full time window was scanned" from
-"every found article was processed." It can store successful records and retry
-failed articles separately. An empty batch is complete only when the listing
-scan crossed the requested start.
+Article failures stay in `failures` but do not change whether all listing rows were found. A caller can distinguish "the full time window was scanned" from "every found article was processed." It can store successful records and retry failed articles separately. An empty batch is complete only when the listing scan crossed the requested start.
 
 ## Who Owns What
 
@@ -204,9 +144,7 @@ The consuming production pipeline owns:
 - later data formats, added fields, and database writes;
 - shared batch callbacks, metrics, and monitoring.
 
-This split lets a separate ingestion job request the last day in one call,
-apply its own rules, and write its own data format without adding those choices
-to the open-source library.
+This split lets a separate ingestion job request the last day in one call, apply its own rules, and write its own data format without adding those choices to the open-source library.
 
 ## How to Verify
 
@@ -214,45 +152,25 @@ Use separate offline and live checks.
 
 ### Offline repository checks
 
-`bash scripts/verify.sh` runs repeatable unit tests, linting, typing, and
-coverage. News tests use saved HTML/RSS files and mocked HTTP responses.
-They cover window validation, time edges, multi-page listings, duplicate
-observations, raw-byte retention, retries, partial failures, and completeness.
+`bash scripts/verify.sh` runs repeatable unit tests, linting, typing, and coverage. News tests use saved HTML/RSS files and mocked HTTP responses. They cover window validation, time edges, multi-page listings, duplicate observations, raw-byte retention, retries, partial failures, and completeness.
 
 ### Live end-to-end news check
 
-`python scripts/verify_news_e2e.py` is the news live-network check. It performs
-three limited checks:
+`python scripts/verify_news_e2e.py` is the news live-network check. It performs three limited checks:
 
 1. fetch and parse the official PR Newswire RSS feed;
-2. scan PR Newswire listing rows for the preceding 24 hours and prove that the
-   scan crossed the window start;
-3. fetch up to 25 unique articles and find the first supported exchange-coded
-   symbol in every group that has one (100% recall).
+2. scan PR Newswire listing rows for the preceding 24 hours and prove that the scan crossed the window start;
+3. fetch up to 25 unique articles and find the first supported exchange-coded symbol in every group that has one (100% recall).
 
-The ticker check uses a separate comparison regex rather than the production
-extractor. It accepts plain, Markdown-link, and emphasis-wrapped symbols. It
-ignores later symbols in a multi-symbol list and exchanges that the extractor
-does not support. The script prints PASS/FAIL plus short listing, article,
-failure, and recall summaries. It fails when RSS or listing data is invalid,
-no sampled article parses, or supported symbols fall below 100% recall. A
-parsed sample with no supported symbols reports `SKIP` and still passes.
+The ticker check uses a separate comparison regex rather than the production extractor. It accepts plain, Markdown-link, and emphasis-wrapped symbols. It ignores later symbols in a multi-symbol list and exchanges that the extractor does not support. The script prints PASS/FAIL plus short listing, article, failure, and recall summaries. It fails when RSS or listing data is invalid, no sampled article parses, or supported symbols fall below 100% recall. A parsed sample with no supported symbols reports `SKIP` and still passes.
 
-The `news` job in `.github/workflows/e2e.yml` runs this check once daily, when
-started manually, and on pull requests that change its direct dependencies.
-The required `.github/workflows/ci.yml` workflow remains network-free so local
-development and unit tests remain repeatable.
+The `news` job in `.github/workflows/e2e.yml` runs this check once daily, when started manually, and on pull requests that change its direct dependencies. The required `.github/workflows/ci.yml` workflow remains network-free so local development and unit tests remain repeatable.
 
 ## Out of Scope and When to Add Shared Code
 
-The first version does not include GlobeNewswire, Business Wire, authenticated
-feeds, continuous cursors, storage, duplicate removal, financial importance
-scoring, or a generic batch-operation base class.
+The first version does not include GlobeNewswire, Business Wire, authenticated feeds, continuous cursors, storage, duplicate removal, financial importance scoring, or a generic batch-operation base class.
 
-When a second source is implemented, compare its real behavior with PR
-Newswire first. Add a shared collector interface only for behavior that both
-working collectors actually share. Keep the public
-`collect_news(NewsWindow, *, cfg)` call unchanged.
+When a second source is implemented, compare its real behavior with PR Newswire first. Add a shared collector interface only for behavior that both working collectors actually share. Keep the public `collect_news(NewsWindow, *, cfg)` call unchanged.
 
 ## Adding a Public News Source
 
@@ -261,16 +179,9 @@ A coding agent adding a second source follows this checklist:
 1. Add the source name to `NewsWindow.source`.
 2. Add one private `quantmind/preprocess/<source>.py` collector.
 3. Add one explicit branch to `collect_news`; the type checker must pass.
-4. Add saved-input tests for success, time edges, duplicate observations,
-   partial failures, and the `complete` flag.
+4. Add saved-input tests for success, time edges, duplicate observations, partial failures, and the `complete` flag.
 5. Add a test proving that only the selected collector is called.
-6. Update the supported-source table in `docs/README.md`, this design, and the
-   focused example if its common path changes.
-7. Add or extend a component-specific live verifier and its named job in the
-   existing `.github/workflows/e2e.yml` when the integration depends on a
-   public network endpoint. Add its command to `docs/README.md`; do not add the
-   command to root agent guidance.
+6. Update the supported-source table in `docs/README.md`, this design, and the focused example if its common path changes.
+7. Add or extend a component-specific live verifier and its named job in the existing `.github/workflows/e2e.yml` when the integration depends on a public network endpoint. Add its command to `docs/README.md`; do not add the command to root agent guidance.
 
-Only after two real collectors share behavior should they use a common Python
-`Protocol`. Never add a source only to the input `Literal`; the type checker is
-expected to reject that incomplete change.
+Only after two real collectors share behavior should they use a common Python `Protocol`. Never add a source only to the input `Literal`; the type checker is expected to reject that incomplete change.

--- a/contexts/design/knowledge/paper.md
+++ b/contexts/design/knowledge/paper.md
@@ -71,10 +71,7 @@ Every chunk span is also checked against that manifest: its page must exist, its
 
 Changing any producer field creates a distinct artifact ID. Multiple chunk sets and summaries may coexist for one source revision. Loading a complete `PaperFlowResult` without explicit artifact IDs is allowed only when one unambiguous linked pair exists.
 
-`PaperStructureTree.producer` records model and prompt identity, the
-instructions hash, the bounded physical-page text input policy, and tree/output
-bounds. It deliberately records no splitter or chunk-set identity. Rechunking
-an unchanged source therefore does not create a different structure tree.
+`PaperStructureTree.producer` records model and prompt identity, the instructions hash, the bounded physical-page text input policy, and tree/output bounds. It deliberately records no splitter or chunk-set identity. Rechunking an unchanged source therefore does not create a different structure tree.
 
 ## Citation and Lineage Integrity
 
@@ -82,10 +79,7 @@ A `PaperCitation` identifies the exact chunk set, chunk, page, and optional verb
 
 `PaperGlobalSummary.derived_from` contains `ArtifactLocator` values. At least one locator must point to its producer's exact input chunk set, with the same source revision and no member ID. The library stores this relationship explicitly so lineage can be checked independently from the summary JSON.
 
-`PaperStructureTree` binds directly to one `PaperSourceRevision`. Each node
-carries inclusive physical-page citations with no chunk coordinates, and the
-root must cover every source page. The tree has no artifact lineage because no
-chunk set or summary is an input to its construction.
+`PaperStructureTree` binds directly to one `PaperSourceRevision`. Each node carries inclusive physical-page citations with no chunk coordinates, and the root must cover every source page. The tree has no artifact lineage because no chunk set or summary is an input to its construction.
 
 ## Retrieval Boundary
 

--- a/contexts/design/library/local.md
+++ b/contexts/design/library/local.md
@@ -81,11 +81,7 @@ The transaction writes or reuses the source, asset blobs, artifacts, members, li
 
 Putting an unchanged result is idempotent and reuses valid vectors. The same source may own multiple chunk-set and summary versions. Artifact identity includes producer configuration, so one version never silently replaces another.
 
-`put_paper_structure_tree(source, tree)` is a separate vectorless transaction.
-It validates that every node citation belongs to the exact source, writes or
-reuses the source and its assets, then stores the tree and normalized members.
-It does not require `put_paper()`, a chunk set, an embedding provider call, or
-artifact-lineage rows.
+`put_paper_structure_tree(source, tree)` is a separate vectorless transaction. It validates that every node citation belongs to the exact source, writes or reuses the source and its assets, then stores the tree and normalized members. It does not require `put_paper()`, a chunk set, an embedding provider call, or artifact-lineage rows.
 
 ## Search Projections
 
@@ -128,8 +124,7 @@ Paper projections inherit both times from their exact source revision. This prev
 
 ## Integrity and Migration
 
-Open performs an explicit SQLite user-version migration from schema 2 to schema 3 by adding paper tables and indexes without rewriting conventional knowledge. Older canonical class references for the pre-V1 paper tree load as `LegacyPaper` solely for database compatibility.
-Schema 3 to 4 permits zero-projection artifacts and adds hierarchical member parents without rewriting conventional knowledge.
+Open performs an explicit SQLite user-version migration from schema 2 to schema 3 by adding paper tables and indexes without rewriting conventional knowledge. Older canonical class references for the pre-V1 paper tree load as `LegacyPaper` solely for database compatibility. Schema 3 to 4 permits zero-projection artifacts and adds hierarchical member parents without rewriting conventional knowledge.
 
 Reads fail closed when canonical hashes, counts, IDs, membership, lineage, source relationships, vector bytes, or asset metadata disagree. Blob SHA-256 hashes and byte lengths are checked, and stored asset table fields must match the canonical source manifest. Missing IDs raise `KeyError`; stale or corrupt linked state raises `RuntimeError` with context.
 

--- a/contexts/design/mind/retrieval.md
+++ b/contexts/design/mind/retrieval.md
@@ -2,29 +2,12 @@
 
 ## Quick Summary
 
-- **Purpose**: Define how a paper becomes a self-contained page-preserving
-  structure tree, how that tree is persisted and reopened, and how a reasoning
-  agent retrieves evidence from it without embeddings replacing reasoning.
-- **Read when**: Designing or changing PageIndex-style tree construction, the
-  `PaperFlow` pipeline collection, the `mind` retrieval operation, structure-tree
-  persistence, or future hybrid semantic-plus-agentic retrieval.
-- **Status**: Redesigned (2026-07). Supersedes the earlier "vectorless empty
-  shell + library page refill" design. The structure tree now carries its own
-  node content; retrieval is a pure value operation over that tree; the library
-  dumps and loads the tree as an independent artifact. Semantic node projections
-  and hybrid seeding remain deferred.
-- **Core rule**: **Pipelines produce complete, self-contained artifacts;
-  persistence and retrieval are separate downstream concerns.** A structure
-  tree's nodes carry their own text (and optionally an embedding), so the tree
-  is usable the moment a pipeline returns it — in memory, with no library. The
-  library only dumps and loads that value; single-tree retrieval reasons over
-  the tree value and returns **evidence values**, never a bare reference that
-  forces a library round-trip. Retrieval reasons over titles and summaries;
-  embeddings are a coarse pre-filter added later, never a replacement.
+- **Purpose**: Define how a paper becomes a self-contained page-preserving structure tree, how that tree is persisted and reopened, and how a reasoning agent retrieves evidence from it without embeddings replacing reasoning.
+- **Read when**: Designing or changing PageIndex-style tree construction, the `PaperFlow` pipeline collection, the `mind` retrieval operation, structure-tree persistence, or future hybrid semantic-plus-agentic retrieval.
+- **Status**: Redesigned (2026-07). Supersedes the earlier "vectorless empty shell + library page refill" design. The structure tree now carries its own node content; retrieval is a pure value operation over that tree; the library dumps and loads the tree as an independent artifact. Semantic node projections and hybrid seeding remain deferred.
+- **Core rule**: **Pipelines produce complete, self-contained artifacts; persistence and retrieval are separate downstream concerns.** A structure tree's nodes carry their own text (and optionally an embedding), so the tree is usable the moment a pipeline returns it — in memory, with no library. The library only dumps and loads that value; single-tree retrieval reasons over the tree value and returns **evidence values**, never a bare reference that forces a library round-trip. Retrieval reasons over titles and summaries; embeddings are a coarse pre-filter added later, never a replacement.
 - **Canonical models**: [Paper source and artifact design](../knowledge/paper.md).
-- **Related work**: issues #122 (context), #95 (feature request), #71 (`mind`
-  scaffold), #120 (source-first Paper Flow V1); prior art `VectifyAI/PageIndex`
-  (MIT).
+- **Related work**: issues #122 (context), #95 (feature request), #71 (`mind` scaffold), #120 (source-first Paper Flow V1); prior art `VectifyAI/PageIndex` (MIT).
 
 ## Contents
 
@@ -46,53 +29,24 @@
 
 ## Motivation
 
-Vector retrieval assumes the passage most similar to a query in embedding space
-is the most relevant one. For long, structured financial documents that
-assumption breaks: near-identical passages differ on a threshold or exception;
-fixed-size chunking fragments a table; a cross-reference such as "see Item 7A"
-shares no similarity with its target; and a stateless retriever cannot use prior
-reasoning to decide where to look.
+Vector retrieval assumes the passage most similar to a query in embedding space is the most relevant one. For long, structured financial documents that assumption breaks: near-identical passages differ on a threshold or exception; fixed-size chunking fragments a table; a cross-reference such as "see Item 7A" shares no similarity with its target; and a stateless retriever cannot use prior reasoning to decide where to look.
 
-Reasoning-based retrieval reframes the problem as relevance classification over a
-document's real structure: an agent reads a tree of section titles and
-summaries, picks a branch, drills down, and reads leaf text with exact page
-provenance. `quantmind.knowledge` already records this as the purpose of
-`TreeKnowledge`, and embeddings there "act as a coarse pre-filter, never as a
-replacement for that reasoning."
+Reasoning-based retrieval reframes the problem as relevance classification over a document's real structure: an agent reads a tree of section titles and summaries, picks a branch, drills down, and reads leaf text with exact page provenance. `quantmind.knowledge` already records this as the purpose of `TreeKnowledge`, and embeddings there "act as a coarse pre-filter, never as a replacement for that reasoning."
 
-The earlier build of this feature made the tree an *empty shell*: nodes stored
-only titles, summaries, and page citations, and leaf text was refilled at query
-time from the library via `resolve(locator)`. That coupled two things that
-should be independent — the tree artifact and the store — and made single-tree
-retrieval impossible without a library. This design removes that coupling.
+The earlier build of this feature made the tree an *empty shell*: nodes stored only titles, summaries, and page citations, and leaf text was refilled at query time from the library via `resolve(locator)`. That coupled two things that should be independent — the tree artifact and the store — and made single-tree retrieval impossible without a library. This design removes that coupling.
 
 ## Pipelines vs Components (Altitude)
 
-This feature is the worked example for the repository's altitude rule (see
-[operations/orchestration.md](../operations/orchestration.md)). Two layers, two
-jobs:
+This feature is the worked example for the repository's altitude rule (see [operations/orchestration.md](../operations/orchestration.md)). Two layers, two jobs:
 
-- **Pipelines** (`quantmind.flows`) are finished, batteries-included workflows.
-  A caller states an intent — "turn this paper into a structure tree" — and gets
-  back a **complete, self-contained artifact**. A pipeline is pure processing:
-  `input → artifact`. It does **not** bind a library, persist anything, or
-  retrieve. Producing the artifact fully — including any embeddings it carries —
-  is the pipeline's job.
-- **Components** (`knowledge`, `preprocess`, `rag`, `library`, `mind`) are the
-  building blocks. A caller who wants only an intermediate (just the parsed
-  source, just chunks) uses a component directly and wires it themselves. A
-  half-finished intermediate is **not** promoted to a public pipeline.
+- **Pipelines** (`quantmind.flows`) are finished, batteries-included workflows. A caller states an intent — "turn this paper into a structure tree" — and gets back a **complete, self-contained artifact**. A pipeline is pure processing: `input → artifact`. It does **not** bind a library, persist anything, or retrieve. Producing the artifact fully — including any embeddings it carries — is the pipeline's job.
+- **Components** (`knowledge`, `preprocess`, `rag`, `library`, `mind`) are the building blocks. A caller who wants only an intermediate (just the parsed source, just chunks) uses a component directly and wires it themselves. A half-finished intermediate is **not** promoted to a public pipeline.
 
-Persistence (`library`) and retrieval (`mind`) are **downstream** of a pipeline,
-not part of it. A structure tree returned by `PaperFlow(cfg).build(input)` is
-immediately usable; putting it in a library and retrieving from it are separate,
-optional steps a caller chooses.
+Persistence (`library`) and retrieval (`mind`) are **downstream** of a pipeline, not part of it. A structure tree returned by `PaperFlow(cfg).build(input)` is immediately usable; putting it in a library and retrieving from it are separate, optional steps a caller chooses.
 
 ## Design at a Glance
 
-The build spine is solid; the dotted branch is the later hybrid path that adds
-embeddings. Processing (including any embeddings) belongs to the pipeline;
-`library` only stores and loads; `mind` only retrieves.
+The build spine is solid; the dotted branch is the later hybrid path that adds embeddings. Processing (including any embeddings) belongs to the pipeline; `library` only stores and loads; `mind` only retrieves.
 
 ```mermaid
 flowchart TD
@@ -127,62 +81,29 @@ flowchart TD
 | `quantmind.library` | Dump a self-contained tree and load it back unchanged (`put` / `open_structure`). A tree is an **independent** artifact: its library need not contain a chunk set, and loading it never depends on refilling text from another artifact. |
 | `quantmind.mind` | `AgenticRetriever(cfg)` binds the strategy config; `retrieve(tree, question)` reasons over one explicit tree value and returns evidence values with content already in them. It does **not** take or bind a library. |
 
-`quantmind.rag` is unchanged: deterministic chunking and BM25, no LLM, no
-PageIndex producer.
+`quantmind.rag` is unchanged: deterministic chunking and BM25, no LLM, no PageIndex producer.
 
 ## Self-Contained Structure Tree
 
-`StructureTree` stays the shared structural base (a plain `BaseModel`:
-`root_node_id`, `nodes`, the `root()` / `children_of()` / `walk_dfs()` /
-`find_path()` traversal surface, and the `validate()` integrity gate). Identity
-is added by subclasses.
+`StructureTree` stays the shared structural base (a plain `BaseModel`: `root_node_id`, `nodes`, the `root()` / `children_of()` / `walk_dfs()` / `find_path()` traversal surface, and the `validate()` integrity gate). Identity is added by subclasses.
 
 The change is in what a node holds. `TreeNode` already has a
 `content: str | None` field; the previous design **forbade** populating it
-(`PaperStructureTree` raised "nodes must not copy content"). That rule is
-**inverted**:
+(`PaperStructureTree` raised "nodes must not copy content"). That rule is **inverted**:
 
-- A `PaperStructureTree` leaf node **carries its own `content`** — the text of
-  the physical source pages it cites, read from the exact source revision at
-  build time. The tree is self-contained: it no longer depends on the source
-  revision or a chunk set to yield node text.
-- The tree also carries the **minimal provenance metadata** it needs to be
-  stored and time-queried standalone: `as_of` (financial time, copied from the
-  source revision) plus a light source ref (uri / title) and the source content
-  hash. This metadata is **not** part of `id` / `content_hash` — a rebuild at a
-  different wall-clock time yields the same identity. It is shared via a light
-  provenance base (an `ArtifactMeta`-style mixin), **not** full `BaseKnowledge`:
-  a structure tree is a derived artifact, not canonical knowledge. With it,
-  `library.put(tree)` stores the tree with no other object required.
-- A node **may** additionally carry an optional `embedding` (reserved for the
-  later hybrid path). Pure agentic retrieval does not need it; when present it is
-  produced by the pipeline and persisted with the tree, never computed at
-  `library.put` time.
-- `content_hash` covers node content (it hashes the full node dump), so a
-  self-contained tree versions by its content as expected; the provenance
-  metadata stays outside it.
-- The redundancy is deliberate and accepted: a structure tree is a derived,
-  rebuildable artifact; carrying its own text and light provenance in a local
-  knowledge base is worth far more (self-contained, independently retrievable,
-  dump/load symmetric) than the storage saved by an empty shell.
+- A `PaperStructureTree` leaf node **carries its own `content`** — the text of the physical source pages it cites, read from the exact source revision at build time. The tree is self-contained: it no longer depends on the source revision or a chunk set to yield node text.
+- The tree also carries the **minimal provenance metadata** it needs to be stored and time-queried standalone: `as_of` (financial time, copied from the source revision) plus a light source ref (uri / title) and the source content hash. This metadata is **not** part of `id` / `content_hash` — a rebuild at a different wall-clock time yields the same identity. It is shared via a light provenance base (an `ArtifactMeta`-style mixin), **not** full `BaseKnowledge`: a structure tree is a derived artifact, not canonical knowledge. With it, `library.put(tree)` stores the tree with no other object required.
+- A node **may** additionally carry an optional `embedding` (reserved for the later hybrid path). Pure agentic retrieval does not need it; when present it is produced by the pipeline and persisted with the tree, never computed at `library.put` time.
+- `content_hash` covers node content (it hashes the full node dump), so a self-contained tree versions by its content as expected; the provenance metadata stays outside it.
+- The redundancy is deliberate and accepted: a structure tree is a derived, rebuildable artifact; carrying its own text and light provenance in a local knowledge base is worth far more (self-contained, independently retrievable, dump/load symmetric) than the storage saved by an empty shell.
 
-Page ranges still reuse `Citation`: a node spanning pages 5-8 carries four
-`Citation(page=5..8)` entries. The integrity gate still requires single-rooted,
-acyclic, fully reachable topology; bidirectional parent/child links; unique
-sibling positions; every cited page inside the source; and every child's pages
-contained in its parent's. The only relaxed rule is the content prohibition.
+Page ranges still reuse `Citation`: a node spanning pages 5-8 carries four `Citation(page=5..8)` entries. The integrity gate still requires single-rooted, acyclic, fully reachable topology; bidirectional parent/child links; unique sibling positions; every cited page inside the source; and every child's pages contained in its parent's. The only relaxed rule is the content prohibition.
 
-A future document type adds its own `StructureTree` subclass with its own source
-binding and its own content-population step; nothing paper-specific leaks into
-the base.
+A future document type adds its own `StructureTree` subclass with its own source binding and its own content-population step; nothing paper-specific leaks into the base.
 
 ## The PaperFlow Pipeline Collection
 
-`PaperFlow` is a **config-bound** flow: you bind the settings once at
-construction, and `build(input)` applies them to each input. The cfg **type**
-selects which knowledge shape it produces — a paper projects into several
-knowledge shapes (tree / flatten / graph), and none is privileged over the
-others.
+`PaperFlow` is a **config-bound** flow: you bind the settings once at construction, and `build(input)` applies them to each input. The cfg **type** selects which knowledge shape it produces — a paper projects into several knowledge shapes (tree / flatten / graph), and none is privileged over the others.
 
 ```python
 from quantmind.flows import PaperFlow, batch_run
@@ -197,24 +118,14 @@ trees = await batch_run(tree_flow.build, inputs)
 
 Rules:
 
-- **Bind the config, not the input.** `PaperFlow(cfg)` stores the immutable cfg;
-  `build(input)` takes only the operand. A batch therefore runs every input under
-  one unified setting, and a config can never drift mid-run — a reproducibility
-  requirement, not ergonomics.
-- **The cfg type picks the shape.** `PaperStructureCfg` → `PaperStructureTree`
-  (implemented now). A later `PaperCardCfg` → the chunk/summary shape reached
-  through the same `build` seam; the existing `paper_flow(input, *, cfg)` function
-  stays as a thin compatibility wrapper for that semantic shape until it lands.
-- **Pure processing.** `build` fetches, parses, and structures, producing the
-  complete self-contained artifact. It binds **no** library, persists nothing,
-  and does not retrieve.
-- A caller who wants only the parsed source uses `quantmind.preprocess` directly;
-  "parse only" is a component seam, not a public pipeline.
+- **Bind the config, not the input.** `PaperFlow(cfg)` stores the immutable cfg; `build(input)` takes only the operand. A batch therefore runs every input under one unified setting, and a config can never drift mid-run — a reproducibility requirement, not ergonomics.
+- **The cfg type picks the shape.** `PaperStructureCfg` → `PaperStructureTree` (implemented now). A later `PaperCardCfg` → the chunk/summary shape reached through the same `build` seam; the existing `paper_flow(input, *, cfg)` function stays as a thin compatibility wrapper for that semantic shape until it lands.
+- **Pure processing.** `build` fetches, parses, and structures, producing the complete self-contained artifact. It binds **no** library, persists nothing, and does not retrieve.
+- A caller who wants only the parsed source uses `quantmind.preprocess` directly; "parse only" is a component seam, not a public pipeline.
 
 ## Persistence: Dump / Load Symmetry
 
-Because the tree is a self-contained value with its own provenance metadata, the
-library reduces to dump/load and needs no second object:
+Because the tree is a self-contained value with its own provenance metadata, the library reduces to dump/load and needs no second object:
 
 ```python
 tree_flow = PaperFlow(PaperStructureCfg())
@@ -224,27 +135,14 @@ await library.put(tree)                          # dump: nodes, text, embeddings
 tree2 = await library.open_structure(tree.id)    # load: identical value object
 ```
 
-- `library.put(tree)` serializes the whole self-contained tree (structure, node
-  text, any node embeddings, and the `as_of` / source-ref provenance). It
-  requires **no** source revision or chunk set. Storing the raw source is a
-  separate, independent `library.put(source)` when a caller wants the PDF kept.
-- `library.open_structure(tree_id)` returns the same `PaperStructureTree` value,
-  embeddings and metadata included.
-- The library is one store holding **independent** artifacts side by side —
-  `PaperSourceRevision`, `PaperChunkSet`, `PaperStructureTree`. A tree does not
-  imply a chunk set or a stored source, and vice versa.
-- The old `resolve(locator)` **text-refill** path for structure-tree nodes is
-  gone; a resolved node returns its own stored content. `resolve` remains for
-  cross-document reference resolution (see below), but single-tree retrieval
-  never uses it.
+- `library.put(tree)` serializes the whole self-contained tree (structure, node text, any node embeddings, and the `as_of` / source-ref provenance). It requires **no** source revision or chunk set. Storing the raw source is a separate, independent `library.put(source)` when a caller wants the PDF kept.
+- `library.open_structure(tree_id)` returns the same `PaperStructureTree` value, embeddings and metadata included.
+- The library is one store holding **independent** artifacts side by side — `PaperSourceRevision`, `PaperChunkSet`, `PaperStructureTree`. A tree does not imply a chunk set or a stored source, and vice versa.
+- The old `resolve(locator)` **text-refill** path for structure-tree nodes is gone; a resolved node returns its own stored content. `resolve` remains for cross-document reference resolution (see below), but single-tree retrieval never uses it.
 
 ## Retrieval Returns Values, Not References
 
-Single-tree retrieval is a **pure value operation** over a self-contained tree.
-`AgenticRetriever(cfg)` binds the retrieval config; `retrieve(retrievable, question)`
-takes only the operand — a `Retrievable` (a `StructureTree` today; it widens
-within `knowledge` to other reasoning-able shapes such as a graph, never to a
-vector store):
+Single-tree retrieval is a **pure value operation** over a self-contained tree. `AgenticRetriever(cfg)` binds the retrieval config; `retrieve(retrievable, question)` takes only the operand — a `Retrievable` (a `StructureTree` today; it widens within `knowledge` to other reasoning-able shapes such as a graph, never to a vector store):
 
 ```python
 from quantmind.mind import AgenticRetriever
@@ -256,8 +154,7 @@ for item in evidence:
     print(item.title, item.content)     # content is already here; no library
 ```
 
-`RetrievalEvidence` carries the **value**, with the reference as an optional
-provenance field, not the path to the content:
+`RetrievalEvidence` carries the **value**, with the reference as an optional provenance field, not the path to the content:
 
 ```python
 class RetrievalEvidence(BaseModel):
@@ -267,121 +164,58 @@ class RetrievalEvidence(BaseModel):
     locator: ArtifactLocator | None = None  # optional: for cross-artifact fusion
 ```
 
-Why this shape resolves the reference dilemma: if retrieval returned a bare node
-**reference**, the consumer would have to resolve it against a library, making
-every single-tree retrieval library-dependent. Because the tree is
-self-contained, retrieval reads `tree.nodes[id].content` directly and returns
-it. The `locator` is there for when a caller *wants* to fuse or re-open across
-artifacts — an optional capability, never the only way to see content.
+Why this shape resolves the reference dilemma: if retrieval returned a bare node **reference**, the consumer would have to resolve it against a library, making every single-tree retrieval library-dependent. Because the tree is self-contained, retrieval reads `tree.nodes[id].content` directly and returns it. The `locator` is there for when a caller *wants* to fuse or re-open across artifacts — an optional capability, never the only way to see content.
 
-There is one strategy: **agentic traversal**. The retriever exposes two SDK
-`@function_tool` functions — `get_document_structure()` (tree without leaf text)
-and `get_node_content(node_ids)` (leaf text read from `tree.nodes`, **not** a
-library) — and lets an Agent decide, turn by turn, which node to open. Content
-for a selected non-leaf node is assembled from its descendant leaves. Mechanical
-retrieval (semantic vector search / BM25) is a different layer entirely
-(`library.search` / `rag`); `mind` never re-implements it, and a future hybrid
-path composes the two rather than adding a "semantic strategy" here.
+There is one strategy: **agentic traversal**. The retriever exposes two SDK `@function_tool` functions — `get_document_structure()` (tree without leaf text) and `get_node_content(node_ids)` (leaf text read from `tree.nodes`, **not** a library) — and lets an Agent decide, turn by turn, which node to open. Content for a selected non-leaf node is assembled from its descendant leaves. Mechanical retrieval (semantic vector search / BM25) is a different layer entirely (`library.search` / `rag`); `mind` never re-implements it, and a future hybrid path composes the two rather than adding a "semantic strategy" here.
 
-`retrieve` calls `agents.Runner.run(...)` with its own `RunConfig`; it does not
-import `flows._runner`. Serialization is bounded by a structure token budget.
-Seeds (when a hybrid shortlist eventually supplies them) are **in-tree node
-ids**, validated against `tree.nodes`; they carry no library dependency.
+`retrieve` calls `agents.Runner.run(...)` with its own `RunConfig`; it does not import `flows._runner`. Serialization is bounded by a structure token budget. Seeds (when a hybrid shortlist eventually supplies them) are **in-tree node ids**, validated against `tree.nodes`; they carry no library dependency.
 
 ## Callable Shape
 
-Both public callables **bind their cfg** and take only the operand per call,
-following the repository's altitude rule
-([operations/naming.md](../operations/naming.md)):
+Both public callables **bind their cfg** and take only the operand per call, following the repository's altitude rule ([operations/naming.md](../operations/naming.md)):
 
-- `AgenticRetriever(cfg)` is a **class**, not a function. It binds the retrieval
-  config so a batch of queries runs under one fixed setting — reproducibility, not
-  ceremony. (The earlier `StructureRetriever` bound a *library*; that binding is
-  gone now that the tree is self-contained, but the *config* binding remains, so
-  the class stays — an absent external dependency is not a reason to demote it.)
-  It has a **single behavior** — an LLM agent reasons over the structure — so it
-  does no cfg-type dispatch. That is deliberate: `mind` is the reasoning layer,
-  and mechanical retrieval (semantic / BM25) stays in `library` / `rag`, never a
-  second strategy bolted onto this class.
-- `PaperFlow(cfg)` is a **class** for the same reason: it binds the build config
-  once so a batch builds every input identically, and its cfg type selects the
-  knowledge shape. It binds no source, no store, and no per-call state.
+- `AgenticRetriever(cfg)` is a **class**, not a function. It binds the retrieval config so a batch of queries runs under one fixed setting — reproducibility, not ceremony. (The earlier `StructureRetriever` bound a *library*; that binding is gone now that the tree is self-contained, but the *config* binding remains, so the class stays — an absent external dependency is not a reason to demote it.) It has a **single behavior** — an LLM agent reasons over the structure — so it does no cfg-type dispatch. That is deliberate: `mind` is the reasoning layer, and mechanical retrieval (semantic / BM25) stays in `library` / `rag`, never a second strategy bolted onto this class.
+- `PaperFlow(cfg)` is a **class** for the same reason: it binds the build config once so a batch builds every input identically, and its cfg type selects the knowledge shape. It binds no source, no store, and no per-call state.
 
 ## Future Multi-Document Composition
 
-References and the library earn their keep at **corpus scale**, which is exactly
-where single-tree value retrieval stops fitting in memory:
+References and the library earn their keep at **corpus scale**, which is exactly where single-tree value retrieval stops fitting in memory:
 
-1. select candidate documents using metadata, descriptions, or global-summary
-   projections;
+1. select candidate documents using metadata, descriptions, or global-summary projections;
 2. `library.open_structure(...)` each candidate tree by identity;
 3. reuse one `AgenticRetriever(cfg).retrieve(tree, question)` per explicit tree;
-4. fuse evidence using the full `(source_revision_id, artifact_id, node_id)`
-   locator carried on each `RetrievalEvidence`.
+4. fuse evidence using the full `(source_revision_id, artifact_id, node_id)` locator carried on each `RetrievalEvidence`.
 
-Here the `locator` field and library-backed `resolve` are the right tools:
-you cannot hold thousands of trees in memory, so you shortlist by reference and
-open on demand. The current release does not implement the collection router or
-evidence fusion; the seam is the optional `locator` on evidence plus
-independent per-artifact persistence.
+Here the `locator` field and library-backed `resolve` are the right tools: you cannot hold thousands of trees in memory, so you shortlist by reference and open on demand. The current release does not implement the collection router or evidence fusion; the seam is the optional `locator` on evidence plus independent per-artifact persistence.
 
 ## Multi-Model Compatibility
 
-- **Rely on the SDK.** `cfg.model` (a plain string, including a
-  `litellm/<provider>/<model>` value) flows unchanged into the SDK `Runner`.
-- **Capability requirement.** Draft structuring needs reliable structured output;
-  agentic traversal needs tool-calling. A provider lacking a stage's capability
-  is unsupported for that stage. Tests cover at least one non-OpenAI model.
-- **Embeddings.** The later hybrid step depends only on the library's existing
-  embedding seam and on `SemanticQuery` / `SemanticHit`, never on a specific
-  vendor.
+- **Rely on the SDK.** `cfg.model` (a plain string, including a `litellm/<provider>/<model>` value) flows unchanged into the SDK `Runner`.
+- **Capability requirement.** Draft structuring needs reliable structured output; agentic traversal needs tool-calling. A provider lacking a stage's capability is unsupported for that stage. Tests cover at least one non-OpenAI model.
+- **Embeddings.** The later hybrid step depends only on the library's existing embedding seam and on `SemanticQuery` / `SemanticHit`, never on a specific vendor.
 
 ## Hybrid Search Compatibility
 
-Hybrid retrieval — shortlist nodes by semantic search, then reason over the
-shortlist — is a later, explicit step. Node embeddings are produced **by the
-pipeline** and persisted **with the tree** (not computed at `put` time), so the
-tree stays self-contained end to end. Two independent embedding sets can then
-coexist in one library — chunk-set embeddings and structure-node embeddings —
-and hybrid queries both. Seeds remain validated in-tree node ids; a hit never
-becomes an answer without the reasoning step.
+Hybrid retrieval — shortlist nodes by semantic search, then reason over the shortlist — is a later, explicit step. Node embeddings are produced **by the pipeline** and persisted **with the tree** (not computed at `put` time), so the tree stays self-contained end to end. Two independent embedding sets can then coexist in one library — chunk-set embeddings and structure-node embeddings — and hybrid queries both. Seeds remain validated in-tree node ids; a hit never becomes an answer without the reasoning step.
 
 ## Boundaries and Import Contracts
 
 - `library` and `rag` must not import `quantmind.mind`.
-- `mind` may import `knowledge`, `configs`, and `utils`. It **no longer needs to
-  import `library`** for retrieval: single-tree `retrieve` is library-free. The
-  existing `mind -> library` allowance may stay for the future collection path,
-  but the retrieval operation must not depend on it.
-- `flows` is the apex and may import `knowledge`, `preprocess`, `rag`, `configs`,
-  `mind`, and `utils`. `PaperFlow` imports no library.
-- Update the `import-linter` contracts if the `mind -> library` edge is dropped
-  from the retrieval path; keep every other edge intact.
+- `mind` may import `knowledge`, `configs`, and `utils`. It **no longer needs to import `library`** for retrieval: single-tree `retrieve` is library-free. The existing `mind -> library` allowance may stay for the future collection path, but the retrieval operation must not depend on it.
+- `flows` is the apex and may import `knowledge`, `preprocess`, `rag`, `configs`, `mind`, and `utils`. `PaperFlow` imports no library.
+- Update the `import-linter` contracts if the `mind -> library` edge is dropped from the retrieval path; keep every other edge intact.
 
 ## Verification Slice
 
-Offline tests use fixed PDFs and fake model outputs. They cover: a table of
-contents, a missing table of contents, a printed page-number reset, and an
-in-body cross-reference; every tree-integrity rejection; **node content
-populated from cited pages and preserved through dump/load**; stable IDs and
-idempotent re-runs; a tree persisted and reopened as an identical self-contained
-value **without any chunk set present**, with `as_of` / provenance preserved;
-agentic retrieval returning evidence **whose content comes from the tree, with
-no library involved**; a bound `PaperFlow(cfg)` producing a self-contained tree
-with the cfg *type* selecting the shape; `AgenticRetriever(cfg)` binding its
-config; multi-model identity forwarding; and in-tree seed validation. P2 adds
-seeded semantic-shortlist tests once node projections exist.
+Offline tests use fixed PDFs and fake model outputs. They cover: a table of contents, a missing table of contents, a printed page-number reset, and an in-body cross-reference; every tree-integrity rejection; **node content populated from cited pages and preserved through dump/load**; stable IDs and idempotent re-runs; a tree persisted and reopened as an identical self-contained value **without any chunk set present**, with `as_of` / provenance preserved; agentic retrieval returning evidence **whose content comes from the tree, with no library involved**; a bound `PaperFlow(cfg)` producing a self-contained tree with the cfg *type* selecting the shape; `AgenticRetriever(cfg)` binding its config; multi-model identity forwarding; and in-tree seed validation. P2 adds seeded semantic-shortlist tests once node projections exist.
 
 ## Out of Scope
 
 - an empty-shell tree or a query-time text-refill path;
-- a nested `TreeKnowledge` inside an artifact, or a second parallel tree
-  implementation;
+- a nested `TreeKnowledge` inside an artifact, or a second parallel tree implementation;
 - a `Citation.end_page` field or a separate page-resolver concept;
 - a shared runtime module or moving `flows._runner`;
-- a generic retriever hierarchy, vector-store abstraction, provider registry, or
-  query-engine hierarchy (a single `retrieve` that branches on cfg/kind is not
-  this);
+- a generic retriever hierarchy, vector-store abstraction, provider registry, or query-engine hierarchy (a single `retrieve` that branches on cfg/kind is not this);
 - answer synthesis or agent memory inside the retrieval primitive;
 - collection routing or evidence fusion in this release;
 - knowledge-graph construction.

--- a/contexts/design/operations/naming.md
+++ b/contexts/design/operations/naming.md
@@ -19,13 +19,9 @@
 
 ## Scope
 
-This page defines how to name public QuantMind functions and small service
-classes. It does not rename packages or existing callables. Any existing name
-change needs a separate plan for users who depend on the old name.
+This page defines how to name public QuantMind functions and small service classes. It does not rename packages or existing callables. Any existing name change needs a separate plan for users who depend on the old name.
 
-The runtime library API is designed for Python callers. Repository guidance
-for coding agents belongs in `AGENTS.md`, skills, docs, fixtures, and checks;
-it does not belong in the runtime API.
+The runtime library API is designed for Python callers. Repository guidance for coding agents belongs in `AGENTS.md`, skills, docs, fixtures, and checks; it does not belong in the runtime API.
 
 ## Name Patterns
 
@@ -40,83 +36,46 @@ Start a public function name with a verb that describes its result:
 | Generic execution | `batch_run` and similar helpers | Apply an operation to a batch without changing what the operation means |
 | Pipeline | `<domain>_<purpose>_pipeline` | Combine several named operations into one reusable function |
 
-`flow` is not a verb that explains a result. Do not add a public `*_flow`
-**function** name only because a function performs several steps. Name the
-result precisely, or use `*_pipeline` when the function combines multiple public
-operations.
+`flow` is not a verb that explains a result. Do not add a public `*_flow` **function** name only because a function performs several steps. Name the result precisely, or use `*_pipeline` when the function combines multiple public operations.
 
-`Flow` as a **noun**, on a domain object that binds a config and applies the
-finished pipeline to each input, is allowed and preferred there: `PaperFlow(cfg)`
-binds the settings once; `build(input)` applies them to each input. The object
-reads as "the paper's workflow," its *method* uses an intent verb (`build`), and
-the cfg *type* selects which knowledge shape it produces. What stays banned is
-`flow` as a verb or a `do_x_flow()` function name.
+`Flow` as a **noun**, on a domain object that binds a config and applies the finished pipeline to each input, is allowed and preferred there: `PaperFlow(cfg)` binds the settings once; `build(input)` applies them to each input. The object reads as "the paper's workflow," its *method* uses an intent verb (`build`), and the cfg *type* selects which knowledge shape it produces. What stays banned is `flow` as a verb or a `do_x_flow()` function name.
 
 ## Service Class Patterns
 
-Use a service class only when repeated calls share dependencies, policy, or a
-lifecycle that belongs at construction time. Keep the active input and result
-on method arguments and return values rather than mutable instance state.
+Use a service class only when repeated calls share dependencies, policy, or a lifecycle that belongs at construction time. Keep the active input and result on method arguments and return values rather than mutable instance state.
 
-- Name the class by its stable role (a `*Builder` / `*Store` noun), not by a
-  single method it exposes.
-- Name its primary async methods with the same intent verbs used for functions,
-  such as `build()` or `retrieve()`.
+- Name the class by its stable role (a `*Builder` / `*Store` noun), not by a single method it exposes.
+- Name its primary async methods with the same intent verbs used for functions, such as `build()` or `retrieve()`.
 - Do not add a class only to group helpers or shorten one function signature.
-- Do not put model clients, stores, or runtime policy on frozen knowledge
-  artifacts; services consume and return those canonical values.
-- Do not add a base service, registry, or manager hierarchy around one concrete
-  implementation.
-- **Config binding alone justifies a class.** A class earns its keep by binding
-  the immutable `cfg` that must stay constant across a batch, even with no store
-  or provider to hold. `AgenticRetriever(RetrievalCfg(...))` binds the retrieval
-  config once; `retrieve(structure, question)` takes only the operand. Do not
-  demote such a class to a function just because it holds no external dependency.
+- Do not put model clients, stores, or runtime policy on frozen knowledge artifacts; services consume and return those canonical values.
+- Do not add a base service, registry, or manager hierarchy around one concrete implementation.
+- **Config binding alone justifies a class.** A class earns its keep by binding the immutable `cfg` that must stay constant across a batch, even with no store or provider to hold. `AgenticRetriever(RetrievalCfg(...))` binds the retrieval config once; `retrieve(structure, question)` takes only the operand. Do not demote such a class to a function just because it holds no external dependency.
 
 ## Config-Bound Flow Patterns
 
-A domain flow binds an immutable `cfg` at construction and applies it to each
-input, so a batch runs under one unified, reproducible setting:
+A domain flow binds an immutable `cfg` at construction and applies it to each input, so a batch runs under one unified, reproducible setting:
 
-- Name it `<Domain>Flow` (`PaperFlow`). `Flow` here is a noun for "the domain's
-  workflow"; the cfg *type* selects which knowledge shape it builds.
-- Construct with the cfg (`PaperFlow(PaperStructureCfg(...))`); the build method
-  takes only the input (`build(input)`), never a per-call cfg.
-- Use an intent verb for the method (`build`). The flow binds no store and does
-  no persistence or retrieval — those are downstream of the artifact it returns.
-- `batch_run(flow.build, inputs)` is the intended batch shape: one bound cfg,
-  many inputs, one setting.
+- Name it `<Domain>Flow` (`PaperFlow`). `Flow` here is a noun for "the domain's workflow"; the cfg *type* selects which knowledge shape it builds.
+- Construct with the cfg (`PaperFlow(PaperStructureCfg(...))`); the build method takes only the input (`build(input)`), never a per-call cfg.
+- Use an intent verb for the method (`build`). The flow binds no store and does no persistence or retrieval — those are downstream of the artifact it returns.
+- `batch_run(flow.build, inputs)` is the intended batch shape: one bound cfg, many inputs, one setting.
 
 ## Type Names
 
-- Input types describe what the caller supplies, such as `NewsWindow` or
-  `PaperInput`.
-- Config types name the domain and stage, such as `NewsCollectionCfg`,
-  `PaperStructureCfg`, or `RetrievalCfg`.
-- Result types describe returned data, such as `NewsBatch`, `PaperFlowResult`, or
-  `PageIndex`.
-- Keep provider names out of public function names unless callers are choosing
-  provider-specific behavior.
+- Input types describe what the caller supplies, such as `NewsWindow` or `PaperInput`.
+- Config types name the domain and stage, such as `NewsCollectionCfg`, `PaperStructureCfg`, or `RetrievalCfg`.
+- Result types describe returned data, such as `NewsBatch`, `PaperFlowResult`, or `PageIndex`.
+- Keep provider names out of public function names unless callers are choosing provider-specific behavior.
 
 ## Current API
 
 - `collect_news` is a collection operation and follows these naming rules.
 - `batch_run` is a generic batch helper, not a news or paper operation.
-- `paper_flow` is an existing extraction **function** with an old name; keep it
-  as a thin compatibility wrapper. Do not copy the `*_flow` function pattern for
-  new operations.
-- `PaperFlow(cfg)` is the config-bound paper flow; `build(input)` produces a
-  knowledge artifact whose shape is chosen by the cfg *type* (`PaperStructureCfg`
-  → `PaperStructureTree` today). `Flow` as a noun here is deliberate and allowed.
-- `AgenticRetriever(cfg)` is the reasoning-retrieval service in `quantmind.mind`;
-  `retrieve(structure, question)` returns evidence values. It has one behavior —
-  an LLM agent reasons over the structure — so it binds `RetrievalCfg` but does
-  no cfg-type dispatch. Mechanical semantic search is `quantmind.library.search`,
-  a different layer, not a strategy here.
+- `paper_flow` is an existing extraction **function** with an old name; keep it as a thin compatibility wrapper. Do not copy the `*_flow` function pattern for new operations.
+- `PaperFlow(cfg)` is the config-bound paper flow; `build(input)` produces a knowledge artifact whose shape is chosen by the cfg *type* (`PaperStructureCfg` → `PaperStructureTree` today). `Flow` as a noun here is deliberate and allowed.
+- `AgenticRetriever(cfg)` is the reasoning-retrieval service in `quantmind.mind`; `retrieve(structure, question)` returns evidence values. It has one behavior — an LLM agent reasons over the structure — so it binds `RetrievalCfg` but does no cfg-type dispatch. Mechanical semantic search is `quantmind.library.search`, a different layer, not a strategy here.
 
-The current `quantmind.flows` package continues to contain public operations in
-this release. Renaming it to `operations` or adding a separate `pipelines`
-package is outside this page.
+The current `quantmind.flows` package continues to contain public operations in this release. Renaming it to `operations` or adding a separate `pipelines` package is outside this page.
 
 ## Review Checklist
 
@@ -126,9 +85,6 @@ Before adding a public callable, state:
 2. What it accepts and returns.
 3. Whether it is one operation or combines several operations.
 4. Why its verb describes the returned result.
-5. If it is a service class, which dependencies, policy, or lifecycle are
-   reused across calls and why they should not remain explicit function
-   arguments.
+5. If it is a service class, which dependencies, policy, or lifecycle are reused across calls and why they should not remain explicit function arguments.
 
-If those answers are unclear, define the behavior before choosing a public
-name.
+If those answers are unclear, define the behavior before choosing a public name.

--- a/contexts/design/operations/orchestration.md
+++ b/contexts/design/operations/orchestration.md
@@ -62,13 +62,7 @@ Using the SDK does **not** force the agentic pattern. Single-agent `Runner.run(a
 
 **Do not build a framework for it.** The fan-out primitive is a function, not a base class: `asyncio.gather` over code-computed items with a `Semaphore`. Keep it inline until a second flow needs it; only then extract a small `map_reduce(items, map_fn, reduce_fn, *, concurrency)` helper. A `BaseFlow`/`ParallelWorkflow` base class is the framework this project explicitly avoids.
 
-Likewise, a small service may bind a genuinely shared construction-time thing —
-a model policy, a provider seam, or (most often) the immutable **config** that
-must stay constant across a batch — without introducing a generic workflow
-hierarchy; see [Callable Shape](#callable-shape-bind-config-pass-the-operand).
-Canonical knowledge artifacts remain frozen values and do not acquire
-`build()`, `retrieve()`, persistence, or provider state merely to make call
-sites look object-oriented.
+Likewise, a small service may bind a genuinely shared construction-time thing — a model policy, a provider seam, or (most often) the immutable **config** that must stay constant across a batch — without introducing a generic workflow hierarchy; see [Callable Shape](#callable-shape-bind-config-pass-the-operand). Canonical knowledge artifacts remain frozen values and do not acquire `build()`, `retrieve()`, persistence, or provider state merely to make call sites look object-oriented.
 
 ## Principle 3: Pipeline vs Component Altitude
 

--- a/contexts/design/utils/structured_output.md
+++ b/contexts/design/utils/structured_output.md
@@ -2,15 +2,10 @@
 
 ## Quick Summary
 
-- **Purpose**: Get a validated Pydantic object back from an Agents SDK run on
-  any provider the SDK can route, including ones that reject strict
-  `json_schema` structured output.
-- **Read when**: Adding or changing an agent call that sets `output_type=`, or
-  debugging a `BadRequestError` about `response_format` on a non-OpenAI model.
-- **Owner**: `quantmind/utils/structured_output.py` (`run_structured`). A leaf
-  helper; every package may import it.
-- **Status**: Current behavior. One bounded fallback — no retry loop, no
-  provider table.
+- **Purpose**: Get a validated Pydantic object back from an Agents SDK run on any provider the SDK can route, including ones that reject strict `json_schema` structured output.
+- **Read when**: Adding or changing an agent call that sets `output_type=`, or debugging a `BadRequestError` about `response_format` on a non-OpenAI model.
+- **Owner**: `quantmind/utils/structured_output.py` (`run_structured`). A leaf helper; every package may import it.
+- **Status**: Current behavior. One bounded fallback — no retry loop, no provider table.
 
 ## Contents
 
@@ -22,13 +17,7 @@
 
 ## Motivation
 
-Setting `output_type=` makes the SDK send a strict
-`response_format={"type": "json_schema"}`. Native OpenAI routes accept it, but
-some LiteLLM-routed providers (DeepSeek, ...) reject that `response_format`
-outright — and they reject it at *request* time, before any output exists, so a
-parse-stage retry cannot recover. The request itself must change: drop
-`output_type`, ask for `{"type": "json_object"}`, and validate the raw output in
-code. This must stay invisible to callers, who pass only `cfg.model`.
+Setting `output_type=` makes the SDK send a strict `response_format={"type": "json_schema"}`. Native OpenAI routes accept it, but some LiteLLM-routed providers (DeepSeek, ...) reject that `response_format` outright — and they reject it at *request* time, before any output exists, so a parse-stage retry cannot recover. The request itself must change: drop `output_type`, ask for `{"type": "json_object"}`, and validate the raw output in code. This must stay invisible to callers, who pass only `cfg.model`.
 
 ## The Fallback Ladder
 
@@ -45,49 +34,26 @@ flowchart LR
     B --> R2["run → raw string"] --> OK
 ```
 
-1. Run the agent from `build_agent(False)` — it carries `output_type=`, so the
-   SDK sends strict `json_schema` and returns a parsed model.
-2. If that raises a `BadRequestError` whose message names the `response_format`
-   / `json_schema` (a narrow check), run the agent from `build_agent(True)` — no
-   `output_type`, the JSON Schema pinned into the instructions, and
-   `response_format` forced to `json_object` — then validate the raw string
-   locally. `json_object_instructions` / `json_object_model_settings` build that
-   agent; a fenced-JSON strip guards Markdown wrappers.
+1. Run the agent from `build_agent(False)` — it carries `output_type=`, so the SDK sends strict `json_schema` and returns a parsed model.
+2. If that raises a `BadRequestError` whose message names the `response_format` / `json_schema` (a narrow check), run the agent from `build_agent(True)` — no `output_type`, the JSON Schema pinned into the instructions, and `response_format` forced to `json_object` — then validate the raw string locally. `json_object_instructions` / `json_object_model_settings` build that agent; a fenced-JSON strip guards Markdown wrappers.
 
-A `BadRequestError` unrelated to `response_format` is re-raised unchanged, never
-masked by the fallback. Incapability is discovered by the provider's own
-rejection, so a capable provider always keeps the stronger strict contract.
+A `BadRequestError` unrelated to `response_format` is re-raised unchanged, never masked by the fallback. Incapability is discovered by the provider's own rejection, so a capable provider always keeps the stronger strict contract.
 
 ## Layer Boundary
 
-The helper lives in `utils` (a leaf every package may import) and takes two
-callbacks so it owns no runtime policy:
+The helper lives in `utils` (a leaf every package may import) and takes two callbacks so it owns no runtime policy:
 
-- `build_agent(json_object)` — how the agent is constructed at this call site
-  (name, instructions, tools, model settings).
-- `run(agent)` — which runner executes it. `flows` passes
-  `run_with_observability`; `mind` passes its own `Runner.run` + `RunConfig`.
+- `build_agent(json_object)` — how the agent is constructed at this call site (name, instructions, tools, model settings).
+- `run(agent)` — which runner executes it. `flows` passes `run_with_observability`; `mind` passes its own `Runner.run` + `RunConfig`.
 
-This is why `mind` never imports `flows`: the shared ladder is in `utils`, and
-each layer injects its own runner. No new runtime module is introduced.
+This is why `mind` never imports `flows`: the shared ladder is in `utils`, and each layer injects its own runner. No new runtime module is introduced.
 
 ## Non-Goals
 
-- No provider registry or model-name prefix table — detection is the provider's
-  own `BadRequestError`, not a static capability list. (`litellm`'s own
-  `supports_response_schema` is unreliable, e.g. it marks `openrouter/openai/*`
-  routes as unsupported.)
-- No unbounded retry — the ladder is exactly two rungs. A malformed
-  `json_object` result surfaces its `ValidationError`; it is not re-prompted in
-  a loop.
-- No second, tool-less "salvage" agent and no fuzzy output repair (alias
-  remapping, UUID regex). Strict schema on capable providers removes the need.
+- No provider registry or model-name prefix table — detection is the provider's own `BadRequestError`, not a static capability list. (`litellm`'s own `supports_response_schema` is unreliable, e.g. it marks `openrouter/openai/*` routes as unsupported.)
+- No unbounded retry — the ladder is exactly two rungs. A malformed `json_object` result surfaces its `ValidationError`; it is not re-prompted in a loop.
+- No second, tool-less "salvage" agent and no fuzzy output repair (alias remapping, UUID regex). Strict schema on capable providers removes the need.
 
 ## Verification
 
-Offline (`tests/utils/test_structured_output.py`, plus the two call sites'
-tests): strict is the default; a simulated `response_format` rejection falls
-back to `json_object` and validates a fenced or bare string; an unrelated
-`BadRequestError` propagates unswallowed. Live: `scripts/verify_structure_e2e.py`
-exercises a real `json_object`-only provider (DeepSeek) and a strict baseline
-(GPT).
+Offline (`tests/utils/test_structured_output.py`, plus the two call sites' tests): strict is the default; a simulated `response_format` rejection falls back to `json_object` and validates a fenced or bare string; an unrelated `BadRequestError` propagates unswallowed. Live: `scripts/verify_structure_e2e.py` exercises a real `json_object`-only provider (DeepSeek) and a strict baseline (GPT).

--- a/contexts/design/utils/usage.md
+++ b/contexts/design/utils/usage.md
@@ -1,0 +1,95 @@
+# Collect per-run token and timing usage from SDK traces
+
+## Quick Summary
+
+- **Purpose**: Answer "how many tokens, how long, and how many LLM steps did one flow run take" by reading the traces the Agents SDK already emits — not by hand-rolling a second accounting path.
+- **Read when**: Adding usage/latency visibility to a flow, wiring a run-usage readout into a runbook or `batch_run`, or debugging why a flow's reported tokens or step count look wrong.
+- **Owner**: `quantmind/utils/usage.py` (`usage_scope`, `SpanCollector`, `RunUsage`, `UsageStep`). A leaf helper; every package and user runbook may import it.
+- **Status**: Planned — this page is the agreed design contract for the implementation, not yet-shipped behavior. It lists current gaps and the one open decision inline.
+- **Core rule**: Observe, never enforce. This reads the SDK's spans after the fact; it never counts tokens to change what a run does (no budget, no cost).
+
+## Contents
+
+- [Motivation](#motivation)
+- [What the SDK Already Provides](#what-the-sdk-already-provides)
+- [Collecting One Run](#collecting-one-run)
+- [What a Run Reports](#what-a-run-reports)
+- [Layer Boundary and Non-Enforcement](#layer-boundary-and-non-enforcement)
+- [Scope, Non-Goals, and Planned Work](#scope-non-goals-and-planned-work)
+- [Verification](#verification)
+
+## Motivation
+
+Every flow LLM call returns a `RunResult` whose `context_wrapper.usage` already carries input/output/total tokens and a `requests` count, but the flow returns only its domain artifact (`PaperStructureTree`, `PaperFlowResult`) and drops the `RunResult`. So today there is no answer to a basic optimization question: for one `PaperFlow(cfg).build(input)` or one `paper_flow(input)`, how many tokens did it burn, how long did it take, and how many model calls did it make.
+
+Two facts make a naive `return result.context_wrapper.usage` insufficient:
+
+- **One flow run is many SDK runs.** `paper_flow`'s summary fans out one research agent per chunk group with `asyncio.gather`, then runs one reducer — `N + 1` separate `Runner.run` calls. A structure build that hits the `json_schema` → `json_object` fallback is two calls. The usage of "one flow run" is a sum across several runs, so it must be aggregated, not read from a single result.
+- **Concurrency makes a summed duration lie.** Those `N` researchers run in parallel; summing their wall times over-reports latency several-fold. Real end-to-end time and summed busy time are different numbers, and optimization needs both.
+
+Cost is explicitly out of scope: this reports tokens, time, and steps only. Pricing changes per provider and per week; a caller who wants dollars multiplies tokens by their own rate table. See [Non-Enforcement](#layer-boundary-and-non-enforcement).
+
+## What the SDK Already Provides
+
+The Agents SDK ships tracing that already models exactly this data, so the design **consumes** it rather than rebuilding it:
+
+- A `Runner.run` opens a **trace** (unless one is already active) containing typed **spans**. Each span carries `started_at` / `ended_at` timestamps, `trace_id` / `span_id` / `parent_id` (a tree — the shape a waterfall needs), and an `error`.
+- Token usage lives on the model spans. Depending on the provider route the SDK emits one of two shapes: a **generation span** (Chat Completions route, e.g. LiteLLM/DeepSeek) carries `usage` directly; a **response span** (Responses API route) carries the full response whose `usage` is read off it. The collector must read **both** shapes, or one provider path silently reports zero tokens.
+- `add_trace_processor(p)` registers a `TracingProcessor` that receives every span via `on_span_end`. This is the SDK's documented extension point and the one CLAUDE.md prescribes ("external processors via `add_trace_processor()`").
+
+Because timestamps and usage come from the SDK's own spans, this design mints no clock and stamps no time of its own — the "which clock" question dissolves. A generation/response span is a superset of the per-step record we want; a hand-rolled timer around `run_with_observability` would be a weaker duplicate that also misses retries, tool calls, and sub-turns the spans already capture.
+
+## Collecting One Run
+
+Three parts, each doing one thing:
+
+```mermaid
+flowchart LR
+    U["usage_scope(name)"] -->|"mint trace_id, open trace()"| T["trace(trace_id)"]
+    T --> R["flow: N+1 Runner.run"]
+    R -->|"spans close"| C["SpanCollector (global TracingProcessor)"]
+    U -->|"on exit: read + evict by trace_id"| C
+    C -->|"aggregate"| RU["RunUsage"]
+```
+
+- **`SpanCollector`** is one process-global `TracingProcessor`, registered once (idempotently) via `add_trace_processor`. Its `on_span_end` buckets each span under its `trace_id`. Bucketing by `trace_id` is what makes concurrent scopes and `batch_run` fan-out safe: each scope only ever reads its own trace.
+- **`usage_scope(workflow_name)`** is a sync context manager (like `trace()`). On enter it mints a `trace_id` with `gen_trace_id()` and opens `trace(workflow_name, trace_id=...)`, so every `Runner.run` inside — all `N + 1` of them, plus any fallback retry — nests into **one** trace. On exit it reads that trace's spans out of the collector, aggregates them into a `RunUsage`, and **evicts** them so the collector never grows unbounded.
+- The caller reads the result **after** the block, once spans have flushed:
+
+  ```python
+  from quantmind.utils.usage import usage_scope
+
+  with usage_scope("quantmind.paper") as u:
+      tree = await PaperFlow(cfg).build(input)
+
+  print(u.usage.total_tokens, u.usage.requests, u.usage.wall_seconds)
+  for step in u.usage.steps:            # the per-step detail optimization needs
+      print(step.label, step.model, step.total_tokens, step.duration_seconds)
+  ```
+
+**Additive, never destructive (the one open decision).** `usage_scope` uses `add_trace_processor` to *add* a local, in-memory sink; it never calls `set_trace_processors` (which would evict the user's own processors) and never touches the default backend exporter. Whether spans *also* go to OpenAI's dashboard stays the user's existing global choice (their `OPENAI_API_KEY`, or `set_tracing_disabled()`), not something this library forces on or off. This is the recommended default and the single behavior to confirm before implementation.
+
+## What a Run Reports
+
+`RunUsage` is the per-flow-run aggregate the caller reads; `UsageStep` is one model span within it. Both are frozen value objects (dataclasses), not LLM-facing, so no Pydantic.
+
+- `RunUsage`: `input_tokens`, `output_tokens`, `total_tokens`, `requests` (the count of model spans — **this is "llm-steps"**), `wall_seconds` (`max(ended_at) − min(started_at)` across the trace — true latency), `busy_seconds` (sum of per-step durations — total model-busy time), and `steps: list[UsageStep]`. The gap between `busy_seconds` and `wall_seconds` is how much parallelism the fan-out actually bought — the headline signal for tuning `summary_concurrency`.
+- `UsageStep`: `label` (the agent name), `model`, `input_tokens`, `output_tokens`, `total_tokens`, `started_at`, `ended_at`, `duration_seconds`, and `span_id` / `parent_id` so a caller can rebuild the span tree for a waterfall without re-reading the SDK.
+
+Per-step is deliberate: a lump `total_tokens=53k` cannot tell you the reducer dwarfs the researchers, or that one retry doubled a call. The list is the point; the totals are its reduce.
+
+## Layer Boundary and Non-Enforcement
+
+- **Home is `utils` (a leaf).** Like `utils/structured_output.py`, this wraps an Agents SDK seam, depends on nothing else in `quantmind`, and is imported by `flows`, by user runbooks, and later by `mind` — without any package importing `flows`. The import-linter leaf contract on `utils` already guards this.
+- **Observation only — no accountant.** This never inspects usage *during* a run to steer it, cap it, or price it. That keeps it clear of the incoherent middle in [orchestration](../operations/orchestration.md#principle-2-agentic-vs-deterministic-orchestration): a concurrency-safe token accountant bolted onto a run to make it behave is a sign the task wanted deterministic decomposition, not observability. Budgets and cost are separate features and are not designed here.
+
+## Scope, Non-Goals, and Planned Work
+
+- **In scope now: flow LLM calls.** Paper structure and paper summary route every model call through `run_with_observability`, and both are single-turn per `Runner.run`, so per-run spans are per-call spans — enough for an accurate token count, step count, and concurrency waterfall today.
+- **Not covered in v1: agentic seams.** `mind.retrieval` and `magic` call `Runner.run` directly and multi-turn. `usage_scope` would still trace them if wrapped, but a single agentic run collapses many internal LLM/tool events into one bar; faithful per-call resolution there is future work. The `UsageStep` shape is a degenerate span on purpose, so extending coverage does not change the reader API.
+- **No cost, no budget.** Tokens/time/steps only; no pricing table and no `max_total_*` enforcement.
+- **Planned: `batch_run` aggregation.** Each input gets its own `usage_scope` (its own `trace_id`), an outer `group_id` ties the batch together, and the per-input `RunUsage` objects populate `BatchResult` (reviving its currently unused `tokens_total`). Not part of the first cut.
+
+## Verification
+
+Offline (`tests/utils/test_usage.py`): feed hand-built generation and response spans (both usage shapes, plus a nested agent span for `label`) through `SpanCollector.on_span_end`, then assert `RunUsage` sums tokens, counts `requests`, derives `wall_seconds` from the min/max timestamps and `busy_seconds` from the per-step sum, and orders `steps`. Assert `usage_scope` mints a distinct `trace_id` per entry, evicts its bucket on exit, and that two concurrent scopes never read each other's spans. A flow-level test wraps a mocked `Runner.run` in `usage_scope` and checks the `N + 1` summary runs land in one `RunUsage`. Live coverage rides on the existing paper E2E script rather than a new one.

--- a/contexts/dev/README.md
+++ b/contexts/dev/README.md
@@ -2,11 +2,9 @@
 
 ## Quick Summary
 
-- **Purpose**: Route contributors and coding agents to existing development
-  rules without copying them here.
+- **Purpose**: Route contributors and coding agents to existing development rules without copying them here.
 - **Read when**: Extending, fixing, reviewing, testing, or publishing QuantMind.
-- **Load next**: Select the single row that matches the task; load additional
-  sources only when that workflow explicitly requires them.
+- **Load next**: Select the single row that matches the task; load additional sources only when that workflow explicitly requires them.
 - **Required check**: Run `bash scripts/verify.sh` for every repository change.
 
 ## Contents
@@ -16,8 +14,7 @@
 
 ## Rule Index
 
-Use this index when extending or maintaining the repository. Follow the linked
-rule instead of treating this page as a replacement for it.
+Use this index when extending or maintaining the repository. Follow the linked rule instead of treating this page as a replacement for it.
 
 | Need | Read |
 |---|---|
@@ -35,6 +32,4 @@ rule instead of treating this page as a replacement for it.
 
 ## Verification Rule
 
-Run `bash scripts/verify.sh` for every change. For a public-network component,
-also run the limited live-network check listed in the public component
-catalog.
+Run `bash scripts/verify.sh` for every change. For a public-network component, also run the limited live-network check listed in the public component catalog.

--- a/contexts/dev/github-writing.md
+++ b/contexts/dev/github-writing.md
@@ -2,59 +2,45 @@
 
 ## Quick Summary
 
-- **Purpose**: Define how raw Markdown should be formatted in QuantMind GitHub
-  issues, pull requests, discussions, and comments.
+- **Purpose**: Define how raw Markdown should be formatted in QuantMind GitHub issues, pull requests, discussions, and comments.
 - **Read when**: Drafting or editing any text submitted to GitHub.
-- **Key rule**: Keep each paragraph, list item, checklist item, table row, and
-  blockquote paragraph on one line in the raw Markdown.
-- **Required check**: Read the raw body back after writing and remove
-  formatter-introduced hard wrapping without changing meaning.
+- **Key rule**: Keep each paragraph, list item, checklist item, table row, and blockquote paragraph on one line in the raw Markdown.
+- **Required check**: Read the raw body back after writing and remove formatter-introduced hard wrapping without changing meaning.
 
 ## Contents
 
 - [Do Not Wrap Prose at a Fixed Width](#do-not-wrap-prose-at-a-fixed-width)
 - [Write Workflow](#write-workflow)
 
-This guide applies to text submitted to GitHub, not to Markdown files stored in
-the repository.
+This guide's workflow (Issue/PR templates, `--body-file`, the raw-body read-back) is specific to text submitted to GitHub. Its prose rule — do not hard-wrap at a fixed width — also governs contexts pages stored in the repository; see the contexts authoring standard.
 
 ## Do Not Wrap Prose at a Fixed Width
 
-GitHub wraps text for the viewer. Do not insert line breaks in the raw body at
-a fixed width, including 80 columns.
+GitHub wraps text for the viewer. Do not insert line breaks in the raw body at a fixed width, including 80 columns.
 
 - Keep each paragraph on one line in the raw Markdown.
 - Keep each list or checklist item on one line.
 - Keep each blockquote paragraph on one line after `>`.
 - Keep each Markdown table row on one line.
 - Preserve line structure inside fenced code blocks.
-- Use blank lines, headings, lists, code fences, tables, or an intentional
-  Markdown hard break only when they express real structure.
+- Use blank lines, headings, lists, code fences, tables, or an intentional Markdown hard break only when they express real structure.
 
-Repository formatters and code line-length settings do not apply to GitHub
-body prose. In particular, do not run Issue or Pull Request bodies through
-`textwrap.fill`, an 80-column editor wrap, or a Markdown formatter configured
-to wrap prose.
+Repository formatters and code line-length settings do not apply to GitHub body prose. In particular, do not run Issue or Pull Request bodies through `textwrap.fill`, an 80-column editor wrap, or a Markdown formatter configured to wrap prose.
 
 ## Write Workflow
 
 1. Draft the complete body with one paragraph or list item per source line.
 2. Preserve the selected Issue or Pull Request template and its checklist.
 3. Submit the body as written, preferably with `--body-file` when using `gh`.
-4. Read the raw body back after creation or editing and check that prose was
-   not hard-wrapped before considering the write complete.
+4. Read the raw body back after creation or editing and check that prose was not hard-wrapped before considering the write complete.
 
-When Prettier is already available, use its no-wrap mode to check the temporary
-body file before submission:
+When Prettier is already available, use its no-wrap mode to check the temporary body file before submission:
 
 ```bash
 prettier --write --parser markdown --prose-wrap never /tmp/github-body.md
 prettier --check --parser markdown --prose-wrap never /tmp/github-body.md
 ```
 
-Do not introduce a repository-wide Markdown formatter or change Python's
-80-column setting for this purpose. This check applies only to the temporary
-GitHub body.
+Do not introduce a repository-wide Markdown formatter or change Python's 80-column setting for this purpose. This check applies only to the temporary GitHub body.
 
-When updating an existing hard-wrapped body, normalize the complete body while
-preserving its meaning, headings, lists, code blocks, links, and checkboxes.
+When updating an existing hard-wrapped body, normalize the complete body while preserving its meaning, headings, lists, code blocks, links, and checkboxes.

--- a/contexts/dev/labels.md
+++ b/contexts/dev/labels.md
@@ -4,10 +4,8 @@
 
 - **Purpose**: Select consistent labels for QuantMind issues and pull requests.
 - **Read when**: Creating, updating, triaging, or reviewing an issue or PR.
-- **Label count**: Use exactly one `type:` label, normally one `area:` label
-  (at most two), and optional `impact:` labels.
-- **Selection rule**: Label the work's actual purpose and main area, not every
-  file it touches.
+- **Label count**: Use exactly one `type:` label, normally one `area:` label (at most two), and optional `impact:` labels.
+- **Selection rule**: Label the work's actual purpose and main area, not every file it touches.
 
 ## Contents
 
@@ -26,18 +24,15 @@ Labels describe three separate parts of the work:
 - `area:` answers which part of the repository owns the work.
 - `impact:` identifies breaking changes or live-network risk.
 
-Choose labels from the work's purpose and agreed scope, not only from the files
-it happens to touch.
+Choose labels from the work's purpose and agreed scope, not only from the files it happens to touch.
 
 ## How Many Labels to Use
 
 Every issue and pull request must have **exactly one** `type:` label.
 
-Normally choose **one** `area:` label. Use two only when the work genuinely
-belongs to two main areas; never use more than two.
+Normally choose **one** `area:` label. Use two only when the work genuinely belongs to two main areas; never use more than two.
 
-Add `impact:` labels only when needed. Resolution and community labels do not
-count toward these limits.
+Add `impact:` labels only when needed. Resolution and community labels do not count toward these limits.
 
 ## Type Labels
 
@@ -50,8 +45,7 @@ count toward these limits.
 | `type: maintenance` | The work performs specific repository upkeep, such as dependency, configuration, release, or housekeeping changes. |
 | `type: design` | The primary deliverable is an architecture decision, RFC, or design that precedes implementation. |
 
-`type: maintenance` is not a catch-all label. If the intended outcome is
-unclear, clarify the work before labeling it.
+`type: maintenance` is not a catch-all label. If the intended outcome is unclear, clarify the work before labeling it.
 
 ## Area Labels
 
@@ -69,9 +63,7 @@ unclear, clarify the work before labeling it.
 | `area: examples` | Examples are the primary deliverable, rather than supporting files for another area. |
 | `area: packaging` | Installation, builds, dependencies, releases, and package metadata. |
 
-Area labels describe the main work, not every touched path. For example, a news
-design-document-only change is `type: docs` + `area: preprocess`, while a
-skill-only guidance change is `type: docs` + `area: harness`.
+Area labels describe the main work, not every touched path. For example, a news design-document-only change is `type: docs` + `area: preprocess`, while a skill-only guidance change is `type: docs` + `area: harness`.
 
 ## Impact Labels
 
@@ -82,23 +74,16 @@ skill-only guidance change is `type: docs` + `area: harness`.
 
 ## Resolution and Community Labels
 
-Keep these standard GitHub labels when applicable: `duplicate`,
-`good first issue`, `help wanted`, `invalid`, `question`, and `wontfix`.
-They describe resolution or collaboration state and are independent of the
-type, area, and impact dimensions.
+Keep these standard GitHub labels when applicable: `duplicate`, `good first issue`, `help wanted`, `invalid`, `question`, and `wontfix`. They describe resolution or collaboration state and are independent of the type, area, and impact dimensions.
 
 ## Issues and Pull Requests
 
-Body source formatting follows the [GitHub writing style](github-writing.md),
-including its no-hard-wrap rule.
+Body source formatting follows the [GitHub writing style](github-writing.md), including its no-hard-wrap rule.
 
 - Label an issue from the intended problem and accepted scope.
 - Label a pull request from its actual diff.
-- A pull request that closes an issue should normally align with the issue's
-  type and area. If implementation differs, label the pull request accurately
-  and update the issue when its agreed scope changed.
-- Re-evaluate labels when scope changes; do not preserve a stale label merely
-  because it was applied first.
+- A pull request that closes an issue should normally align with the issue's type and area. If implementation differs, label the pull request accurately and update the issue when its agreed scope changed.
+- Re-evaluate labels when scope changes; do not preserve a stale label merely because it was applied first.
 
 ## Examples
 
@@ -113,8 +98,7 @@ including its no-hard-wrap rule.
 
 ## Rename Existing Labels
 
-Rename labels instead of deleting and recreating them so GitHub preserves
-history and current assignments:
+Rename labels instead of deleting and recreating them so GitHub preserves history and current assignments:
 
 | Existing | Rename to |
 |---|---|
@@ -125,6 +109,4 @@ history and current assignments:
 | `example` | `area: examples` |
 | `harness` | `area: harness` |
 
-After renaming, create the missing labels and audit open issues and
-pull requests. Remove accidental multiple `type:` labels, choose one or two
-areas from accepted scope, and leave resolution/community labels intact.
+After renaming, create the missing labels and audit open issues and pull requests. Remove accidental multiple `type:` labels, choose one or two areas from accepted scope, and leave resolution/community labels intact.

--- a/contexts/usage/README.md
+++ b/contexts/usage/README.md
@@ -2,15 +2,10 @@
 
 ## Quick Summary
 
-- **Purpose**: Route library users and agents to current public operations,
-  inputs, results, examples, and guides.
-- **Read when**: Calling QuantMind as a library or selecting a supported public
-  operation.
-- **Load next**: Start with the component row that matches the requested
-  operation; do not load unrelated component designs.
-- **Import rule**: Import inputs and configs from `quantmind.configs`,
-  operations from `quantmind.flows`, and result types from the package shown in
-  the component catalog.
+- **Purpose**: Route library users and agents to current public operations, inputs, results, examples, and guides.
+- **Read when**: Calling QuantMind as a library or selecting a supported public operation.
+- **Load next**: Start with the component row that matches the requested operation; do not load unrelated component designs.
+- **Import rule**: Import inputs and configs from `quantmind.configs`, operations from `quantmind.flows`, and result types from the package shown in the component catalog.
 
 ## Contents
 
@@ -19,8 +14,7 @@
 
 ## Public Usage Sources
 
-Use this index when calling QuantMind as a library. These links point to the
-current public API, focused examples, and component-specific guidance.
+Use this index when calling QuantMind as a library. These links point to the current public API, focused examples, and component-specific guidance.
 
 | Need | Read |
 |---|---|
@@ -34,6 +28,4 @@ current public API, focused examples, and component-specific guidance.
 
 ## Where to Import From
 
-Import public inputs and configs from `quantmind.configs`, public operations
-from `quantmind.flows`, and result types from the package shown in the
-component catalog.
+Import public inputs and configs from `quantmind.configs`, public operations from `quantmind.flows`, and result types from the package shown in the component catalog.

--- a/examples/utils/usage_scope.py
+++ b/examples/utils/usage_scope.py
@@ -5,8 +5,24 @@ tokens it spent, how long it took, and how many model calls it made — all read
 from the traces the Agents SDK already emits. Tokens, time, and steps only; no
 cost. Read ``run.usage`` after the ``with`` block, not inside it.
 
-Running this end to end needs network access (a model provider). The example
-imports and type-checks offline.
+Here it wraps ``PaperFlow(PaperStructureCfg).build`` (one structure-extraction
+agent). ``requests`` is the model-call count: OpenRouter accepts the strict
+``json_schema`` request, so this is a single clean call and ``requests`` is 1.
+It grows when the provider or flow does more — a json-object-only provider adds
+a rejected strict attempt before its json_object fallback (``requests`` 2), and
+a fan-out flow such as the summary map-reduce shows one step per researcher plus
+the reducer, where ``wall`` drops below ``busy`` as they overlap.
+
+Running this end to end needs network access and the chosen provider's API key.
+The example imports and type-checks offline.
+
+Example output (a real run on OpenRouter deepseek-v4-flash; varies by run):
+
+    built structure tree: 10 nodes
+    tokens: in=1144 out=429 total=1573
+    llm-steps (requests): 1
+    time: wall=13.07s busy=13.07s
+      - paper_structure_builder  openrouter/deepseek/deepseek-v4-flash in=1144 out=429 13.07s
 """
 
 import asyncio
@@ -18,15 +34,21 @@ from quantmind.configs.paper import LocalFilePath
 from quantmind.flows import PaperFlow
 from quantmind.utils.usage import usage_scope
 
+# usage_scope works with any provider; swap in your model and set its API key.
+# OpenRouter accepts strict json_schema, so this run is one clean call. A
+# json-object-only provider (e.g. "litellm/deepseek/deepseek-chat") instead adds
+# a rejected strict attempt before the json_object fallback (requests=2).
+_MODEL = "litellm/openrouter/deepseek/deepseek-v4-flash"
+
 
 async def main(pdf_path: Path) -> None:
-    """Build one paper structure tree and print its per-run usage."""
-    flow = PaperFlow(PaperStructureCfg(model="gpt-5.6-luna"))
+    """Build one paper structure tree and print the per-run usage of that flow."""
+    flow = PaperFlow(PaperStructureCfg(model=_MODEL))
 
     with usage_scope("quantmind.paper.structure") as run:
         tree = await flow.build(LocalFilePath(path=pdf_path))
 
-    print("built:", tree.id)
+    print(f"built structure tree: {len(tree.nodes)} nodes")
     usage = run.usage
     print(
         f"tokens: in={usage.input_tokens} out={usage.output_tokens} "
@@ -38,7 +60,7 @@ async def main(pdf_path: Path) -> None:
     )
     for step in usage.steps:
         print(
-            f"  - {step.label} [{step.model}] "
+            f"  - {step.label:<24} {step.model or '-':<24} "
             f"in={step.input_tokens} out={step.output_tokens} "
             f"{step.duration_seconds:.2f}s"
         )

--- a/examples/utils/usage_scope.py
+++ b/examples/utils/usage_scope.py
@@ -1,0 +1,52 @@
+"""Measure token usage, time, and LLM steps for one flow run.
+
+``usage_scope`` wraps any flow call and, after the block, reports how many
+tokens it spent, how long it took, and how many model calls it made — all read
+from the traces the Agents SDK already emits. Tokens, time, and steps only; no
+cost. Read ``run.usage`` after the ``with`` block, not inside it.
+
+Running this end to end needs network access (a model provider). The example
+imports and type-checks offline.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+from quantmind.configs import PaperStructureCfg
+from quantmind.configs.paper import LocalFilePath
+from quantmind.flows import PaperFlow
+from quantmind.utils.usage import usage_scope
+
+
+async def main(pdf_path: Path) -> None:
+    """Build one paper structure tree and print its per-run usage."""
+    flow = PaperFlow(PaperStructureCfg(model="gpt-5.6-luna"))
+
+    with usage_scope("quantmind.paper.structure") as run:
+        tree = await flow.build(LocalFilePath(path=pdf_path))
+
+    print("built:", tree.id)
+    usage = run.usage
+    print(
+        f"tokens: in={usage.input_tokens} out={usage.output_tokens} "
+        f"total={usage.total_tokens}"
+    )
+    print(f"llm-steps (requests): {usage.requests}")
+    print(
+        f"time: wall={usage.wall_seconds:.2f}s busy={usage.busy_seconds:.2f}s"
+    )
+    for step in usage.steps:
+        print(
+            f"  - {step.label} [{step.model}] "
+            f"in={step.input_tokens} out={step.output_tokens} "
+            f"{step.duration_seconds:.2f}s"
+        )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit(
+            "usage: python examples/utils/usage_scope.py paper.pdf"
+        )
+    asyncio.run(main(Path(sys.argv[1])))

--- a/quantmind/utils/usage.py
+++ b/quantmind/utils/usage.py
@@ -1,0 +1,318 @@
+"""Per-run token, timing, and step usage, read from the Agents SDK's traces.
+
+A flow run makes several model calls (a paper summary fans out ``N`` research
+agents and one reducer, each its own ``Runner.run``), and the Agents SDK already
+records every one as a typed span carrying token usage and ISO start/end
+timestamps. This module collects those spans instead of hand-rolling a second
+accounting path, and reports one ``RunUsage`` per flow run.
+
+Usage:
+
+    from quantmind.utils.usage import usage_scope
+
+    with usage_scope("quantmind.paper") as run:
+        tree = await PaperFlow(cfg).build(input)
+
+    print(run.usage.total_tokens, run.usage.requests, run.usage.wall_seconds)
+    for step in run.usage.steps:
+        print(step.label, step.model, step.total_tokens, step.duration_seconds)
+
+``usage_scope`` opens one SDK ``trace`` (a minted ``trace_id``) so every
+``Runner.run`` inside nests into a single tree, then reads and evicts that
+trace's spans on exit. It only *adds* a local ``TracingProcessor`` via
+``add_trace_processor`` — it never replaces the SDK's processors and never
+touches the default backend exporter, so whether spans also reach any external
+dashboard stays the caller's own global tracing configuration.
+
+This is observation only: it reads usage after the fact and never inspects it to
+cap, price, or steer a run. Tokens/time/steps only — no cost, no budget.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from agents import add_trace_processor, gen_trace_id, trace
+from agents.tracing import TracingProcessor
+
+# ``span_data.type`` values for a single model call — the leaf spans that carry
+# one request's token usage. ``task`` / ``turn`` spans also expose ``usage`` but
+# aggregate their children, so summing them would double-count.
+_MODEL_SPAN_TYPES = frozenset({"generation", "response"})
+_AGENT_SPAN_TYPE = "agent"
+
+
+@dataclass(frozen=True, slots=True)
+class UsageStep:
+    """One model call within a run — a degenerate span kept for optimization.
+
+    ``label`` is the enclosing agent's name (e.g. ``paper_chunk_researcher``),
+    resolved from the span tree. ``started_at`` / ``ended_at`` are the SDK's ISO
+    timestamps; ``span_id`` / ``parent_id`` let a caller rebuild the tree for a
+    waterfall.
+    """
+
+    label: str
+    model: str | None
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    started_at: str | None
+    ended_at: str | None
+    duration_seconds: float
+    span_id: str
+    parent_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RunUsage:
+    """Aggregate token/time/step usage for one flow run.
+
+    ``requests`` is the number of model-call spans — the "llm-steps" count.
+    ``wall_seconds`` is true end-to-end latency (last end minus first start);
+    ``busy_seconds`` is the sum of per-step durations. Their gap is how much the
+    fan-out actually overlapped — the signal for tuning concurrency.
+    """
+
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    requests: int
+    wall_seconds: float
+    busy_seconds: float
+    steps: tuple[UsageStep, ...]
+
+    @classmethod
+    def empty(cls) -> RunUsage:
+        """A zeroed ``RunUsage`` (a run with no recorded model calls)."""
+        return cls(0, 0, 0, 0, 0.0, 0.0, ())
+
+
+@dataclass
+class UsageScope:
+    """Handle yielded by ``usage_scope``; ``usage`` is filled when the block exits.
+
+    Read ``usage`` *after* the ``with`` block: spans are aggregated on exit, so
+    inside the block it is still the empty default.
+    """
+
+    trace_id: str
+    usage: RunUsage = field(default_factory=RunUsage.empty)
+
+
+class SpanCollector(TracingProcessor):
+    """Process-global sink that buckets finished spans by ``trace_id``.
+
+    Bucketing by ``trace_id`` is what makes concurrent scopes and ``batch_run``
+    fan-out safe: each scope only ever reads and evicts its own trace.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._by_trace: dict[str, list[Any]] = defaultdict(list)
+
+    def on_trace_start(self, trace: Any) -> None:  # noqa: D102 - no-op sink
+        return None
+
+    def on_trace_end(self, trace: Any) -> None:  # noqa: D102 - no-op sink
+        return None
+
+    def on_span_start(self, span: Any) -> None:  # noqa: D102 - no-op sink
+        return None
+
+    def on_span_end(self, span: Any) -> None:
+        """Store the finished span under its trace bucket (thread-safe)."""
+        with self._lock:
+            self._by_trace[span.trace_id].append(span)
+
+    def shutdown(self) -> None:  # noqa: D102 - nothing to flush
+        return None
+
+    def force_flush(self) -> None:  # noqa: D102 - synchronous, nothing queued
+        return None
+
+    def pop(self, trace_id: str) -> list[Any]:
+        """Return and remove every span collected for ``trace_id``."""
+        with self._lock:
+            return self._by_trace.pop(trace_id, [])
+
+
+_collector: SpanCollector | None = None
+_collector_lock = threading.Lock()
+
+
+def _get_collector() -> SpanCollector:
+    """Return the process-global collector, registering it once on first use.
+
+    Registration is *additive* (``add_trace_processor``): the SDK's own
+    processors and default exporter are left untouched.
+    """
+    global _collector
+    if _collector is None:
+        with _collector_lock:
+            if _collector is None:
+                collector = SpanCollector()
+                add_trace_processor(collector)
+                _collector = collector
+    return _collector
+
+
+@contextmanager
+def usage_scope(
+    workflow_name: str = "quantmind",
+    *,
+    group_id: str | None = None,
+) -> Iterator[UsageScope]:
+    """Trace one flow run and expose its ``RunUsage`` after the block.
+
+    Args:
+        workflow_name: Trace name for this run (shown in any tracing UI).
+        group_id: Optional grouping id to link several runs (e.g. one per input
+            across a ``batch_run``) into one logical session.
+
+    Yields:
+        A ``UsageScope`` whose ``usage`` is populated when the block exits.
+        Reading it inside the block returns the empty default; read it after.
+    """
+    collector = _get_collector()
+    trace_id = gen_trace_id()
+    scope = UsageScope(trace_id=trace_id)
+    try:
+        with trace(workflow_name, trace_id=trace_id, group_id=group_id):
+            yield scope
+    finally:
+        # Aggregate on exit even when the block raised, so a failed run still
+        # reports whatever model calls it managed to make before failing.
+        scope.usage = _aggregate(collector.pop(trace_id))
+
+
+def _aggregate(spans: list[Any]) -> RunUsage:
+    """Reduce one trace's spans into a ``RunUsage`` (leaf model spans only)."""
+    by_id: dict[str, Any] = {s.span_id: s for s in spans}
+    steps: list[UsageStep] = []
+    for span in spans:
+        span_data = span.span_data
+        if getattr(span_data, "type", None) not in _MODEL_SPAN_TYPES:
+            continue
+        tokens = _extract_usage(span_data) or (0, 0, 0)
+        steps.append(
+            UsageStep(
+                label=_resolve_label(span, by_id),
+                model=_model_of(span_data),
+                input_tokens=tokens[0],
+                output_tokens=tokens[1],
+                total_tokens=tokens[2],
+                started_at=span.started_at,
+                ended_at=span.ended_at,
+                duration_seconds=_duration(span.started_at, span.ended_at),
+                span_id=span.span_id,
+                parent_id=span.parent_id,
+            )
+        )
+    steps.sort(key=lambda step: step.started_at or "")
+    return RunUsage(
+        input_tokens=sum(s.input_tokens for s in steps),
+        output_tokens=sum(s.output_tokens for s in steps),
+        total_tokens=sum(s.total_tokens for s in steps),
+        requests=len(steps),
+        wall_seconds=_wall_seconds(steps),
+        busy_seconds=round(sum(s.duration_seconds for s in steps), 6),
+        steps=tuple(steps),
+    )
+
+
+def _extract_usage(span_data: Any) -> tuple[int, int, int] | None:
+    """Pull (input, output, total) tokens from a model span's usage.
+
+    The SDK normalizes chat-completions ``prompt``/``completion`` to
+    ``input_tokens``/``output_tokens`` in the span usage dict; a response span
+    may instead expose it on ``response.usage``. Both are handled.
+    """
+    usage = getattr(span_data, "usage", None)
+    if isinstance(usage, dict) and usage:
+        tokens_in = _as_int(
+            usage.get("input_tokens", usage.get("prompt_tokens"))
+        )
+        tokens_out = _as_int(
+            usage.get("output_tokens", usage.get("completion_tokens"))
+        )
+        total = _as_int(usage.get("total_tokens")) or (tokens_in + tokens_out)
+        return tokens_in, tokens_out, total
+    response_usage = getattr(
+        getattr(span_data, "response", None), "usage", None
+    )
+    if response_usage is not None:
+        tokens_in = _as_int(getattr(response_usage, "input_tokens", None))
+        tokens_out = _as_int(getattr(response_usage, "output_tokens", None))
+        total = _as_int(getattr(response_usage, "total_tokens", None)) or (
+            tokens_in + tokens_out
+        )
+        return tokens_in, tokens_out, total
+    return None
+
+
+def _model_of(span_data: Any) -> str | None:
+    """Model name — direct on a generation span, on ``response`` for a response."""
+    model = getattr(span_data, "model", None)
+    if model:
+        return str(model)
+    response_model = getattr(
+        getattr(span_data, "response", None), "model", None
+    )
+    return str(response_model) if response_model else None
+
+
+def _resolve_label(span: Any, by_id: dict[str, Any]) -> str:
+    """Nearest enclosing agent name, walking parents; else the span's own type."""
+    current = span
+    seen: set[str] = set()
+    while True:
+        parent_id = getattr(current, "parent_id", None)
+        if parent_id is None or parent_id in seen:
+            break
+        seen.add(parent_id)
+        parent = by_id.get(parent_id)
+        if parent is None:
+            break
+        if getattr(parent.span_data, "type", None) == _AGENT_SPAN_TYPE:
+            return str(getattr(parent.span_data, "name", "") or "")
+        current = parent
+    return str(getattr(span.span_data, "type", "") or "")
+
+
+def _wall_seconds(steps: list[UsageStep]) -> float:
+    """End-to-end latency: last ``ended_at`` minus first ``started_at``."""
+    starts = [dt for dt in (_parse_iso(s.started_at) for s in steps) if dt]
+    ends = [dt for dt in (_parse_iso(s.ended_at) for s in steps) if dt]
+    if not starts or not ends:
+        return 0.0
+    return round(max(0.0, (max(ends) - min(starts)).total_seconds()), 6)
+
+
+def _duration(started_at: str | None, ended_at: str | None) -> float:
+    start, end = _parse_iso(started_at), _parse_iso(ended_at)
+    if start is None or end is None:
+        return 0.0
+    return round(max(0.0, (end - start).total_seconds()), 6)
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value) if value is not None else 0
+    except (TypeError, ValueError):
+        return 0

--- a/tests/utils/test_usage.py
+++ b/tests/utils/test_usage.py
@@ -1,0 +1,306 @@
+"""Tests for per-run usage collection from Agents SDK spans.
+
+Spans are hand-built so the suite runs fully offline: no model call, no real
+trace export. ``usage_scope`` is driven with a patched ``trace`` and spans
+pushed straight into the collector, simulating what the SDK would record.
+"""
+
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+from quantmind.utils import usage
+from quantmind.utils.usage import RunUsage, SpanCollector, usage_scope
+
+
+class _SpanData:
+    """Stand-in for an SDK ``*SpanData`` — exposes ``.type`` plus given attrs."""
+
+    def __init__(self, type_: str, **attrs: Any) -> None:
+        self._type = type_
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+    @property
+    def type(self) -> str:
+        return self._type
+
+
+class _Span:
+    """Stand-in for an SDK ``Span``."""
+
+    def __init__(
+        self,
+        *,
+        span_id: str,
+        parent_id: str | None,
+        trace_id: str,
+        started_at: str | None,
+        ended_at: str | None,
+        span_data: _SpanData,
+    ) -> None:
+        self.span_id = span_id
+        self.parent_id = parent_id
+        self.trace_id = trace_id
+        self.started_at = started_at
+        self.ended_at = ended_at
+        self.span_data = span_data
+
+
+class _RespUsage:
+    def __init__(self, input_tokens: int, output_tokens: int) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.total_tokens = None  # force the input+output fallback
+
+
+class _Response:
+    def __init__(self, model: str, usage: _RespUsage) -> None:
+        self.model = model
+        self.usage = usage
+
+
+def _agent(span_id: str, name: str, trace_id: str = "t1") -> _Span:
+    return _Span(
+        span_id=span_id,
+        parent_id=None,
+        trace_id=trace_id,
+        started_at="2026-07-22T10:00:00+00:00",
+        ended_at="2026-07-22T10:00:05+00:00",
+        span_data=_SpanData("agent", name=name),
+    )
+
+
+def _generation(
+    span_id: str,
+    parent_id: str | None,
+    *,
+    start: str,
+    end: str,
+    usage_dict: dict[str, Any] | None,
+    model: str | None = "gpt-4o",
+    trace_id: str = "t1",
+) -> _Span:
+    return _Span(
+        span_id=span_id,
+        parent_id=parent_id,
+        trace_id=trace_id,
+        started_at=start,
+        ended_at=end,
+        span_data=_SpanData("generation", usage=usage_dict, model=model),
+    )
+
+
+class AggregateTests(unittest.TestCase):
+    """The core reduce: leaf model spans only, labels, and token sums."""
+
+    def test_sums_generation_and_response_and_skips_aggregate_spans(
+        self,
+    ) -> None:
+        agent = _agent("a1", "paper_extractor")
+        gen = _generation(
+            "g1",
+            "a1",
+            start="2026-07-22T10:00:00+00:00",
+            end="2026-07-22T10:00:02+00:00",
+            usage_dict={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            },
+        )
+        resp = _Span(
+            span_id="r1",
+            parent_id="a1",
+            trace_id="t1",
+            started_at="2026-07-22T10:00:02+00:00",
+            ended_at="2026-07-22T10:00:04+00:00",
+            # response span: usage on response.usage, no top-level dict, no model
+            span_data=_SpanData(
+                "response",
+                usage=None,
+                response=_Response("gpt-4o-mini", _RespUsage(200, 80)),
+            ),
+        )
+        # A task-level aggregate span that must NOT be summed (double-count trap).
+        task = _Span(
+            span_id="k1",
+            parent_id=None,
+            trace_id="t1",
+            started_at="2026-07-22T10:00:00+00:00",
+            ended_at="2026-07-22T10:00:05+00:00",
+            span_data=_SpanData("task", usage={"input_tokens": 9999}),
+        )
+
+        result = usage._aggregate([task, agent, gen, resp])
+
+        self.assertEqual(result.requests, 2)  # only the two model spans
+        self.assertEqual(result.input_tokens, 300)
+        self.assertEqual(result.output_tokens, 130)
+        self.assertEqual(result.total_tokens, 430)  # 150 + (200 + 80)
+        self.assertEqual(
+            [s.label for s in result.steps], ["paper_extractor"] * 2
+        )
+        self.assertEqual(
+            [s.model for s in result.steps], ["gpt-4o", "gpt-4o-mini"]
+        )
+        self.assertEqual(result.steps[0].span_id, "g1")  # sorted by start time
+
+    def test_wall_is_span_wide_while_busy_is_per_step_sum(self) -> None:
+        # Two overlapping calls: 10:00:00-04 (4s) and 10:00:01-03 (2s).
+        a = _generation(
+            "g1",
+            None,
+            start="2026-07-22T10:00:00+00:00",
+            end="2026-07-22T10:00:04+00:00",
+            usage_dict={"input_tokens": 1, "output_tokens": 1},
+        )
+        b = _generation(
+            "g2",
+            None,
+            start="2026-07-22T10:00:01+00:00",
+            end="2026-07-22T10:00:03+00:00",
+            usage_dict={"input_tokens": 1, "output_tokens": 1},
+        )
+
+        result = usage._aggregate([a, b])
+
+        self.assertEqual(result.busy_seconds, 6.0)  # 4 + 2, sum of durations
+        self.assertEqual(result.wall_seconds, 4.0)  # max end - min start
+
+    def test_label_falls_back_to_span_type_without_agent_ancestor(self) -> None:
+        gen = _generation(
+            "g1",
+            None,
+            start="2026-07-22T10:00:00+00:00",
+            end="2026-07-22T10:00:01+00:00",
+            usage_dict={"input_tokens": 5, "output_tokens": 5},
+        )
+        result = usage._aggregate([gen])
+        self.assertEqual(result.steps[0].label, "generation")
+
+    def test_empty_trace_yields_zeroed_usage(self) -> None:
+        result = usage._aggregate([])
+        self.assertEqual(result, RunUsage.empty())
+
+
+class UsageExtractionTests(unittest.TestCase):
+    """Provider-shape tolerance and timestamp parsing."""
+
+    def test_prompt_completion_keys_map_to_input_output(self) -> None:
+        span_data = _SpanData(
+            "generation",
+            usage={"prompt_tokens": 12, "completion_tokens": 8},
+            model="deepseek-chat",
+        )
+        self.assertEqual(usage._extract_usage(span_data), (12, 8, 20))
+
+    def test_missing_usage_returns_none(self) -> None:
+        span_data = _SpanData("generation", usage=None, model="x")
+        self.assertIsNone(usage._extract_usage(span_data))
+
+    def test_parse_iso_accepts_z_suffix_and_rejects_garbage(self) -> None:
+        self.assertIsNotNone(usage._parse_iso("2026-07-22T10:00:00Z"))
+        self.assertIsNone(usage._parse_iso("not-a-timestamp"))
+        self.assertIsNone(usage._parse_iso(None))
+
+
+class SpanCollectorTests(unittest.TestCase):
+    """Bucketing and eviction by trace id."""
+
+    def test_buckets_by_trace_id_and_pop_clears(self) -> None:
+        collector = SpanCollector()
+        collector.on_span_end(_agent("a1", "x", trace_id="t1"))
+        collector.on_span_end(_agent("a2", "y", trace_id="t1"))
+        collector.on_span_end(_agent("a3", "z", trace_id="t2"))
+
+        first = collector.pop("t1")
+        self.assertEqual(len(first), 2)
+        self.assertEqual(collector.pop("t1"), [])  # evicted
+        self.assertEqual(len(collector.pop("t2")), 1)
+
+    def test_no_op_lifecycle_methods_do_not_raise(self) -> None:
+        collector = SpanCollector()
+        self.assertIsNone(collector.on_trace_start(object()))
+        self.assertIsNone(collector.on_trace_end(object()))
+        self.assertIsNone(collector.on_span_start(object()))
+        self.assertIsNone(collector.shutdown())
+        self.assertIsNone(collector.force_flush())
+
+
+class GetCollectorTests(unittest.TestCase):
+    """The global collector is a singleton, registered exactly once."""
+
+    def setUp(self) -> None:
+        usage._collector = None
+
+    def tearDown(self) -> None:
+        usage._collector = None
+
+    def test_singleton_registered_once(self) -> None:
+        with patch.object(usage, "add_trace_processor") as add:
+            first = usage._get_collector()
+            second = usage._get_collector()
+        self.assertIs(first, second)
+        add.assert_called_once_with(first)
+
+
+class UsageScopeTests(unittest.TestCase):
+    """End-to-end scope behavior with a patched trace and simulated spans."""
+
+    def setUp(self) -> None:
+        usage._collector = None
+        self._add = patch.object(usage, "add_trace_processor").start()
+        self._trace = patch.object(usage, "trace").start()
+
+    def tearDown(self) -> None:
+        patch.stopall()
+        usage._collector = None
+
+    def test_populates_usage_on_exit_and_evicts(self) -> None:
+        with usage_scope("quantmind.paper") as run:
+            trace_id = run.trace_id
+            collector = usage._get_collector()
+            collector.on_span_end(
+                _generation(
+                    "g1",
+                    None,
+                    start="2026-07-22T10:00:00+00:00",
+                    end="2026-07-22T10:00:01+00:00",
+                    usage_dict={"input_tokens": 10, "output_tokens": 4},
+                    trace_id=trace_id,
+                )
+            )
+            self.assertEqual(run.usage, RunUsage.empty())  # not yet aggregated
+
+        self.assertEqual(run.usage.requests, 1)
+        self.assertEqual(run.usage.total_tokens, 14)
+        self.assertEqual(usage._get_collector().pop(trace_id), [])  # evicted
+        self._trace.assert_called_once()
+
+    def test_distinct_trace_id_per_scope(self) -> None:
+        with usage_scope() as a, usage_scope() as b:
+            self.assertNotEqual(a.trace_id, b.trace_id)
+
+    def test_usage_populated_even_when_block_raises(self) -> None:
+        scope_ref = {}
+        with self.assertRaises(ValueError):
+            with usage_scope() as run:
+                scope_ref["run"] = run
+                usage._get_collector().on_span_end(
+                    _generation(
+                        "g1",
+                        None,
+                        start="2026-07-22T10:00:00+00:00",
+                        end="2026-07-22T10:00:01+00:00",
+                        usage_dict={"input_tokens": 7, "output_tokens": 3},
+                        trace_id=run.trace_id,
+                    )
+                )
+                raise ValueError("boom")
+
+        self.assertEqual(scope_ref["run"].usage.total_tokens, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- github-prose-style: Keep each logical paragraph/list item on one physical line; do not hard-wrap at 80 columns. -->

## Summary

Adds `usage_scope`, a small `quantmind/utils/` helper that reports token, time, and LLM-step usage for one flow run by collecting the spans the Agents SDK already emits — no hand-rolled accounting, no cost, no budget enforcement. This delivers the tokens/time/steps observability half of #127.

`usage_scope(name)` opens one SDK `trace` (a minted `trace_id`) so a run's `N+1` `Runner.run` calls — a paper summary's fan-out researchers plus the reducer, plus any structured-output fallback retry — nest into a single tree; on exit it reads and evicts that trace's spans into a frozen `RunUsage`:

```python
from quantmind.utils.usage import usage_scope

with usage_scope("quantmind.paper") as run:
    tree = await PaperFlow(cfg).build(input)

print(run.usage.total_tokens, run.usage.requests, run.usage.wall_seconds)
for step in run.usage.steps:
    print(step.label, step.model, step.total_tokens, step.duration_seconds)
```

`RunUsage` carries `input/output/total_tokens`, `requests` (the llm-steps count), `wall_seconds` (end-to-end latency) versus `busy_seconds` (sum of per-step durations — the gap shows how much the fan-out actually overlapped, the signal for tuning concurrency), and a per-step `UsageStep` list (label, model, tokens, ISO timestamps, and span ids for a waterfall).

Design decisions: a process-global `SpanCollector` is registered additively via `add_trace_processor` (it never replaces the SDK's processors and never touches the default backend exporter — whether spans also reach an external dashboard stays the caller's own global tracing config) and buckets spans by `trace_id`, so concurrent scopes and `batch_run` fan-out stay isolated. Aggregation counts only leaf `generation`/`response` spans (skipping `task`/`turn` aggregate spans to avoid double-counting), resolves each step's label from its nearest `agent` span, and tolerates both usage-dict shapes (`input/output` and `prompt/completion`) plus `response.usage`. Cost, pricing, and budget enforcement are intentionally out of scope. The full rationale lives in `contexts/design/utils/usage.md`.

This PR also bundles a small, orthogonal docs-convention change that writing the design context motivated: contexts pages no longer hard-wrap prose at a fixed width (fixed-width wrapping is for code, not prose), matching the existing no-hard-wrap rule for GitHub bodies. The rule is flipped in `write-contexts.md` (both skill mirrors) and `github-writing.md`, and the existing hard-wrapped contexts pages are reflowed to one paragraph or list item per line — line breaks only, no prose added, removed, or changed (verified by whitespace-normalized comparison). The three commits are cleanly separable for commit-by-commit review, and I am happy to split the convention change into its own PR if you prefer.

## Related Issue

Part of #127 (surface token usage and cost for runs and `batch_run`) — this PR delivers the tokens/time/steps observability; cost and budget are deliberately left out. Also part of #71 (Agents SDK migration).

## Verification

- `bash scripts/verify.sh` — green: `ruff format --check`, `ruff check`, `basedpyright`, `lint-imports`, and `pytest --cov` (405 passed, 85.66% total coverage; `quantmind/utils/usage.py` at 95%).
- End-to-end wiring exercised with real Agents SDK spans (real `trace()` plus `agent_span`/`generation_span` flowing through `add_trace_processor` → `SpanCollector` → aggregation): three steps, correct labels and models, correct token sums, and wall-versus-busy timing.
- No live-network smoke test applies: the helper reads local traces and makes no network call of its own.

## Checklist

- [x] The title uses English Conventional Commit format: `type(scope): summary`.
- [x] The related issue or design discussion is linked when applicable.
- [x] `bash scripts/verify.sh` passes.
- [x] Every applicable live-network component smoke test passes, or this PR states why none applies.
- [x] Public behavior has focused tests, an example, and documentation where applicable.
- [ ] The PR is complete, small, and contains no unrelated changes. (Bundles an orthogonal contexts-wrapping convention change; can be split on request.)
