### PR TITLE
fix(preprocess): skip article fetches for incomplete discovery

### DIFF
--- a/contexts/design/flow/news.md
+++ b/contexts/design/flow/news.md
@@ -31,7 +31,7 @@ The primary requirement is that any caller can request a complete, one-shot coll
 ## Design Principles
 
 1. **Ask for news, not fetch details.** Callers choose a source and time window. They do not choose RSS, listing pages, how to move between pages, or article parsing rules.
-2. **Return every source row.** QuantMind does not silently remove duplicate source rows. Repeated rows remain repeated output records, and may share the same stable ID.
+2. **Return every source row for complete windows.** QuantMind does not silently remove duplicate source rows. Repeated rows remain repeated output records, and may share the same stable ID. An incomplete listing scan returns discovery evidence without fetching partial article bodies.
 3. **Show partial failures.** The returned batch includes item failures. Invalid inputs still raise before network work starts.
 4. **Hide source implementation details.** PR Newswire may later use a public mechanism other than listing pages without changing the public function.
 5. **List supported sources explicitly.** The first version selects from a closed source list. It does not expose a provider plugin API or registry.
@@ -97,6 +97,7 @@ NewsWindow
   -> select the source collector
   -> scan public listing pages from newest to oldest
   -> keep rows inside [start, end)
+  -> stop before article fetches when listing coverage is incomplete
   -> fetch each linked article
   -> convert HTML to Markdown
   -> NewsDocument or NewsFailure
@@ -123,6 +124,8 @@ After collection begins, one item failure does not stop independent items. Each 
 
 - a listing page could not be fetched or parsed;
 - the listing scan stopped before crossing the window start.
+
+An incomplete listing scan returns its discovery failures and observed row count without fetching article bodies. Its documents are empty because the caller cannot treat the partial listing as complete coverage; a completeness-preserving caller can retry narrower windows without downloading the same parent-window articles again.
 
 Article failures stay in `failures` but do not change whether all listing rows were found. A caller can distinguish "the full time window was scanned" from "every found article was processed." It can store successful records and retry failed articles separately. An empty batch is complete only when the listing scan crossed the requested start.
 

--- a/quantmind/preprocess/pr_newswire.py
+++ b/quantmind/preprocess/pr_newswire.py
@@ -279,6 +279,12 @@ async def _collect_pr_newswire(
             end=end,
             fetcher=fetcher,
         )
+        if not discovery.complete:
+            return NewsBatch(
+                failures=discovery.failures,
+                observed_count=discovery.observed_count,
+                complete=False,
+            )
         outcomes = await asyncio.gather(
             *(
                 _collect_observation(

--- a/tests/preprocess/test_pr_newswire.py
+++ b/tests/preprocess/test_pr_newswire.py
@@ -2,7 +2,7 @@ import re
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import respx
@@ -337,6 +337,36 @@ class DiscoverPRNewswireTests(unittest.IsolatedAsyncioTestCase):
 
 
 class CollectPRNewswireTests(unittest.IsolatedAsyncioTestCase):
+    async def test_incomplete_discovery_skips_article_collection(self) -> None:
+        with (
+            patch(
+                "quantmind.preprocess.pr_newswire._DEFAULT_FETCH_POLICY",
+                _TEST_POLICY,
+            ),
+            patch("quantmind.preprocess.pr_newswire._MAX_PAGES", 1),
+            patch(
+                "quantmind.preprocess.pr_newswire._collect_observation",
+                new=AsyncMock(),
+            ) as collect_observation,
+            respx.mock(assert_all_called=True) as router,
+        ):
+            router.get(url__regex=_LISTING_RE).mock(
+                side_effect=lambda request: _listing_response(
+                    _fixture("listing_short_page_1.html"), request
+                )
+            )
+            result = await _collect_pr_newswire(
+                start=datetime(2026, 7, 12, tzinfo=timezone.utc),
+                end=datetime(2026, 7, 14, 4, 30, tzinfo=timezone.utc),
+                retain_raw_html=False,
+            )
+
+        self.assertFalse(result.complete)
+        self.assertGreater(result.observed_count, 0)
+        self.assertEqual(result.documents, ())
+        self.assertIn("exceeded 1 pages", result.failures[0].message)
+        collect_observation.assert_not_awaited()
+
     async def test_collects_article_and_discards_raw_html_by_default(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Stop PR Newswire collection before article-body fetching when listing discovery is incomplete.
- Preserve discovery failures and the observed row count while returning no partial documents, so completeness-preserving retries do not download the same parent-window articles first.
- Document the incomplete-window contract and add a focused regression test proving the article collector is not invoked.

This PR deliberately addresses only the redundant-fetch defect. The independent proposal to expose public article-fetch concurrency remains out of scope so that any configuration API can be reviewed and benchmarked separately.

## Related Issue

Part of #144

## Verification

- `bash scripts/verify.sh` in the project's Linux test environment: 486 passed, 86.46% coverage, import contracts and static checks passed.
- `python -m pytest tests/preprocess/test_pr_newswire.py tests/flows/test_news.py tests/configs/test_news.py -q -o addopts=`: 19 passed.
- `python scripts/verify_news_e2e.py`: PR Newswire discovery passed (332 observed rows across 4 pages) and ticker recovery passed (8/8 expected tickers); the independent RSS smoke check failed because the configured public PR Newswire RSS URL currently returns HTTP 404.
- A live 14-day collection probe reached the 2,000-row discovery cap and returned `complete=False`, `documents=0`, and the discovery failure evidence without collecting partial article bodies.

## Checklist

- [x] The title uses English Conventional Commit format: `type(scope): summary`.
- [x] The related issue or design discussion is linked when applicable.
- [x] `bash scripts/verify.sh` passes.
- [x] Every applicable live-network component smoke test passes, or this PR states why none applies.
- [x] Public behavior has focused tests, an example, and documentation where applicable.
- [x] The PR is complete, small, and contains no unrelated changes.
