### PR TITLE
chore(harness): add actions/stale workflow to auto-close inactive issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,47 @@
+name: Stale
+
+# Two-phase inactivity policy: mark stale (with a comment) after 14 days of
+# inactivity, then close 7 days later if still untouched. Any comment, commit,
+# or label change resets the clock and clears the stale label.
+
+on:
+  schedule:
+    - cron: '0 1 * * *' # Daily at 01:00 UTC.
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: stale
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 14
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: 'help wanted,good first issue'
+          exempt-pr-labels: 'help wanted,good first issue'
+          exempt-draft-pr: true
+          operations-per-run: 60
+          stale-issue-message: >
+            This issue has been inactive for 14 days and is now marked stale.
+            It will be closed in 7 days if there is no further activity. Comment
+            or remove the stale label to keep it open.
+          stale-pr-message: >
+            This pull request has been inactive for 14 days and is now marked
+            stale. It will be closed in 7 days if there is no further activity.
+            Comment or remove the stale label to keep it open.
+          close-issue-message: >
+            Closing after 21 days of inactivity. Comment to reopen if this is
+            still relevant.
+          close-pr-message: >
+            Closing after 21 days of inactivity. Reopen when you are ready to
+            pick this back up.


### PR DESCRIPTION
## Summary

Add GitHub's maintained [`actions/stale`](https://github.com/actions/stale) action so inactive issues and pull requests are surfaced and eventually closed automatically, keeping the backlog honest. The job runs daily at 01:00 UTC and can also be triggered manually via `workflow_dispatch`.

The policy is two-phase (warn before close), so nothing is closed cold:

- An issue or PR with no activity for 14 days is marked `stale` with a comment.
- If it stays inactive for 7 more days it is closed (21 days total).
- Any comment, commit, or label change resets the clock and clears the `stale` label.
- `help wanted` and `good first issue` are exempt; draft PRs are never marked stale.

The `stale` label is managed by the action; it is an operational state label, separate from the `type:` / `area:` / `impact:` taxonomy in `contexts/dev/labels.md`.

## Related Issue

No issue applies — this is repository maintenance automation.

## Verification

- `check-yaml` pre-commit hook validated the workflow file.
- This is a workflow-only change with no Python diff, so the `verify` pre-push hook (scoped to `types: [python]`) is not exercised and `scripts/verify.sh` has no runtime surface to cover here.

## Checklist

- [x] The title uses English Conventional Commit format: `type(scope): summary`.
- [x] The related issue or design discussion is linked when applicable.
- [x] `bash scripts/verify.sh` passes. — Not exercised: no Python diff; the `verify` hook is Python-scoped.
- [x] Every applicable live-network component smoke test passes, or this PR states why none applies. — None applies; no component code changes.
- [x] Public behavior has focused tests, an example, and documentation where applicable. — Not applicable to a CI-only workflow.
- [x] The PR is complete, small, and contains no unrelated changes.
